### PR TITLE
Build pages on tags

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build branch
         run: |-
           PATH=""
-          [[ "${{ GITHUB_HEAD_REF }}" != "versione_corrente" ]] && PATH="${GITHUB_HEAD_REF}/" # note the trailing slash
+          [[ "${{ GITHUB_REF }}" != "versione_corrente" ]] && PATH="${GITHUB_REF}/" # note the trailing slash
           sphinx-build -b html docs/it/  html/$PATH/it
           sphinx-build -b html docs/en/  html/$PATH/en
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,6 +4,7 @@ name: gh-pages
 
 on:
   push:
+    tags: [ "*" ]
     branches: ["versione-corrente"]
     paths-ignore:
       - README.md
@@ -44,8 +45,10 @@ jobs:
 
       - name: Build branch
         run: |-
-          sphinx-build -b html docs/it/  html/${GITHUB_HEAD_REF}/it
-          sphinx-build -b html docs/en/  html/${GITHUB_HEAD_REF}/en
+          PATH=""
+          [[ "${{ GITHUB_HEAD_REF }}" != "versione_corrente" ]] && PATH="${GITHUB_HEAD_REF}/" # note the trailing slash
+          sphinx-build -b html docs/it/  html/$PATH/it
+          sphinx-build -b html docs/en/  html/$PATH/en
 
       # Runs a single command using the runners shell
       - name: Create GH page index

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,8 +46,9 @@ jobs:
       - name: Build branch
         run: |-
           [[ "$GITHUB_REF" != "versione_corrente" ]] && P="${GITHUB_REF}/" || P="" # note the trailing slash
-          sphinx-build -b html docs/it/  html/$P/it
-          sphinx-build -b html docs/en/  html/$P/en
+          echo "Publish on $P sub path"
+          sphinx-build -b html docs/it/  html/$Pit
+          sphinx-build -b html docs/en/  html/$Pen
 
       # Runs a single command using the runners shell
       - name: Create GH page index

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -45,10 +45,9 @@ jobs:
 
       - name: Build branch
         run: |-
-          PATH=""
-          [[ "$GITHUB_REF" != "versione_corrente" ]] && PATH="${GITHUB_REF}/" # note the trailing slash
-          sphinx-build -b html docs/it/  html/$PATH/it
-          sphinx-build -b html docs/en/  html/$PATH/en
+          [[ "$GITHUB_REF" != "versione_corrente" ]] && P="${GITHUB_REF}/" || P="" # note the trailing slash
+          sphinx-build -b html docs/it/  html/$P/it
+          sphinx-build -b html docs/en/  html/$P/en
 
       # Runs a single command using the runners shell
       - name: Create GH page index

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -47,15 +47,6 @@ jobs:
           sphinx-build -b html docs/it/  html/${GITHUB_HEAD_REF}/it
           sphinx-build -b html docs/en/  html/${GITHUB_HEAD_REF}/en
 
-      - name: Install deps
-        run: |-
-            python -m pip install -r requirements-dev.txt
-
-      - name: Build branch
-        run: |-
-          sphinx-build -b html docs/it/ html/${GITHUB_HEAD_REF}/it
-          sphinx-build -b html docs/en/ html/${GITHUB_HEAD_REF}/en
-
       # Runs a single command using the runners shell
       - name: Create GH page index
         run: |-

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build branch
         run: |-
           PATH=""
-          [[ "${{ GITHUB_REF }}" != "versione_corrente" ]] && PATH="${GITHUB_REF}/" # note the trailing slash
+          [[ "$GITHUB_REF" != "versione_corrente" ]] && PATH="${GITHUB_REF}/" # note the trailing slash
           sphinx-build -b html docs/it/  html/$PATH/it
           sphinx-build -b html docs/en/  html/$PATH/en
 


### PR DESCRIPTION
🚧  Need to better understand the value of `GITHUB_REF` and `GITHUB_HEAD_REF`, to discriminate between cases.

----

Run the publication workflow on tags, too. This will enable documentation to be referable to a specific version, example: https://italia.github.io/eidas-it-wallet-docs/0.4.0/en/.

The final rule should be the following:
* When merging into `versione_corrente` --> https://italia.github.io/eidas-it-wallet-docs/en/
* When tagging  --> https://italia.github.io/eidas-it-wallet-docs/my-tag/en/
* When opening a PR  --> https://italia.github.io/eidas-it-wallet-docs/my-pr-branch/en/
