### PR TITLE
fix!: credential_definition.type is a single value

### DIFF
--- a/docs/en/pid-eaa-issuance.rst
+++ b/docs/en/pid-eaa-issuance.rst
@@ -137,7 +137,7 @@ The JWS payload of the request object is represented below:
         "type":"openid_credential",
         "format": "vc+sd-jwt",
         "credential_definition": {
-            "type": ["PersonIdentificationData"]
+            "type": "PersonIdentificationData"
         }
     }
     ],


### PR DESCRIPTION
There's a small deviation from the sd-jwt vc spec, given by the authorization details example that uses the parameter type as an array and not as literal string.

when we have defined it we assumed that the type should be multivalued, this have been consolidated now in the sd-jwt vc using the single valued approach.

See also [here](https://github.com/vcstuff/oid4vc-haip-sd-jwt-vc/pull/56/files#diff-15671165287eaf4ce50e0013632c722709931937f92d73118d2265657914f61f).