### PR TITLE
fix: [RP] same device uri and cross device security and implementation considerations

### DIFF
--- a/docs/en/relying-party-solution.rst
+++ b/docs/en/relying-party-solution.rst
@@ -106,9 +106,9 @@ In the Same Device Flow the Relying Party uses a HTTP response redirect (status 
 .. code:: text
 
     HTTP/1.1 /pre-authz-endpoint Found
-    Location: https://verifier.example.org/request_uri_endpoint?
+    Location: eudiw://authorize?
     client_id=https%3A%2F%2Fverifier.example.org%2Fcb
-    &request_uri=https%3A%2F%2Fverifier.example.org%2Frequest_uri_endpoint
+    &request_uri=https%3A%2F%2Fverifier.example.org%2Frequest_uri_endpoint%2Funique-session-identifier
 
 .. note::
     The Same Device flow proposed in this specification is under discussion and must be considered as experimental.
@@ -140,13 +140,13 @@ Below is a non-normative example of the QR Code raw payload:
 
 .. code-block:: text
 
-  ZXVkaXc6Ly9hdXRob3JpemU/Y2xpZW50X2lkPWh0dHBzOi8vdmVyaWZpZXIuZXhhbXBsZS5vcmcmcmVxdWVzdF91cmk9aHR0cHM6Ly92ZXJpZmllci5leGFtcGxlLm9yZy9yZXF1ZXN0X3VyaQ==
+  ZXVkaXc6Ly9hdXRob3JpemU/Y2xpZW50X2lkPWh0dHBzOi8vdmVyaWZpZXIuZXhhbXBsZS5vcmcmcmVxdWVzdF91cmk9aHR0cHM6Ly92ZXJpZmllci5leGFtcGxlLm9yZy9yZXF1ZXN0X3VyaS8kdW5pcXVlLXNlc3Npb24taWRlbnRpZmllcg==
 
 Below follows its Base64 decoded content:
 
 .. code-block:: text
 
-  eudiw://authorize?client_id=https://verifier.example.org&request_uri=https://verifier.example.org/request_uri
+  eudiw://authorize?client_id=https://verifier.example.org&request_uri=https://verifier.example.org/request_uri/$unique-session-identifier
 
 
 Request Object Details


### PR DESCRIPTION
this PR brings the URI used in the Cross Device flow also in the Same Device flow

it also appends in the non-normative example of the request URI a `unique-session-id` webpath

In a Cross Device Flow the user-agent uses the JS (with WS or polling) made available in the QRCode Page to check if the authentication is successfully. For doing that it has to request to a specific URL (and also be authenticated with a session cookie that binds the unique-session-identifier, to avoid adversary to be able to made hijacks).

This opens a interesting scenario where the cross device flow is "animated" within the desktop user-agent with three different steps

1. The RP shows the QRcode (and periodically checks the authentication status in a time window of maximum 5 minutes)
    - the user frames the qrcode using their wallet instance
    - the wallet instance extract the request_uri and issues the HTTP request to obtain the signed request
    - The RP gives the signed_request (and update the session status)
2. The JS executed by the desktop user-agent receives a response containing a status code 201(Content Created) and optionally displaying a message to the user like "The Wallet Instance is processing the request" . Then continue polling to the unique-session-id endpoint
   - The User accepts the request using their wallet instance, selects the required data to be released, then issue the presentation response to the RP
   - The RP authenticates the user (and update the session status)
 3. The JS executed by the desktop user-agent receives a response with a JSON containing a status code 200 (OK), having requested with the session cookie, the session bound within it is then updated, allowing the RP (JS) to redirect the User to the previous resource requested, before the authentication (next= parameter or whatever)
 
In absence of a session-cookie linked to a cross device session-id  the flow may be hijacked by an adversary that by stolen the sole session-id could authenticate using another user-agent
  