### PR TITLE
fix: SD-JWT example schema

### DIFF
--- a/docs/en/pid-eaa-data-model.rst
+++ b/docs/en/pid-eaa-data-model.rst
@@ -46,7 +46,7 @@ The Disclosures are sent to the Holder together with the SD-JWT in the *Combined
 
 .. code-block::
 
-  <JWT>~<Disclosure 1>~<Disclosure 2>~...~<Disclosure N>
+  <Issuer-Signed-JWT>~<Disclosure 1>~<Disclosure 2>~...~<Disclosure N>
 
 See `[draft-terbu-sd-jwt-vc-latest] <https://vcstuff.github.io/draft-terbu-sd-jwt-vc/draft-terbu-oauth-sd-jwt-vc.html>`_ and `[SD-JWT] <https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt-04>`__ for more details. 
 

--- a/docs/en/pid-eaa-data-model.rst
+++ b/docs/en/pid-eaa-data-model.rst
@@ -46,7 +46,7 @@ The Disclosures are sent to the Holder together with the SD-JWT in the *Combined
 
 .. code-block::
 
-  <SD-JWT>~<Disclosure 1>~<Disclosure 2>~...~<Disclosure N>
+  <JWT>~<Disclosure 1>~<Disclosure 2>~...~<Disclosure N>
 
 See `[draft-terbu-sd-jwt-vc-latest] <https://vcstuff.github.io/draft-terbu-sd-jwt-vc/draft-terbu-oauth-sd-jwt-vc.html>`_ and `[SD-JWT] <https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt-04>`__ for more details. 
 

--- a/docs/en/relying-party-solution.rst
+++ b/docs/en/relying-party-solution.rst
@@ -470,7 +470,7 @@ Below is a non-normative example of the ``vp_token`` decoded content, represente
     "iat": 1541493724,
     "exp": 1573029723,
     "nonce": "2c128e4d-fc91-4cd3-86b8-18bdea0988cb"
-    "vp": "<SD-JWT>~<Disclosure 1>~<Disclosure 2>~...~<Disclosure N>"
+    "vp": "<Issuer-Signed-JWT>~<Disclosure 1>~<Disclosure 2>~...~<Disclosure N>"
    }
 
 Where the following parameters are used:


### PR DESCRIPTION
SD-JWT contains multiple artifacts, while the first JWT is the issuer signed one

this PR fixes this aspect within the non normative examples