### PR TITLE
feat!: Add `response_modes_supported` to Wallet Instance Attestation

### DIFF
--- a/docs/en/wallet-instance-attestation.rst
+++ b/docs/en/wallet-instance-attestation.rst
@@ -184,7 +184,7 @@ request where the decoded JWS headers and payload are separated by a comma:
 
 Whose corresponding JWS is verifiable using the public key
 of the Wallet Provider corresponding to the `kid` made available
-in the header.
+in the JWS header.
 
 
 Wallet Instance Attestation

--- a/docs/en/wallet-instance-attestation.rst
+++ b/docs/en/wallet-instance-attestation.rst
@@ -267,8 +267,7 @@ Payload
 || response_modes_supported || JSON array containing a list of the OAuth 2.0 |
 ||                          || "response_mode" values that this              |
 ||                          || authorization server supports.                |
-||                          || `RFC 8414 <https://www.rfc-editor.org/rfc/    |
-||                          || rfc8414.html>`_                               |
+||                          || `RFC 8414 section 2`_                         |
 +---------------------------+------------------------------------------------+
 || vp_formats_supported     || JSON object containing                        |
 ||                          || ``jwt_vp_json`` and ``jwt_vc_json``           |
@@ -346,3 +345,4 @@ Below is an example of Wallet Instance Attestation:
 .. _Wallet Instance Attestation Request: wallet-instance-attestation.html#format-of-the-wallet-instance-attestation-request
 .. _Wallet Instance Attestation: wallet-instance-attestation.html#format-of-the-wallet-instance-attestation
 .. _RFC 7523 section 4: https://www.rfc-editor.org/rfc/rfc7523.html#section-4
+.. _RFC 8414 section 2: https://www.rfc-editor.org/rfc/rfc8414.html#section-2

--- a/docs/en/wallet-instance-attestation.rst
+++ b/docs/en/wallet-instance-attestation.rst
@@ -79,7 +79,7 @@ Request from the Wallet Instance containing the associated public key
 The Wallet Instance MUST do an HTTP request to the Wallet Provider `token endpoint`_,
 using the method `POST <https://datatracker.ietf.org/doc/html/rfc6749#section-3.2>`__.
 
-The **token** endpoint (as defined in `RFC 7523 section 4`_) requires the following parameters 
+The **token** endpoint (as defined in `RFC 7523 section 4`_) requires the following parameters
 encoded in ``application/x-www-form-urlencoded`` format:
 
 * ``grant_type`` set to ``urn:ietf:params:oauth:grant-type:jwt-bearer``;
@@ -102,7 +102,7 @@ The response is the `Wallet Instance Attestation`_ in JWT format:
 
     HTTP/1.1 201 OK
     Content-Type: application/jwt
-    
+
     eyJhbGciOiJFUzI1NiIsInR5cCI6IndhbGxldC1hdHRlc3RhdGlvbitqd3QiLCJraWQiOiI1dDVZWXBCaE4tRWdJRUVJNWlVenI2cjBNUjAyTG5WUTBPbWVrbU5LY2pZIiwidHJ1c3RfY2hhaW4iOlsiZXlKaGJHY2lPaUpGVXouLi42UzBBIiwiZXlKaGJHY2lPaUpGVXouLi5qSkxBIiwiZXlKaGJHY2lPaUpGVXouLi5IOWd3Il19.eyJpc3MiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZyIsInN1YiI6InZiZVhKa3NNNDV4cGh0QU5uQ2lHNm1DeXVVNGpmR056b3BHdUt2b2dnOWMiLCJ0eXBlIjoiV2FsbGV0SW5zdGFuY2VBdHRlc3RhdGlvbiIsInBvbGljeV91cmkiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZy9wcml2YWN5X3BvbGljeSIsInRvc191cmkiOiJodHRwczovL3dhbGxldC1wcm92aWRlci5leGFtcGxlLm9yZy9pbmZvX3BvbGljeSIsImxvZ29fdXJpIjoiaHR0cHM6Ly93YWxsZXQtcHJvdmlkZXIuZXhhbXBsZS5vcmcvbG9nby5zdmciLCJhdHRlc3RlZF9zZWN1cml0eV9jb250ZXh0IjoiaHR0cHM6Ly93YWxsZXQtcHJvdmlkZXIuZXhhbXBsZS5vcmcvTG9BL2Jhc2ljIiwiY25mIjp7Imp3ayI6eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6IjRITnB0SS14cjJwanlSSktHTW56NFdtZG5RRF91SlNxNFI5NU5qOThiNDQiLCJ5IjoiTElablNCMzl2RkpoWWdTM2s3alhFNHIzLUNvR0ZRd1p0UEJJUnFwTmxyZyIsImtpZCI6InZiZVhKa3NNNDV4cGh0QU5uQ2lHNm1DeXVVNGpmR056b3BHdUt2b2dnOWMifX0sImF1dGhvcml6YXRpb25fZW5kcG9pbnQiOiJldWRpdzoiLCJyZXNwb25zZV90eXBlc19zdXBwb3J0ZWQiOlsidnBfdG9rZW4iXSwidnBfZm9ybWF0c19zdXBwb3J0ZWQiOnsiand0X3ZwX2pzb24iOnsiYWxnX3ZhbHVlc19zdXBwb3J0ZWQiOlsiRVMyNTYiXX0sImp3dF92Y19qc29uIjp7ImFsZ192YWx1ZXNfc3VwcG9ydGVkIjpbIkVTMjU2Il19fSwicmVxdWVzdF9vYmplY3Rfc2lnbmluZ19hbGdfdmFsdWVzX3N1cHBvcnRlZCI6WyJFUzI1NiJdLCJwcmVzZW50YXRpb25fZGVmaW5pdGlvbl91cmlfc3VwcG9ydGVkIjpmYWxzZSwiaWF0IjoxNjg3MjgxMTk1LCJleHAiOjE2ODcyODgzOTV9.tNvCyFPCL5tUi2NakKwdaG9xbrtWWl4djSRYRfHrF8NdmffdT044U55pRn35J2cl0LZxbesEDrfSAz2pllw2Ug
 
 
@@ -183,7 +183,7 @@ request where the decoded JWS headers and payload are separated by a comma:
   }
 
 Whose corresponding JWS is verifiable using the public key
-of the Wallet Provider corresponding to the `kid` made available 
+of the Wallet Provider corresponding to the `kid` made available
 in the header.
 
 
@@ -222,7 +222,7 @@ Header
 +-----------------------------------+-----------------------------------+
 
 .. note::
-   
+
    The claim `trust_chain` or the claim `x5c` MUST be provisioned.
    If these are both provisioned, the related public key contained in
    MUST be the same in both `trust_chain` and `x5c`.
@@ -263,6 +263,12 @@ Payload
 +---------------------------+------------------------------------------------+
 || response_types_supported || JSON array containing a list of               |
 ||                          || the OAuth 2.0 ``response_type`` values.       |
++---------------------------+------------------------------------------------+
+|| response_modes_supported || JSON array containing a list of the OAuth 2.0 |
+||                          || "response_mode" values that this              |
+||                          || authorization server supports.                |
+||                          || `RFC 8414 <https://www.rfc-editor.org/rfc/    |
+||                          || rfc8414.html>`_                               |
 +---------------------------+------------------------------------------------+
 || vp_formats_supported     || JSON object containing                        |
 ||                          || ``jwt_vp_json`` and ``jwt_vc_json``           |
@@ -315,6 +321,9 @@ Below is an example of Wallet Instance Attestation:
     "authorization_endpoint": "eudiw:",
     "response_types_supported": [
       "vp_token"
+    ],
+    "response_modes_supported": [
+      "form_post.jwt"
     ],
     "vp_formats_supported": {
       "jwt_vp_json": {

--- a/docs/en/wallet-solution.rst
+++ b/docs/en/wallet-solution.rst
@@ -77,7 +77,7 @@ Provider Entity Configuration.
 
 The Wallet Provider Entity Configuration is a JWS containing the public keys and supported algorithms of the Wallet Provider metadata definition. It is structured in accordance with the `OpenID Connect Federation <https://openid.net/specs/openid-connect-federation-1_0.html>`_ and the Trust Model section outlined in this specification.
 
-The returning Entity Configuration of the Wallet Provider MUST contain the 
+The returning Entity Configuration of the Wallet Provider MUST contain the
 attributes listed below:
 
 Header


### PR DESCRIPTION
Add `response_modes_supported` to Wallet Instance Attestation as discussed in https://github.com/italia/eudi-wallet-it-docs/issues/132