### PR TITLE
fix!: attested_security_context -> aal

### DIFF
--- a/docs/en/wallet-instance-attestation.rst
+++ b/docs/en/wallet-instance-attestation.rst
@@ -249,9 +249,9 @@ Payload
 ||                          || problems is to have a limited                 |
 ||                          || duration of the attestation.                  |
 +---------------------------+------------------------------------------------+
-|| attested_security_context|| Attested security context:                    |
-||                          || Represents the level of "security"            |
-||                          || attested by the Wallet Provider.              |
+|| aal                      || JSON String asserting the authentication level|
+||                          || of the Wallet and the key as asserted in      |
+||                          || the cnf claim.                                |
 +---------------------------+------------------------------------------------+
 || cnf                      || This parameter contains the ``jwk``           |
 ||                          || parameter                                     |
@@ -283,10 +283,6 @@ Payload
 ||                          || reference. MUST set to `false`.               |
 +---------------------------+------------------------------------------------+
 
-.. note::
-   The claim ``attested_security_context`` (Attested Security Context) is under discussion
-   and MUST be intended as experimental.
-
 Below is an example of Wallet Instance Attestation:
 
 .. code-block:: javascript
@@ -305,7 +301,7 @@ Below is an example of Wallet Instance Attestation:
   {
     "iss": "https://wallet-provider.example.org",
     "sub": "vbeXJksM45xphtANnCiG6mCyuU4jfGNzopGuKvogg9c",
-    "attested_security_context": "https://wallet-provider.example.org/LoA/basic",
+    "aal": "https://wallet-provider.example.org/LoA/basic",
     "cnf":
     {
       "jwk":

--- a/docs/en/wallet-solution.rst
+++ b/docs/en/wallet-solution.rst
@@ -145,14 +145,11 @@ Payload
 | token_endpoint                              | Endpoint for obtaining the Wallet                                   |
 |                                             | Instance Attestation.                                               |
 +---------------------------------------------+---------------------------------------------------------------------+
-| attested_security_context_values_supported  | List of supported values for the                                    |
+| aal_values_supported                        | List of supported values for the                                    |
 |                                             | certifiable security context. These                                 |
 |                                             | values specify the security level                                   |
 |                                             | of the app, according to the levels: low, medium, or high.          |
-|                                             | An attested security context is                                     |
-|                                             | defined by the proof that the                                       |
-|                                             | Wallet Instance can provide to the                                  |
-|                                             | Wallet Provider.                                                    |
+|                                             | Authenticator Assurance Level values supported.                     |
 +---------------------------------------------+---------------------------------------------------------------------+
 | grant_types_supported                       | The types of grants supported by                                    |
 |                                             | the token endpoint. It MUST be set to                               |
@@ -163,11 +160,11 @@ Payload
 | ted                                         | the token endpoint.                                                 |
 +---------------------------------------------+---------------------------------------------------------------------+
 | token_endpoint_auth_signing_alg_va          | Supported signature                                                 |
-| lues_supported                              | algorithms for the token endpoint                                   |
+| lues_supported                              | algorithms for the token endpoint.                                  |
 +---------------------------------------------+---------------------------------------------------------------------+
 
 .. note::
-   The `attested_security_context_values_supported` parameter is experimental and under review.
+   The `aal_values_supported` parameter is experimental and under review.
 
 Payload `federation_entity`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -224,7 +221,7 @@ Below a non-normative example of the Entity Configuration.
         ]
       },
       "token_endpoint": "https://wallet-provider.example.org/token",
-      "attested_security_context_values_supported": [
+      "aal_values_supported": [
         "https://wallet-provider.example.org/LoA/basic",
         "https://wallet-provider.example.org/LoA/medium",
         "https://wallet-provider.example.org/LoA/high"


### PR DESCRIPTION
this PR changes the claim `attested_security_context` to NIST's `aal`, according to [OpenID4VC High Assurance Interoperability Profile with SD-JWT VC](https://vcstuff.github.io/oid4vc-haip-sd-jwt-vc/draft-oid4vc-haip-sd-jwt-vc.html#section-4.3.1-4)
