### PR TITLE
fix: wallet instance attestation iat and exp

### DIFF
--- a/docs/en/wallet-instance-attestation.rst
+++ b/docs/en/wallet-instance-attestation.rst
@@ -151,6 +151,12 @@ Assertion Payload
 ||       || containing the public key of the                           |
 ||       || Wallet Instance.                                           |
 +--------+-------------------------------------------------------------+
+|| iat   || Unix timestamp of attestation request                      |
+||       || issuance time.                                             |
++--------+-------------------------------------------------------------+
+|| exp   || Unix timestamp regarding the                               |
+||       || expiration date time.                                      |
++--------+-------------------------------------------------------------+
 
 
 Below a non-normative example of the Wallet Instance Attestation


### PR DESCRIPTION
This PR fixes the normative table about the claims iat and exp in the wallet instance attestation request. They was just listed in the non normative example

thx @rohe
