### PR TITLE
fix: VCI metadata aligned with OpenID4VCI ID-1

### DIFF
--- a/docs/en/pid-eaa-issuance.rst
+++ b/docs/en/pid-eaa-issuance.rst
@@ -972,8 +972,14 @@ Below is a non-normative example of an Entity Configuration containing an `openi
               {
                 "format": "vc+sd-jwt",
                 "cryptographic_binding_methods_supported": ["jwk"],
-                "cryptographic_suites_supported": ["RS256", "RS512", "ES256", "ES512"],
-                "proof_types": ["jwt"],
+                "credential_signing_alg_values_supported": ["ES256", "ES384", "ES512"],
+                "proof_types_supported": {
+                  "jwt": {
+                      "proof_signing_alg_values_supported": [
+                          "ES256"
+                      ]
+                  }
+                },
                 "display": [{
                     "name": "PID Italiano di esempio",
                     "locale": "it-IT",


### PR DESCRIPTION
This PR aligns the latest changes of the OpenID4VCI Imp Draft, according to https://github.com/openid/OpenID4VCI/pull/235/files

