### PR TITLE
fix: rp presentation definition typo

### DIFF
--- a/docs/en/remote-flow.rst
+++ b/docs/en/remote-flow.rst
@@ -328,7 +328,7 @@ The JWS payload parameters are described herein:
                 ]
               }
             ],
-            "limit_discolusre": "preferred"
+            "limit_disclosure": "preferred"
           }
         }
       ]


### PR DESCRIPTION
This PR fixes the non-normative example of the RP presentation definition