### PR TITLE
fix: sd-jwt vc sub value

### DIFF
--- a/docs/en/pid-eaa-data-model.rst
+++ b/docs/en/pid-eaa-data-model.rst
@@ -85,7 +85,7 @@ The following claims MUST be in the JWT payload. Some of these claims can be dis
       - [NSD].URL string representing the PID/(Q)EAA Issuer unique identifier.
       - `[RFC7519, Section 4.1.1] <https://www.iana.org/go/rfc7519>`_.
     * - **sub**
-      - [NSD].Thumbprint of the JWK in the ``cnf`` parameter.
+      - [NSD].The identifier of the subject of the Digital Credential, the User, must be opaque and should not correspond to any anagraphic data or be derived from the User's anagraphic data through pseudonymization.
       - `[RFC7519, Section 4.1.2] <https://www.iana.org/go/rfc7519>`_.
     * - **iat**
       - [SD].UNIX Timestamp with the time of JWT issuance, coded as NumericDate as indicated in :rfc:`7519`.

--- a/docs/en/pid-eaa-data-model.rst
+++ b/docs/en/pid-eaa-data-model.rst
@@ -85,7 +85,7 @@ The following claims MUST be in the JWT payload. Some of these claims can be dis
       - [NSD].URL string representing the PID/(Q)EAA Issuer unique identifier.
       - `[RFC7519, Section 4.1.1] <https://www.iana.org/go/rfc7519>`_.
     * - **sub**
-      - [NSD].The identifier of the subject of the Digital Credential, the User, must be opaque and should not correspond to any anagraphic data or be derived from the User's anagraphic data through pseudonymization.
+      - [NSD]. The identifier of the subject of the Digital Credential, the User, MUST be opaque and MUST NOT correspond to any anagraphic data or be derived from the User's anagraphic data via pseudonymization. Additionally, it is required that two different Credentials issued MUST NOT use the same ``sub`` value.
       - `[RFC7519, Section 4.1.2] <https://www.iana.org/go/rfc7519>`_.
     * - **iat**
       - [SD].UNIX Timestamp with the time of JWT issuance, coded as NumericDate as indicated in :rfc:`7519`.


### PR DESCRIPTION
This PR aims to resolve the issue https://github.com/italia/eudi-wallet-it-docs/issues/276

the solution proposed goes along the experience made with openid connect, where the sub value identifying the user is opaque and not reversible.