### PR TITLE
Updated italic text

### DIFF
--- a/docs/en/wallet-attestation.rst
+++ b/docs/en/wallet-attestation.rst
@@ -27,10 +27,10 @@ The following requirements for the Wallet Attestation are met:
 - Private keys MUST be generated and stored in the WSCD using at least one of the approaches listed below:
 
   - **Local Internal WSCD**: in this approach, the WSCD relies entirely on the device's native cryptographic hardware, such as the Secure Enclave on iOS devices or the Hardware Backed Keystore or Strongbox on Android devices.
-  - **Local External WSCD**: the WSCD is an hardware external to the User's device, such as a smart card compliant with _GlobalPlatform_ and supporting _JavaCard_.
+  - **Local External WSCD**: the WSCD is an hardware external to the User's device, such as a smart card compliant with *GlobalPlatform* and supporting *JavaCard*.
   - **Remote WSCD**: Here, the WSCD utilizes a remote Hardware Security Module (HSM).
 
-  - **Local Hybrid WSCD**: the WSCD involves a pluggable internal hardware component within the User's device, such as an _eUICC_ that adheres to _GlobalPlatform_ standards and supports _JavaCard_.
+  - **Local Hybrid WSCD**: the WSCD involves a pluggable internal hardware component within the User's device, such as an *eUICC* that adheres to *GlobalPlatform* standards and supports *JavaCard*.
   - **Remote Hybrid WSCD**: the WSCD involves a local component mixed with a remote service.
 
 .. warning::


### PR DESCRIPTION
Chapter : Wallet Attestation
Paragraph : Requirements
some words are written with the underscore before and after. It should be in italic.
*word* and not _word_

## Title

## Content

## Review

- [ ] Ensure your files are written following RST specs (*not MD!*)
- [ ] Italian version
- [ ] English version
- [ ] Example files 
- [ ] Ask for review
