### PR TITLE
fix: aud in WIA

### DIFF
--- a/docs/en/wallet-attestation.rst
+++ b/docs/en/wallet-attestation.rst
@@ -457,9 +457,6 @@ The body of the Wallet Attestation JWT MUST contain:
     * - **iss**
       - Identifier of the Wallet Provider
       - :rfc:`9126` and :rfc:`7519`.
-    * - **aud**
-      - Identifier of the Wallet Provider concatenated with thumbprint of the Wallet Instance.
-      - :rfc:`9126` and :rfc:`7519`.
     * - **exp**
       - UNIX Timestamp with the expiry time of the JWT.
       - :rfc:`9126` and :rfc:`7519`.


### PR DESCRIPTION
thanks to collegues of trentino digitale, this PR fixes the Wallet Instance table regarding the claim `aud` that must not be included within the WIA
