### PR TITLE
[Remote Flow/Relying Party Entity Configuration] edit intent_to_retain type

### DIFF
--- a/docs/en/remote-flow.rst
+++ b/docs/en/remote-flow.rst
@@ -711,7 +711,7 @@ Below is a non-normative response example:
                                             "path": [
                                                 "$.unique_id"
                                             ],
-                                            "intent_to_retain": "true"
+                                            "intent_to_retain": true
                                         }
                                     ]
                                 }
@@ -804,19 +804,19 @@ Below is a non-normative response example:
                                                 "path": [
                                                     "$.mdoc.family_name"
                                                 ],
-                                                "intent_to_retain": "false"
+                                                "intent_to_retain": false
                                             },
                                             {
                                                 "path": [
                                                     "$.mdoc.portrait"
                                                 ],
-                                                "intent_to_retain": "false"
+                                                "intent_to_retain": false
                                             },
                                             {
                                                 "path": [
                                                     "$.mdoc.driving_privileges"
                                                 ],
-                                                "intent_to_retain": "false"
+                                                "intent_to_retain": false
                                             }
                                         ]
                                     }


### PR DESCRIPTION
this PR aims to solve this issue https://github.com/italia/eudi-wallet-it-docs/issues/291

the value has been edited from "true" to true to specify that it is a boolean value and not string.
