### PR TITLE
revocation: issuer must revoke credential when technical security issues happens

### DIFF
--- a/docs/en/revocation-lists.rst
+++ b/docs/en/revocation-lists.rst
@@ -94,7 +94,7 @@ Credential Revocation Flows can start under different scenarios, such as:
     - Users who lose access to their Wallet Instance (e.g., due to theft or loss of the device) can request the Credential Issuer to revoke their Credentials or ask the Wallet Provider to revoke the Wallet Instance. If the Wallet Provider is authorized by the User and is aware of the types of Credentials and their issuers stored in the Wallet, it can then initiate the revocation of all Digital Credentials contained within the Wallet Instance on behalf of the User.
     - The Law-Enforcing Authorities, for the fulfillment of their functions and any other judicial reasons, may request the Authentic Source to revoke entitlements, licenses, certificates, identification documents, etc., which in turn leads to the revocation of any linked Credentials.
     - The Authentic Sources that for any update of one or more User attributes, SHOULD inform the Credential Issuer that has previously requested those data for the issuance of a Credential about that User. 
-    - The Credential Issuers, for technical security reasons (e.g. in the case of compromised cryptographic keys), SHOULD decide to revoke the Credentials.
+    - For technical security reasons, such as compromised cryptographic keys, Credential Issuers MUST revoke the Credentials.
 
 
 The revocation scenarios involve two main flows:


### PR DESCRIPTION
This PR resolves https://github.com/italia/eudi-wallet-it-docs/issues/456
