### PR TITLE
Structural update for Presentation Flow and Relying Party Solution sections

### DIFF
--- a/docs/common/common_definitions.rst
+++ b/docs/common/common_definitions.rst
@@ -53,3 +53,5 @@
 .. _W3C.CSS-COLOR: https://www.w3.org/TR/css-color/
 .. _EU_2024/2977: https://eur-lex.europa.eu/eli/reg_impl/2024/2977/
 .. _TOKEN-STATUS-LIST: https://datatracker.ietf.org/doc/draft-ietf-oauth-status-list/07/
+.. _ISO18013-5: https://www.iso.org/standard/69084.html
+

--- a/docs/common/standards.rst
+++ b/docs/common/standards.rst
@@ -67,7 +67,7 @@ Technical References
       - Looker, T., Bastian, P., "OAuth 2.0 Attestation-Based Client Authentication", May 2024, Draft 3.    
     * - `OAUTH-MULT-RESP-TYPE`_
       - de Medeiros, B., Scurtescu, M., Tarjan, P., Jones, M., "OAuth 2.0 Multiple Response Type Encoding Practices", February 2014.
-    * - ISO18013-5
+    * - `ISO18013-5`_
       - ISO/IEC 18013-5 2020. Information technology — Personal identification — ISO-compliant driving license — Part 5: Mobile driving license (mDL) application. International Organization for Standardization.
     * - `OIDC`_
       - Sakimura, N., Bradley, J., Jones, M.,  de Medeiros, B., Mortimore, C., "OpenID Connect Core 1.0 incorporating errata set 2", December 2023.

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -38,11 +38,12 @@ Index of content
    defined-terms.rst
    trust.rst
    wallet-solution.rst
+   relying-party-solution.rst
    pid-eaa-data-model.rst
    pid-eaa-issuance.rst
+   pid-eaa-presentation.rst
    credential-revocation.rst
    authentic-sources.rst
-   relying-party-solution.rst
    backup-restore.rst
    algorithms.rst
    security-privacy-considerations.rst

--- a/docs/en/pid-eaa-presentation.rst
+++ b/docs/en/pid-eaa-presentation.rst
@@ -1,0 +1,17 @@
+.. include:: ../common/common_definitions.rst
+
+.. _pid-eaa-presentation.rst:
+
+PID/(Q)EAA Presentation
++++++++++++++++++++
+
+This section describes how a remote Relying Party Instance requests to a Wallet Instance the presentation of the PID/EAAs.
+
+In this section the following flows are described:
+
+- :ref:`Remote Flow`, where the User presents a Credential to a remote Relying Party according to `OpenID4VP`_ Draft 20. In this scenario the user-agent and the Wallet Instance can be used in the same device (**Same Device Flow**), or in different devices (**Cross Device Flow**).
+- :ref:`Proximity Flow`, where the User presents a Credential to a Verifier App according to ISO 18013-5. The User interacts with a Verifier using proximity connection technologies such as QR Code and Bluetooth Low Energy (BLE).
+
+.. include:: remote-flow.rst
+
+.. include:: proximity-flow.rst

--- a/docs/en/pid-eaa-presentation.rst
+++ b/docs/en/pid-eaa-presentation.rst
@@ -15,3 +15,4 @@ In this section the following flows are described:
 .. include:: remote-flow.rst
 
 .. include:: proximity-flow.rst
+

--- a/docs/en/pid-eaa-presentation.rst
+++ b/docs/en/pid-eaa-presentation.rst
@@ -3,14 +3,14 @@
 .. _pid-eaa-presentation.rst:
 
 PID/(Q)EAA Presentation
-+++++++++++++++++++
+++++++++++++++++++++++++
 
 This section describes how a remote Relying Party Instance requests to a Wallet Instance the presentation of the PID/EAAs.
 
 In this section the following flows are described:
 
-- :ref:`Remote Flow`, where the User presents a Credential to a remote Relying Party according to `OpenID4VP`_ Draft 20. In this scenario the user-agent and the Wallet Instance can be used in the same device (**Same Device Flow**), or in different devices (**Cross Device Flow**).
-- :ref:`Proximity Flow`, where the User presents a Credential to a Verifier App according to ISO 18013-5. The User interacts with a Verifier using proximity connection technologies such as QR Code and Bluetooth Low Energy (BLE).
+- :ref:`Remote Flow`, where the User presents a Credential to a remote Relying Party according to `OpenID4VP`_. In this scenario the user-agent and the Wallet Instance can be used in the same device (**Same Device Flow**), or in different devices (**Cross Device Flow**).
+- :ref:`Proximity Flow`, where the User presents a Credential to a Verifier App according to `ISO18013-5`_. The User interacts with a Verifier using proximity connection technologies such as using QR Codes and Bluetooth Low Energy (BLE).
 
 .. include:: remote-flow.rst
 

--- a/docs/en/relying-party-solution.rst
+++ b/docs/en/relying-party-solution.rst
@@ -1,21 +1,13 @@
-
-
-
+.. include:: ../common/common_definitions.rst
 
 .. _relying-party-solution:
 
 Relying Party Solution
 +++++++++++++++++++++++
 
-This section describes how a remote Relying Party or a Verifier App requests to a Wallet Instance the presentation of the PID/EAAs.
+This section provides technical details on the Relying Party Solution.
 
-In this section the following flows are described:
-
-- :ref:`Remote Flow`, where the User presents a Credential to a remote Relying Party according to `OpenID4VP`_ Draft 20. In this scenario the user-agent and the Wallet Instance can be used in the same device (**Same Device Flow**), or in different devices (**Cross Device Flow**).
-- :ref:`Proximity Flow`, where the User presents a Credential to a Verifier App according to ISO 18013-5. The User interacts with a Verifier using proximity connection technologies such as QR Code and Bluetooth Low Energy (BLE).
-
-.. include:: remote-flow.rst
-
-.. include:: proximity-flow.rst
+.. note:: 
+    This section is currently under development.
 
 .. include:: relying-party-entity-configuration.rst


### PR DESCRIPTION
Currently, the "Relying Party Solution" section describes the presentation flows (both remote and proximity). Given the upcoming introduction of the subsections related to the Relying Party Instance, we propose the following structural changes:
- Move the description of the presentation flows to a new section ("PID/(Q)EAA Presentation") to align with the "PID/(Q)EAA Issuance" section.
- Refocus the "Relying Party Solution" section on the technical architecture and lifecycle of Relying Party Instances, ensuring consistency with the "Wallet Solution" section. With this PR, this section will initially contain only the "Entity Configuration of Relying Parties" subsection, along with a note indicating that the rest of the content is still under development.