### PR TITLE
Fix minor typo and rephrase in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository hosts the sphinx project tree of IT-Wallet Technical Specificati
 
 ## Preview
 
-Preview of the lates editor's copy build, corresponding to the branch `versione-corrente` can be navigated using the following link:
+Preview of the latest editor's copy build, corresponding to the branch `versione-corrente` can be navigated using the following link:
 
  - [Editor's Copy](https://italia.github.io/eid-wallet-it-docs/versione-corrente/en/)
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ pandoc -o eidas-it-wallet-docs.odt index.html
 
 ## Versioning
 
-This project participates in the versioning model [*Semantic
-Versioning*](https://semver.org/).
+This project adheres to the [*Semantic
+Versioning*](https://semver.org/) model.
 
 Furthermore, this project uses the git *branches* and *tags* in the following way:
 * the branch `versione-corrente` contains the last stable version of the standard;

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ Versioning*](https://semver.org/) model.
 
 Furthermore, this project uses the git *branches* and *tags* in the following way:
 * the branch `versione-corrente` contains the last stable version of the standard;
-* The [release page](https://github.com/italia/publiccode.yml/releases) of
-  GitHub contains all the released versions of the standard. For the sake of coherence, the *releases* are made according to the tag names.
+* The [release page](https://github.com/italia/eid-wallet-it-docs/releases) of
+  GitHub contains all the released versions of the specifications. For the sake of coherence, the *releases* are made according to the tag names.
 
 Each time a release is created or edited, a preview is built based on the tag the release refers to. See [the preview section](preview-of-released-versions) for more.
 


### PR DESCRIPTION
## Title

Fix minor typo and rephrase in README

## Content

changelog : 

- fix: minor typo in readme (lates -> latest)
- chore: rephrase semantic versioning model to improve clarity
- fix: link to release page of eid-wallet-it-docs project

Additional considerations : 

- The link [the preview section](preview-of-released-versions) for more. is actually broken (404). Is it correct or should it be fixed somehow?

## Review

NOTE: Actually only README.md has beend updated

- [X] Ensure your files are written following RST specs (*not MD!*)
- [ ] Italian version
- [X] English version
- [ ] Example files 
- [ ] Ask for review
