### PR TITLE
Status Assertion alignment

### DIFF
--- a/docs/en/credential-issuer-entity-configuration.rst
+++ b/docs/en/credential-issuer-entity-configuration.rst
@@ -92,8 +92,8 @@ The *openid_credential_issuer* metadata MUST contain the following claims.
     - URL of the revocation endpoint. See :rfc:`8414#section-2`.
   * - **deferred_credential_endpoint**
     - URL of the deferred credential endpoint, as defined in Section 11.2.3 of `OpenID4VCI`_.
-  * - **status_attestation_endpoint**
-    - It MUST be an HTTPs URL indicating the endpoint where the Wallet Instances can request Status Assertions. See Section :ref:`credential-revocation:Digital Credential Lifecycle` for more details.
+  * - **status_assertion_endpoint**
+    - It MUST be an HTTPs URL indicating the endpoint where the Wallet Instances can request Status Assertions. See Section :ref:`credential-revocation:Digital Credential Lifecycle` for more details. (`OAUTH-STATUS-ASSERTION`_ Section 11.1.).
   * - **notification_endpoint**
     - It MUST be an HTTPs URL indicating the notification endpoint. See Section 11.2.3 of [`OpenID4VCI`_].
   * - **authorization_servers**
@@ -135,10 +135,8 @@ The *openid_credential_issuer* metadata MUST contain the following claims.
         - *eudi_wallet*: Member State EUDI Wallet trust framework supported.
   * - **evidence_supported**
     - JSON array containing all types of identity evidence supported by the Credential Issuer. See `OIDC-IDA`_ Section 8. The supported value is ``vouch``.
-  * - **status_assertion_endpoint**
-    - URL of the Status Assertion Endpoint. See `OAUTH-STATUS-ASSERTION`_ Section 11.1.
   * - **credential_hash_alg_supported**
-    - The supported algorithm used by the Wallet Instance to hash the Digital Credential for which the Status Assertion is requested. It is RECOMMENDED to use *sha-256*. See `OAUTH-STATUS-ASSERTION`_ Section 11.1.
+    - The supported algorithm used by the Wallet Instance to hash the Digital Credential for which the Status Assertion is requested. It is RECOMMENDED to use *sha-256*. (See `OAUTH-STATUS-ASSERTION`_ Section 11.1.).
 
 
 Example of a (Q)EAA Provider Entity Configuration

--- a/examples/ec-eaa.json
+++ b/examples/ec-eaa.json
@@ -94,8 +94,9 @@
             "nonce_endpoint": "https://eaa-provider.example.org/nonce-endpoint",
             "deferred_credential_endpoint": "https://eaa-provider.example.org/deferred-credential",
             "revocation_endpoint": "https://eaa-provider.example.org/revoke",
-            "status_attestation_endpoint": "https://eaa-provider.example.org/status",
+            "status_assertion_endpoint": "https://eaa-provider.example.org/status",
             "notification_endpoint": "https://eaa-provider.example.org/notification",
+            "credential_hash_alg_supported": "sha-256",
             "display": [
                 {
                     "name": "EAA Provider",


### PR DESCRIPTION
This PR:

- resolves #711 

List changes introduced:

- **status_attestation_endpoint** changed to **status_assertion_endpoint**
- Added **credential_hash_alg_supported** in the non-normative example of the Credential Issuer Metadataù
- Added **kid** and **x5c** parameters in the header of Status Assertion 
- Detailed the list of parameters contained in the Status Assertion Error object