### PR TITLE
Authentic Source PDND E-Service: differentiation of User claim from Attribute claim

### DIFF
--- a/docs/en/oas3/OAS3-PDND-AS.yaml
+++ b/docs/en/oas3/OAS3-PDND-AS.yaml
@@ -264,16 +264,48 @@ components:
               description: Required if claims parameter is not present. This represents the estimated amount of time (in seconds) required before making the request of the attribute claims again.
               type: integer
               example: "864000"
-            claims:
-              description: List of Credential Claims.
+            userClaims:
+              description: List of User Claims.
               type: object
-              example: '"given_name": "Mario",
-                "family_name": "Rossi",
-                "birth_date": "1980-01-10",
-                "birth_place": "Roma",
-                "nationality": "IT",
-                "personal_administrative_number": "XX00000XX",
-                "tax_id_code": "TINIT-XXXXXXXXXXXXXXXX"'
+              properties:
+                given_name:
+                  description: Current First Name.
+                  type: string
+                  example: '"Mario"'
+                family_name:
+                  description: Current Family Name.
+                  type: string
+                  example: '"Rossi"'
+                birth_date:
+                  description: Date of Birth.
+                  type: string
+                  example: '"1980-01-10"'
+                birth_place:
+                  description: Place of Birth.
+                  type: string
+                  example: '"Roma"'
+                tax_id_code:
+                  description: National tax identification number. REQUIRED if personal_administrative_number is absent.
+                  type: string
+                  example: '"TINIT-XXXXXXXXXXXXXXXX"'
+                personal_administrative_number:
+                  description: National unique identifier of a natural person. REQUIRED if tax_id_code is absent.
+                  type: string
+                  example: '"XX00000XX"'
+            attributeClaims:
+              description: List of Datasets of Attribute.
+              type: array
+              items: 
+                type: object
+                properties:
+                  id:
+                    description: Unique identifier of the Dataset.
+                    type: string
+                    example: '"6F9619FF-8B86-D011-B42D-00C04FC964FF"'
+                additionalProperties:
+                    type: string
+                required: [id]
+                example: '[{"id": "6F9619FF-8B86-D011-B42D-00C04FC964FF", "nationality": "IT"}, {...}]'
           required: [iss, aud, exp, iat, jti]
     CredentialClaimsRequest:
       required:

--- a/docs/en/oas3/OAS3-PDND-AS.yaml
+++ b/docs/en/oas3/OAS3-PDND-AS.yaml
@@ -301,7 +301,7 @@ components:
                   id:
                     description: Unique identifier of the Dataset.
                     type: string
-                    example: '"6F9619FF-8B86-D011-B42D-00C04FC964FF"'
+                    example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
                 additionalProperties:
                     type: string
                 required: [id]


### PR DESCRIPTION
This PR resolve #749.

In general, this PR has introduced the following change:

- In the PDND oas3 of the Authentic Source, User personal information (given_name, family_name, birth_date, birth_place, tax_id_code, personal_administrative_number) has been separated from the user datasets of attributes.