### PR TITLE
fix: removed duplication about federation resolve endpoint

### DIFF
--- a/docs/en/trust.rst
+++ b/docs/en/trust.rst
@@ -445,9 +445,7 @@ The *federation_entity* metadata for Leaves MUST contain the following claims.
   * - **contacts**
     - Institutional certified email address (PEC) of the entity. See `OID-FED`_ Draft 36 Section 5.2.2
   * - **federation_resolve_endpoint**
-    - See `OID-FED`_ Draft 41 Section 5.1.1
-  * - **federation_resolve_endpoint**
-    - [OPTIONAL] The resolver fetches the requested subject's Entity Configuration, assembles a Trust Chain that starts with the subject's Entity Configuration and ends with the specified Trust Anchor's Entity Configuration, verifies the Trust Chain, and then applies all the policies present in the Trust Chain to the subject's metadata. See `OID-FED`_.
+    - See `OID-FED`_ Section 5.1.1
   * - **tos_uri**
     - [OPTIONAL] URL string that points to a human-readable terms of service document for the client that describes a contractual relationship between the end-user and the client that the end-user accepts when authorizing the client. See `OID-FED`_.
 

--- a/docs/en/trust.rst
+++ b/docs/en/trust.rst
@@ -435,15 +435,15 @@ The *federation_entity* metadata for Leaves MUST contain the following claims.
   * - **Claim**
     - **Description**
   * - **organization_name**
-    - See `OID-FED`_ Draft 41 Section 5.2.2
+    - See `OID-FED`_ Section 5.2.2
   * - **homepage_uri**
-    - See `OID-FED`_ Draft 41 Section 5.2.2
+    - See `OID-FED`_ Section 5.2.2
   * - **policy_uri**
-    - See `OID-FED`_ Draft 41 Section 5.2.2
+    - See `OID-FED`_ Section 5.2.2
   * - **logo_uri**
-    - URL of the entity's logo; it MUST be in SVG format. See `OID-FED`_ Draft 36 Section 5.2.2
+    - URL of the entity's logo; it MUST be in SVG format. See `OID-FED`_ Section 5.2.2
   * - **contacts**
-    - Institutional certified email address (PEC) of the entity. See `OID-FED`_ Draft 36 Section 5.2.2
+    - Institutional certified email address (PEC) of the entity. See `OID-FED`_ Section 5.2.2
   * - **federation_resolve_endpoint**
     - See `OID-FED`_ Section 5.1.1
   * - **tos_uri**

--- a/docs/it/trust.rst
+++ b/docs/it/trust.rst
@@ -436,15 +436,15 @@ I metadati *federation_entity* per le Foglie DEVONO contenere i seguenti claim.
   * - **Claim**
     - **Descrizione**
   * - **organization_name**
-    - Vedi `OID-FED`_ Draft 41 Sezione 5.2.2
+    - Vedi `OID-FED`_ Sezione 5.2.2
   * - **homepage_uri**
-    - Vedi `OID-FED`_ Draft 41 Sezione 5.2.2
+    - Vedi `OID-FED`_ Sezione 5.2.2
   * - **policy_uri**
-    - Vedi `OID-FED`_ Draft 41 Sezione 5.2.2
+    - Vedi `OID-FED`_ Sezione 5.2.2
   * - **logo_uri**
-    - URL del logo dell'entità; DEVE essere in formato SVG. Vedi `OID-FED`_ Draft 36 Sezione 5.2.2
+    - URL del logo dell'entità; DEVE essere in formato SVG. Vedi `OID-FED`_ Sezione 5.2.2
   * - **contacts**
-    - Indirizzo email certificato istituzionale (PEC) dell'entità. Vedi `OID-FED`_ Draft 36 Sezione 5.2.2
+    - Indirizzo email certificato istituzionale (PEC) dell'entità. Vedi `OID-FED`_ Sezione 5.2.2
   * - **federation_resolve_endpoint**
     - OPZIONALE. Vedi `OID-FED`_ Sezione 5.1.1
   * - **tos_uri**

--- a/docs/it/trust.rst
+++ b/docs/it/trust.rst
@@ -446,7 +446,7 @@ I metadati *federation_entity* per le Foglie DEVONO contenere i seguenti claim.
   * - **contacts**
     - Indirizzo email certificato istituzionale (PEC) dell'entità. Vedi `OID-FED`_ Draft 36 Sezione 5.2.2
   * - **federation_resolve_endpoint**
-    - OPZIONALE. Vedi `OID-FED`_ Draft 41 Sezione 5.1.1
+    - OPZIONALE. Vedi `OID-FED`_ Sezione 5.1.1
   * - **tos_uri**
     - OPZIONALE. URL che contiene i termini di servizio del Fornitore di Wallet. Vedi `OID-FED`_.
 


### PR DESCRIPTION
Removed a duplication about the federation resolve endpoint

it also removes all the references to the federation draft numbers, since the related draft is the one defined within the dedicated section.

## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [ ] Example files 
- [x] Ask for review
