### PR TITLE
Update L2+

### DIFF
--- a/docs/en/credential-issuance-l2plus.rst
+++ b/docs/en/credential-issuance-l2plus.rst
@@ -269,7 +269,7 @@ If the HTTP Request is successfully processed, the MRTD PoP Service MUST send a 
      - REQUIRED. Signature algorithm.
    * - **typ**
      - string
-     - REQUIRED. It MUST be ``mrtd+ias+pop``.
+     - REQUIRED. It MUST be ``mrtd-ias-pop+jwt``.
    * - **kid**
      - string
      - REQUIRED. Identifier of the PID Provider's key that MUST be used to verify the signature of this JWT.
@@ -318,7 +318,7 @@ Below a non-normative example of an MRTD PoP Response:
     Content-Type: application/jwt; charset=utf-8
     {
       "alg":"ES256",
-      "typ":"mrtd+ias+pop",
+      "typ":"mrtd-ias-pop+jwt",
       "kid":"b3f1a6c2e9d54a8f9c3e7d1a2f4b6c78"
     }
     .

--- a/docs/en/credential-issuance-l2plus.rst
+++ b/docs/en/credential-issuance-l2plus.rst
@@ -90,7 +90,7 @@ This section provides technical details about the PID Issuance using Level of As
 .. plantuml:: plantuml/l2plus-detailed-flow.puml
     :width: 99%
     :alt: The figure illustrates the eID Substantial Authentication with MRTD Verification Detailed Flow.
-    :caption: `eID Substantial Authentication with MRTD Verification Detailed Flow. <https://www.plantuml.com/plantuml/svg/nLRhRXit4_tFfvZFGVBPYbUAxVmeX2ZEHhvOHM8l93b1MnS2jJkIs53abkJALf--7EvgTKaL16YB0ePXS-ToPixm3DzPnuqhvXAmTm4VT7m6SU5cg9n8kHDQmKimEDSEGMHqwfQG6wqdGar1AEWDeyzSIdIGUF-UjGLNASALr8_i___pWUO8APf28bUHBfmK2Xald5R5V8o6vTpuJ2Bdoi71lKLp0Dp2_VPvbQ6dhAFemIJUDkdsBiDnbutr4y01eKcCNeYCGZxx8AOpzruMkEr5LbIkDkAFije1caK58Xvi6t_i3trCdGGRKS6uIEwI0KELWS_x5IIu3L6vX3vEXNLc6Pm-zcwtJLTc3wfNDRa67nnw5mbZp9zB_1TuOlSGlOMu3Py9ZDF0KoSMt27u152vFQZ2KYnAFoZ6n8GJNCAZS3C8hVc4HamgD8nrEXr8PjmYdBJXZh3kTBgFlnTe7NGwB0xv1z269ExN7mu1KYbGkP78Zi6KftVZtp1rHnuEXDHbwAWR3AFOEMzJnkSgs_in8Xg52lNT8C_Ga3d5R3H2LBu9TPIXuqA2M-O81yADvEdBJAV5dB259Xyq6epv0YAgeox3vbfPXCCA-gWmuXZmAHS6xKYeerNTRU9aJtS8q_Nb45ehH7XUDwNJR3PVR0Id_yd-HblNXbnaKLuDKHEV-3oNsDHckadDgKzjn9oRvUuqHO5ekf2xNwW_D81RKq0a3gWQFwbjSjtsgkjX_ZkyeJRTjyleV7UAKsgQAYr3U_R4AxkxMSrP6-ex-ebBaGNJ6XjD-CrmcBHEcYTmzkeKhdGHIF-Wow1jc3cNstQh5KIn-HWcVxDthNH6PsgAvut6tBYifB_pPlttwCVFmxTX72Xba8UsdweQMDM8HkD19NS3JoncEes2QqieuMg87jYtYNnG_-G5O4pdZW50m4pz8fbgWmViZC05-jx-x5qcsin32B8b4uZMTUwQeCeOg-8H0TkTg2YaLjIyd7fUuZJ5t65M5LZsLkSZfLMAnr1p42eyr7cfdN9v5F9xrZbZN3heJKf05fHsm1TSI3wM24w7kdUsIgWdXd8qAvR8L7Y8na4tlWqMAwtihOzHMWHH9zDZnuN23BY3WSCSJaxgsEHv-UGCJrq02XEZv-HOjcfgT95Ns-edb5wSuVQgwtCv99Vw-X7yS7jyg-6YaY98Q8Z0_oJQMhJMczEPqwcMGUa9nGhABy-c1b7z-XQwKDCIvxbSAq0ITo-9d3xo32wkJuxfb_yzkBiOaNa8rOMeZXN4xwyiWUrBsui7crdhTBUzmJ74TD-bLhHtacBiZU0BBikmvBW7mFVxRWDgRpc5fYikTvJdGTdmH5YFuHuK_K4SdRvw_GDOCLNS5GQ96XzgxKcaxnMAjO9zKpCMj7MN_vbg0B1jlI0WAy0qdiH6rBs21vLgOr2MMT8Pfb_AdRkWEkcvGaaAMpN9swzMB2tGXKut78yOsn6U3Vru1NTVzelEkglVhJy6Cs4m3IkM89U2v66lHOb83Aa2sTym21I_D_hHeed6t686LuA6hAlLH9XvVGdypg-tqJugM-du_EjK8uA0sGjDctLKwK3vD3XqCwEBwGp69OAZpUtvUjyphUpIrXfjDEZ5iiSmD2r4wkeiTFTlRjrpRvtwK6KHy886fVv7MDi90PwVnSzFh_pF_eUFKTeXQBgzyN4yy4BRkxuPNlSlBs_PS8Om8OrCjN925MY1fwas6Mc1qzlFvc38BMGu2KfVtOdr8zlccAuVmwYoa9gzytyLS_ad>`_
+    :caption: `eID Substantial Authentication with MRTD Verification Detailed Flow. <https://www.plantuml.com/plantuml/svg/nLPjRnf74Fw-lsBgAAbDV13R-L2X4EU2NqoLs2V0YTgwGilT0DiikzVTFMpwwxkpTnmlAL6aLgg44DmzC_FCCxCp-yuwRbmnb-p77zmCvmWfca8YLv4kd1GA6I-SLiLyZ8Rb7YjIaNFbuE3UeZa0Rk5--_bdBYKww2dlMgKO8F4sfDkx38-xRAoV00wItWKaHYz4HYwVVH3JcNil2zos8bHSk9asuY_kX5OmGBEeICI3RV37_j3xr4d0Y8h6HNAN31Yg37pShoZ1RV3A9VHnAgmpos3qiNUx3Lt17bGlG-M4MzRaWq7l8c6C-USI0Jtd3pe-2yG9d9RCNuB1kNO8OkKYDrfFX9g2KD0RHfMAb7FFseAKX2kf7ncxX-Wjn6tuJ6IS1fuwiU0EmGU0okn15PPyKVX1CQPAEC4bF0etWo3D9pHYKh5XhDFfG3BZ5k6a3NV4TKVfFlvPe7NGwR0un1z06vAuNxyu14YbGEL68Zi6Kpwz6_-1gJloTA0C7Ln7tG2COkSyflJFLRRtPKHb52haTuFSoqnmyjbe1Azya-eeGyU51BVC4Gw46ydJbvbEYpbn2o8VD1gC-GGYogDEm-PQMOJ3YlgeCE8Oy2aN1kr8gADLtcsgoHvrYDFrvH1QAqPuNelIQJQRBpQSqt_2tsZhsf2BBCgh9chY4v_d4flQJ3TBS-f36p7dPhdRJL4eD1t8tJUa3pNWLXTG4GUKZU_KDfbkMzNvCFyUtf1Cz-tIEz_jufH4Km5PohF7NwdkPZPdRQZFw2SkHHQWDJVgy9lXC6cTD4_WxDKfNEaY5Fs3BfssOUPSRjkjLXXXpSVG-PlQjT8PFLDJF6yqviPbPVaxRzQ_Hpz_7huDxK0XmtXe-wwgYLL2D1eFAhaR-C9YfjCecBQ44gwcw8bzkv0Fwhyy08pft34029n9BnfJRV24dH6uGA_jhzvaeiqyk20iGI1QvxaBGPKnLlcZ0cmhKPMGfAZhSkhh4gSfvWwpAi5IMvsFb5Of7aDTWsDVhuA-vY7NGvsNKrGkZm8JNt_E69SEUfEIcWMb7V055vAF9OBJGO6T_H8oYo4qwQfU11MUh77GZMy3OZKrU-l7A2s2g8FfiUD2OGRSmS1X3YSdjM-ol7noXgSk48M9qNCoB4MR6btarTxw1QKVqt1xrVMn7999VH29VZX7NdIug8OI9DHEu3-9jXQjzN1wvdIgPPZvn695vRTdKuEeVdyBNQWB5EUvNC-29EvUKfdwo3Euk3uvfY__FRYx614ykEf2LFiAO_2VaC3sXUt5WyseTRZRtk0OOZhvKYlQG4anzY3uWilIBHdk8V3zjjk4sbj6GNJ5vSuCUb0sN1RM3Rc7HNyGHwUlNly4LamLTuL1AertjRQaekyT6UjPzitfiQ3zk_pVvWS0svuSH6H5cDgJgX5rh-11fTeOb6MKT8RfbtBxBYXFkhXGaC9M8ddyQjdIAbteTCFmYB6T4RGnILx1tPVzusUjwdTF8eEPC9Y6PKkKoz7aQQ_7KoXY24N5_WOWbFYzqOyMJJJc5ZEu4jHaNQqcmiphG-2tVxsNzfMobOxFlmur8WgOlT2qOqVL72Wl2OTkPdGndS6uP72qkKTVxxkmbIfjBTH6W-ukUu11jE2fgxEWxh_Sl-SUdNfNPHBmWXgb_YEixGG7py_YvwTN_hF_2cIKTWYQJczy70_yeErTtmol-vUNjsmuGvZGZ4orSa8LQ86dgJOPpGAdjo_G0SWjP3W9axuw4-lhjiqnNL-BKMKXD7ldVnLp-JS0>`_
 
 Phase 1: OAuth Authorization Request
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -254,9 +254,9 @@ The MRTD PoP Service MAY request the MRZ information (document number, date of b
 MRTD PoP Response
 """""""""""""""""
 
-If the HTTP Request is successfully processed, the MRTD PoP Service MUST send a HTTP Response with code *202 Accepted* and ``application/json`` as content type. The payload of the JSON response contains the parameters included in the following table:
+If the HTTP Request is successfully processed, the MRTD PoP Service MUST send a HTTP Response with code *202 Accepted* and ``application/jwt`` as content type. The JWT structure is defined as follows:
 
-.. _table_eID_MRTD_PoP_Response:
+.. _table_eID_MRTD_PoP_Response_Header:
 .. list-table:: MRTD PoP Response Parameters
    :widths: 20 15 65
    :header-rows: 1
@@ -264,6 +264,36 @@ If the HTTP Request is successfully processed, the MRTD PoP Service MUST send a 
    * - **Parameter**
      - **Type**
      - **Description**
+   * - **alg**
+     - string
+     - REQUIRED. Signature algorithm.
+   * - **typ**
+     - string
+     - REQUIRED. It MUST be ``mrtd+ias+pop``.
+   * - **kid**
+     - string
+     - REQUIRED. Identifier of the PID Provider's key that MUST be used to verify the signature of this JWT.
+
+.. _table_eID_MRTD_PoP_Response_Payload:
+.. list-table:: MRTD PoP Response Parameters
+   :widths: 20 15 65
+   :header-rows: 1
+
+   * - **Parameter**
+     - **Type**
+     - **Description**
+   * - **iss**
+     - string
+     - REQUIRED. PID Provider identifier.
+   * - **aud**
+     - string
+     - REQUIRED. Wallet Instance identifier.
+   * - **iat**
+     - integer
+     - REQUIRED. Issuance time (Unix timestamp).
+   * - **exp**
+     - integer
+     - REQUIRED. Expiration time (Unix timestamp).
    * - **challenge**
      - string
      - REQUIRED. Challenge data for cryptographic document validation. It SHOULD be the SHA-256 hash value of a random value with the ``mrtd_auth_session`` and timestamp for cryptographic binding.
@@ -273,18 +303,35 @@ If the HTTP Request is successfully processed, the MRTD PoP Service MUST send a 
    * - **mrz**
      - string
      - OPTIONAL. Machine Readable Zone information including document number, date of birth, expiry date, citizenship and gender.
+   * - **htu**
+     - string
+     - REQUIRED. HTTP URI of the MRTD PoP validation endpoint.
+   * - **htm**
+     - string
+     - REQUIRED. HTTP method for the MRTD PoP validation request. MUST be ``POST``.
 
 Below a non-normative example of an MRTD PoP Response:
 
 .. code-block:: http
 
     HTTP/1.1 202 Accepted
-    Content-Type: application/json; charset=utf-8
-
+    Content-Type: application/jwt; charset=utf-8
     {
+      "alg":"ES256",
+      "typ":"mrtd+ias+pop",
+      "kid":"b3f1a6c2e9d54a8f9c3e7d1a2f4b6c78"
+    }
+    .
+    {
+      "iss":"https://pid-provider.example.org",
+      "aud":"https://wallet.example.org/instance/12345",
+      "iat": 1753555800,
+      "exp": 1753556000,
       "mrtd_pop_nonce":"9f2c4a7e3b1d8c9a6e5f4b2a1c3d7e8f",
       "mrz":"...",
-      "challenge":"..."
+      "challenge":"...",
+      "htu":"...",
+      "htm":"..."
     }
 
 **The MRTD PoP Service MUST:**
@@ -522,7 +569,7 @@ Upon successful MRTD PoP validation, the Wallet Instance MUST redirect the User 
 
 .. code-block:: text
 
-    https://pid-provider.example.org/l2plus-callback?mrtd_val_pop_nonce=0f2bff024317345b6927ce17e776361d_signed&auth_session=wxroVrBY2MCq4dDNGXACS
+    https://pid-provider.example.org/l2plus-callback?mrtd_val_pop_nonce=0f2bff024317345b6927ce17e776361d_signed&mrtd_auth_session=wxroVrBY2MCq4dDNGXACS
 
 The Wallet Instance MUST validate that the ``mrtd_val_pop_nonce`` matches the value received from the MRTD PoP Validation Response.
 

--- a/docs/en/plantuml/l2plus-detailed-flow.puml
+++ b/docs/en/plantuml/l2plus-detailed-flow.puml
@@ -1,4 +1,4 @@
-@startuml eID LoA3 Authentication + remote identity proofing in IT-Wallet PID Issuance Flow
+@startuml
 '!theme cerulean-outline
 autonumber
 participant "User" as U
@@ -37,7 +37,7 @@ opt
     MIN --> DPOPS: MRZ information
 end
 
-DPOPS --> A: **MRTD PoP Response**\nHTTP/1.1 202 Accepted\nwith mrtd_pop_nonce, challenge and (optionally) MRZ data
+DPOPS --> A: **MRTD PoP Response**\nHTTP/1.1 202 Accepted\nwith mrtd_pop_nonce, challenge, htu, htm and (optionally) MRZ data
 
 alt If MRZ is not available to the Wallet Instance
     A -> U: Request to insert CAN

--- a/docs/it/credential-issuance-l2plus.rst
+++ b/docs/it/credential-issuance-l2plus.rst
@@ -270,7 +270,7 @@ Se la Richiesta HTTP è elaborata con successo, il Servizio MRTD PoP DEVE inviar
      - OBBLIGATORIO. Algoritmo di firma.
    * - **typ**
      - string
-     - OBBLIGATORIO. DEVE essere ``mrtd+ias+pop``.
+     - OBBLIGATORIO. DEVE essere ``mrtd-ias-pop+jwt``.
    * - **kid**
      - string
      - OBBLIGATORIO. Identificatore della chiave del Provider PID che DEVE essere utilizzata per verificare la firma di questo JWT.
@@ -319,7 +319,7 @@ Di seguito un esempio non normativo di una Risposta MRTD PoP:
     Content-Type: application/jwt; charset=utf-8
     {
       "alg":"ES256",
-      "typ":"mrtd+ias+pop",
+      "typ":"mrtd-ias-pop+jwt",
       "kid":"b3f1a6c2e9d54a8f9c3e7d1a2f4b6c78"
     }
     .

--- a/docs/it/credential-issuance-l2plus.rst
+++ b/docs/it/credential-issuance-l2plus.rst
@@ -90,7 +90,7 @@ Questa sezione fornisce dettagli tecnici su come richiedere l'Emissione PID attr
 .. plantuml:: plantuml/l2plus-detailed-flow.puml
     :width: 99%
     :alt: La figura illustra il Flusso Dettagliato di Autenticazione eID Substantial con Verifica MRTD.
-    :caption: `Flusso Dettagliato di Autenticazione eID Substantial con Verifica MRTD. <https://www.plantuml.com/plantuml/svg/nLRhRXit4_tFfvZFGVBPYbUAxVmeX2ZEHhvOHM8l93b1MnS2jJkIs53abkJALf--7EvgTKaL16YB0ePXS-ToPixm3DzPnuqhvXAmTm4VT7m6SU5cg9n8kHDQmKimEDSEGMHqwfQG6wqdGar1AEWDeyzSIdIGUF-UjGLNASALr8_i___pWUO8APf28bUHBfmK2Xald5R5V8o6vTpuJ2Bdoi71lKLp0Dp2_VPvbQ6dhAFemIJUDkdsBiDnbutr4y01eKcCNeYCGZxx8AOpzruMkEr5LbIkDkAFije1caK58Xvi6t_i3trCdGGRKS6uIEwI0KELWS_x5IIu3L6vX3vEXNLc6Pm-zcwtJLTc3wfNDRa67nnw5mbZp9zB_1TuOlSGlOMu3Py9ZDF0KoSMt27u152vFQZ2KYnAFoZ6n8GJNCAZS3C8hVc4HamgD8nrEXr8PjmYdBJXZh3kTBgFlnTe7NGwB0xv1z269ExN7mu1KYbGkP78Zi6KftVZtp1rHnuEXDHbwAWR3AFOEMzJnkSgs_in8Xg52lNT8C_Ga3d5R3H2LBu9TPIXuqA2M-O81yADvEdBJAV5dB259Xyq6epv0YAgeox3vbfPXCCA-gWmuXZmAHS6xKYeerNTRU9aJtS8q_Nb45ehH7XUDwNJR3PVR0Id_yd-HblNXbnaKLuDKHEV-3oNsDHckadDgKzjn9oRvUuqHO5ekf2xNwW_D81RKq0a3gWQFwbjSjtsgkjX_ZkyeJRTjyleV7UAKsgQAYr3U_R4AxkxMSrP6-ex-ebBaGNJ6XjD-CrmcBHEcYTmzkeKhdGHIF-Wow1jc3cNstQh5KIn-HWcVxDthNH6PsgAvut6tBYifB_pPlttwCVFmxTX72Xba8UsdweQMDM8HkD19NS3JoncEes2QqieuMg87jYtYNnG_-G5O4pdZW50m4pz8fbgWmViZC05-jx-x5qcsin32B8b4uZMTUwQeCeOg-8H0TkTg2YaLjIyd7fUuZJ5t65M5LZsLkSZfLMAnr1p42eyr7cfdN9v5F9xrZbZN3heJKf05fHsm1TSI3wM24w7kdUsIgWdXd8qAvR8L7Y8na4tlWqMAwtihOzHMWHH9zDZnuN23BY3WSCSJaxgsEHv-UGCJrq02XEZv-HOjcfgT95Ns-edb5wSuVQgwtCv99Vw-X7yS7jyg-6YaY98Q8Z0_oJQMhJMczEPqwcMGUa9nGhABy-c1b7z-XQwKDCIvxbSAq0ITo-9d3xo32wkJuxfb_yzkBiOaNa8rOMeZXN4xwyiWUrBsui7crdhTBUzmJ74TD-bLhHtacBiZU0BBikmvBW7mFVxRWDgRpc5fYikTvJdGTdmH5YFuHuK_K4SdRvw_GDOCLNS5GQ96XzgxKcaxnMAjO9zKpCMj7MN_vbg0B1jlI0WAy0qdiH6rBs21vLgOr2MMT8Pfb_AdRkWEkcvGaaAMpN9swzMB2tGXKut78yOsn6U3Vru1NTVzelEkglVhJy6Cs4m3IkM89U2v66lHOb83Aa2sTym21I_D_hHeed6t686LuA6hAlLH9XvVGdypg-tqJugM-du_EjK8uA0sGjDctLKwK3vD3XqCwEBwGp69OAZpUtvUjyphUpIrXfjDEZ5iiSmD2r4wkeiTFTlRjrpRvtwK6KHy886fVv7MDi90PwVnSzFh_pF_eUFKTeXQBgzyN4yy4BRkxuPNlSlBs_PS8Om8OrCjN925MY1fwas6Mc1qzlFvc38BMGu2KfVtOdr8zlccAuVmwYoa9gzytyLS_ad>`_
+    :caption: `Flusso Dettagliato di Autenticazione eID Substantial con Verifica MRTD. <https://www.plantuml.com/plantuml/svg/nLV_Rjis4FvVJt5BqJPnewH9-iTWr4rLEquqj8aH9IssUJ1ewUpSHf4QHQLjdcZliHSRURBymvcm3Him810ayxkxxxux7fctfHN6LhaCddzZxp17ID5K4eKATMKbAGn4PRMgyYcQe71OIgaGoiBEhKLbSGT42RURAx5pgXu4V19IecL4j8densVySp-OwYy0EoEZxob30wDui0DFtjFyphwJ5MvQ9MZk7IPoX0mzF8W7qWhPX4CaZz7a8F3X-cO08prYr61qDKe2L1cuo9i6rpYdqXeDb-nPI8I6vuVuSXFR41whE4DboOgL5Ll4Wr4G16v1eYViCUc2CCO3UA-Z4tW1L1j_XS9eFICr1uEvjXeKIXZAgYmrdELKbasc4D-4jQn1S0lX6uYwyB7I4a5OI_V2891S20zZLPL2PPeZ9jNKbyMIa91g1H_HqCnnOdc2eDVhmL2K24TTkARqZj2XjwM-SjztqEi54OTEO1qxYgvX5o2LXCfEADi7WxzMRkbg-ZEcTi_H0OxCNi8-uyB8MczjoIrWwrBeokSraSylKFW-GU-iq_7kX3Fn91auoT0Aac2_5WWxP2Vo-4Mcqohtd5ZadKud21prq6V02PI5Nl9VK9vKXlO1lnHai9oGscioRXU7g-DPdP_Tm6532a-NUlGE3WwUhVdttnv_uQ9teQ0iB1PDTO1VH5v8FD1clbQPu-vs9uqCvSAGW71xXJSdjnfBxjfjlG6uX8dFoBNfPahRdHeu1BpsOjq-2izV22zyY19LgHcyq8brRV6vokd4jQ-Gb2qMcwtQ4EJ-lhYv6HqU7Hp1oSjZ6EfAPMEVKSe5xyATjKNPFJpaINRmcLj_NS73zCx_fkPuskdancPr7_HUhzudttswUSDzuKFoYEYwxbhfql3gTCPgT9Mu0cEcqv2D3qcHNP8Sgxyew5ZzHtiW27HX0m1WmYoM6rDTW6jCgmAD058pRNAMbbmAFp3OOI1SPHblOr1bGR3moFgp45pBJHsMPJbsPOdI50kBMPrThQmk9agh5FTXMO5zLwtAFt90sDL5FJ7zviGzo8IjAGH2MaZGluFp0B__1fbde6XAVj8v2JQF64wCQtUxtiqP0QaI3Hc4VdJ9g6PenhnGflKAoXA1PXpHHTFMeggiTg4WiLZ0qL4JWetFIci4Cc7tMCasDxeg5iVNzoYb_kpYM3IBxhuSzdatokUBxLcWQQRyo6YhKoqbl-ePkB-HBalasG-3nGpJ3OyVdymDelhf3VJ1boWg2adf-ZOAOHJrptobtkDyJZ0uFzht3_TChWOJZs5dVGXNtdWa_XdoRyMDesGLxp9Ezg5_H-8UeQYcKm-3o4y2gHMfUUtScRIm-6VsczGUZIekWzgm7wjbMqB9DuiM8aCokO3h90gFNxxw5ZAKguRckhUEZUtHrZf2N72QVVrVXiZcy5XoPoxSeCpDQ--36eEowUOu2Vj3Vn9xtnhkVR9a1GiqLbdJiR2xz63mNgTYBmYsXj3QA7a9Lx-qpvysGTjd4HZCo63AHovWFPeSrTLuul9ne1aNkXt1rUrhDKEF6n9V4T-9KbW1PGNlZFvSel5y_1sWEPVQQdYOJayVnvgKD5UOFTF-1Z5PRF_wgh1hZSZ98aphG7jhv-YhrO7RVcbBO4FGbZkC5wslCqeHl2NB--zEu5E7JdM6THhmpFVByeFAiiSEdfv4Ju-7xg_zAcIKjWYQ_mdOZn8tQUFpYvlpwxEpoo2MCEDHwXEmf2e19RhNJ0FnqkExTAfpX0ndfAY-SajdKs3ApRfsqqQLSUJWhNkhSla7>`_
 
 Fase 1: Richiesta di Autorizzazione OAuth
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -254,9 +254,28 @@ Il Servizio MRTD PoP PUÒ richiedere le informazioni MRZ (numero documento, data
 Risposta MRTD PoP
 """"""""""""""""""
 
-Se la Richiesta HTTP è elaborata con successo, il Servizio MRTD PoP DEVE inviare una Risposta HTTP con codice *202 Accepted* e ``application/json`` come content type. Il payload della risposta JSON contiene i parametri inclusi nella seguente tabella:
+Se la Richiesta HTTP è elaborata con successo, il Servizio MRTD PoP DEVE inviare una Risposta HTTP con codice *202 Accepted* e ``application/jwt`` come content type. La struttura JWT è definita come segue:
 
-.. _table_eID_MRTD_PoP_Response:
+
+.. _table_eID_MRTD_PoP_Response_Header:
+.. list-table:: MRTD PoP Response Parameters
+   :widths: 20 15 65
+   :header-rows: 1
+
+   * - **Parameter**
+     - **Type**
+     - **Description**
+   * - **alg**
+     - string
+     - OBBLIGATORIO. Algoritmo di firma.
+   * - **typ**
+     - string
+     - OBBLIGATORIO. DEVE essere ``mrtd+ias+pop``.
+   * - **kid**
+     - string
+     - OBBLIGATORIO. Identificatore della chiave del Provider PID che DEVE essere utilizzata per verificare la firma di questo JWT.
+
+.. _table_eID_MRTD_PoP_Response_Payload:
 .. list-table:: Parametri Risposta MRTD PoP
    :widths: 20 15 65
    :header-rows: 1
@@ -264,6 +283,18 @@ Se la Richiesta HTTP è elaborata con successo, il Servizio MRTD PoP DEVE inviar
    * - **Parametro**
      - **Tipo**
      - **Descrizione**
+   * - **iss**
+     - string
+     - OBBLIGATORIO. Identificatore Provider PID.
+   * - **aud**
+     - string
+     - OBBLIGATORIO. Identificatore Istanza del Wallet.
+   * - **iat**
+     - integer
+     - OBBLIGATORIO. Tempo di emissione (Unix timestamp).
+   * - **exp**
+     - integer
+     - OBBLIGATORIO. Tempo di scadenza (Unix timestamp).
    * - **challenge**
      - string
      - OBBLIGATORIO. Dati di challenge per validazione crittografica del documento. DOVREBBE essere il valore hash SHA-256 di un valore casuale con ``mrtd_auth_session`` e timestamp per binding crittografico.
@@ -273,18 +304,35 @@ Se la Richiesta HTTP è elaborata con successo, il Servizio MRTD PoP DEVE inviar
    * - **mrz**
      - string
      - OPZIONALE. Informazioni Machine Readable Zone inclusi numero documento, data di nascita, data di scadenza, cittadinanza e genere.
+   * - **htu**
+     - string
+     - OBBLIGATORIO. URI HTTP dell'endpoint di validazione MRTD PoP.
+   * - **htm**
+     - string
+     - OBBLIGATORIO. Metodo HTTP per la richiesta di validazione MRTD PoP. DEVE essere ``POST``.
 
 Di seguito un esempio non normativo di una Risposta MRTD PoP:
 
 .. code-block:: http
 
     HTTP/1.1 202 Accepted
-    Content-Type: application/json; charset=utf-8
-
+    Content-Type: application/jwt; charset=utf-8
     {
+      "alg":"ES256",
+      "typ":"mrtd+ias+pop",
+      "kid":"b3f1a6c2e9d54a8f9c3e7d1a2f4b6c78"
+    }
+    .
+    {
+      "iss":"https://pid-provider.example.org",
+      "aud":"https://wallet.example.org/instance/12345",
+      "iat": 1753555800,
+      "exp": 1753556000,
       "mrtd_pop_nonce":"9f2c4a7e3b1d8c9a6e5f4b2a1c3d7e8f",
       "mrz":"...",
-      "challenge":"..."
+      "challenge":"...",
+      "htu":"...",
+      "htm":"..."
     }
 
 **Il Servizio MRTD PoP DEVE:**

--- a/docs/it/plantuml/l2plus-detailed-flow.puml
+++ b/docs/it/plantuml/l2plus-detailed-flow.puml
@@ -1,4 +1,4 @@
-@startuml Autenticazione eID LoA3 + identity proofing remoto nel Flusso Emissione PID IT-Wallet
+@startuml
 '!theme cerulean-outline
 autonumber
 participant "Utente" as U
@@ -37,7 +37,7 @@ opt
     MIN --> DPOPS: Informazioni MRZ
 end
 
-DPOPS --> A: **Risposta MRTD PoP**\nHTTP/1.1 202 Accepted\ncon mrtd_pop_nonce, challenge e (opzionalmente) dati MRZ
+DPOPS --> A: **Risposta MRTD PoP**\nHTTP/1.1 202 Accepted\ncon mrtd_pop_nonce, challenge, htu, htm e (opzionalmente) dati MRZ
 
 alt Se MRZ non è disponibile all'Istanza Wallet
     A -> U: Richiesta di inserire CAN


### PR DESCRIPTION
This PR introduces the following changes in the L2+ flow:

 - Content type of MRTD PoP response becomes `application/jwt`
 - Added `htm` and `htu` parameter related to the URI of MRTD PoP validation endpoint in the MRTD PoP Response JWT
 - Update sequence diagram