### PR TITLE
fix: pid/attestation deletion made by Holders must not notify to credential issuer

### DIFF
--- a/docs/en/credential-revocation.rst
+++ b/docs/en/credential-revocation.rst
@@ -207,7 +207,7 @@ Status Update related to the User
 
 Users MAY change their Digital Credential validity status by:
 
-  1. Deleting the Digital Credential from their Wallet Instance: the Wallet Instance SHOULD prompt the User about the deletion motivation to be optionally notified to the Credential Issuer. When the User uses this functionality, the notification to be sent to the Credential Issuer MUST use the Notification Endpoint provided by the Issuer, as described in Section :ref:`credential-revocation:Status Update by Wallet Instance`.
+  1. Deleting the Digital Credential from their Wallet Instance: the Wallet Instance SHOULD prompt the User to be optionally notify the Credential Issuer about the User's intention to revoke the Digital Credential. When the User uses this functionality, the notification to be sent to the Credential Issuer MUST use the Notification Endpoint provided by the Issuer, as described in Section :ref:`credential-revocation:Status Update by Wallet Instance`.
   2. Using the Issuer's web portal:
 
     a. Users MAY access a secure area with at least the same Level of Assurance used during the issuance phase.

--- a/docs/en/credential-revocation.rst
+++ b/docs/en/credential-revocation.rst
@@ -228,9 +228,11 @@ The User's death triggers a change in the validity status of the User's identifi
 Status Update by Wallet Instance
 """"""""""""""""""""""""""""""""
 
-When the User deletes a Digital Credential from the Wallet Instance, the Wallet Instance SHALL NOT notify the Credential Issuer of this deletion event. Deleting a Digital Credential from the Wallet Instance only removes the local copy and does not change the validity status at the Issuer. If the User wants the Issuer to revoke a Digital Credential, the User MUST use the Issuer's web portal or other Issuer-provided channels.
+When the User deletes a Digital Credential from the Wallet Instance, the Wallet Instance by default SHALL NOT notify the Credential Issuer of this deletion event. Deleting a Digital Credential from the Wallet Instance only removes the local copy and does not change the validity status at the Issuer.
 
-The Wallet Instance MAY inform the User, prior to deletion, that deletion is a local action and does not imply revocation at the Issuer.
+The Wallet Instance MAY inform the User, prior to deletion, that deletion is a local action and does not imply revocation at the Issuer, and MAY implement, under the User’s explicit consent at deletion time, a notification feature to inform the Credential Issuer of the User’s intention to revoke the Digital Credential.
+
+If the User wants the Issuer to revoke a Digital Credential, the User SHOULD explicitly confirm this intention via the Wallet Instance’s deletion prompt (when available), which SHALL then notify the Credential Issuer; alternatively, the User MAY use the Issuer's web portal or other Issuer-provided channels.
 
 Status Update by Wallet Providers
 """""""""""""""""""""""""""""""""
@@ -282,11 +284,11 @@ Batch Credential Lifecycle Management
 
 When multiple Digital Credentials are issued together in a single batch, their lifecycle remains fully granular:
 
-  * **Grouped triggers, independent updates**: A single batch status update request referencing the batch's ``notification_id`` and sent by an authorized entity (e.g. a Wallet Provider via PDND) is handled as N separate status changes. The Issuer updates each Credential's own status individually (for example, flipping its status-list bit to ``INVALID`` or ``SUSPENDED``). A Wallet Instance SHALL NOT trigger batch status updates when the User deletes local Credentials.
+  * **Grouped triggers, independent updates**: A single batch status update request referencing the batch's ``notification_id`` and sent by an authorized entity (e.g. a Wallet Provider via PDND) is handled as N separate status changes. The Issuer updates each Credential's own status individually (for example, flipping its status-list bit to ``INVALID`` or ``SUSPENDED``). By default, a Wallet Instance SHALL NOT trigger batch status updates when the User deletes local Credentials. Upon deletion, the Wallet Instance MAY, under the User’s explicit consent, notify the Credential Issuer of the User’s intention to revoke the affected Credential(s); such a notification does not constitute a batch status update request.
   * **Batch-wide revoke**: That same batch update request also serves as a revoke all request. The Issuer marks every Credential in the batch as revoked and MAY emit a single notification for the entire batch according to Issuer policy.
 
 .. note::
-  As the Wallet UI typically surfaces a batch as one Credential (e.g., 3 uses remaining), a User-driven deletion in the Wallet removes the entire batch locally. It does not request revocation at the Issuer.
+  As the Wallet UI typically surfaces a batch as one Credential (e.g., 3 uses remaining), a User-driven deletion in the Wallet removes the entire batch locally. By default it does not request revocation at the Issuer. The Wallet MAY offer the User an optional prompt to request revocation at the Issuer as part of the deletion flow.
 
 
 

--- a/docs/en/credential-revocation.rst
+++ b/docs/en/credential-revocation.rst
@@ -207,7 +207,8 @@ Status Update related to the User
 
 Users MAY change their Digital Credential validity status by:
 
-  1. Using the Issuer's web portal:
+  1. Deleting the Digital Credential from their Wallet Instance: the Wallet Instance SHOULD prompt the User about the deletion motivation to be optionally notified to the Credential Issuer. When the User uses this functionality, the notification to be sent to the Credential Issuer MUST use the Notification Endpoint provided by the Issuer, as described in Section :ref:`credential-revocation:Status Update by Wallet Instance`.
+  2. Using the Issuer's web portal:
 
     a. Users MAY access a secure area with at least the same Level of Assurance used during the issuance phase.
     b. The Issuer MUST allow Users to:

--- a/docs/en/credential-revocation.rst
+++ b/docs/en/credential-revocation.rst
@@ -230,9 +230,9 @@ Status Update by Wallet Instance
 
 When the User deletes a Digital Credential from the Wallet Instance, the Wallet Instance by default SHALL NOT notify the Credential Issuer of this deletion event. Deleting a Digital Credential from the Wallet Instance only removes the local copy and does not change the validity status at the Issuer.
 
-The Wallet Instance MAY inform the User, prior to deletion, that deletion is a local action and does not imply revocation at the Issuer, and MAY implement, under the User’s explicit consent at deletion time, a notification feature to inform the Credential Issuer of the User’s intention to revoke the Digital Credential.
+The Wallet Instance MAY inform the User, prior to deletion, that deletion is a local action and does not imply revocation at the Issuer, and MAY implement, under the User's explicit consent at deletion time, a notification feature to inform the Credential Issuer of the User's intention to revoke the Digital Credential.
 
-If the User wants the Issuer to revoke a Digital Credential, the User SHOULD explicitly confirm this intention via the Wallet Instance’s deletion prompt (when available), which SHALL then notify the Credential Issuer; alternatively, the User MAY use the Issuer's web portal or other Issuer-provided channels.
+If the User wants the Issuer to revoke a Digital Credential, the User SHOULD explicitly confirm this intention via the Wallet Instance's deletion prompt (when available), which SHALL then notify the Credential Issuer; alternatively, the User MAY use the Issuer's web portal or other Issuer-provided channels.
 
 Status Update by Wallet Providers
 """""""""""""""""""""""""""""""""
@@ -284,7 +284,7 @@ Batch Credential Lifecycle Management
 
 When multiple Digital Credentials are issued together in a single batch, their lifecycle remains fully granular:
 
-  * **Grouped triggers, independent updates**: A single batch status update request referencing the batch's ``notification_id`` and sent by an authorized entity (e.g. a Wallet Provider via PDND) is handled as N separate status changes. The Issuer updates each Credential's own status individually (for example, flipping its status-list bit to ``INVALID`` or ``SUSPENDED``). By default, a Wallet Instance SHALL NOT trigger batch status updates when the User deletes local Credentials. Upon deletion, the Wallet Instance MAY, under the User’s explicit consent, notify the Credential Issuer of the User’s intention to revoke the affected Credential(s); such a notification does not constitute a batch status update request.
+  * **Grouped triggers, independent updates**: A single batch status update request referencing the batch's ``notification_id`` and sent by an authorized entity (e.g. a Wallet Provider via PDND) is handled as N separate status changes. The Issuer updates each Credential's own status individually (for example, flipping its status-list bit to ``INVALID`` or ``SUSPENDED``). By default, a Wallet Instance SHALL NOT trigger batch status updates when the User deletes local Credentials. Upon deletion, the Wallet Instance MAY, under the User's explicit consent, notify the Credential Issuer of the User's intention to revoke the affected Credential(s); such a notification does not constitute a batch status update request.
   * **Batch-wide revoke**: That same batch update request also serves as a revoke all request. The Issuer marks every Credential in the batch as revoked and MAY emit a single notification for the entire batch according to Issuer policy.
 
 .. note::

--- a/docs/en/credential-revocation.rst
+++ b/docs/en/credential-revocation.rst
@@ -207,8 +207,7 @@ Status Update related to the User
 
 Users MAY change their Digital Credential validity status by:
 
-  1. Deleting the Digital Credential from their Wallet Instance: the Wallet Instance MUST use the Notification Endpoint provided by the Issuer as described in Section :ref:`credential-revocation:Status Update by Wallet Instance`.
-  2. Using the Issuer's web portal:
+  1. Using the Issuer's web portal:
 
     a. Users MAY access a secure area with at least the same Level of Assurance used during the issuance phase.
     b. The Issuer MUST allow Users to:
@@ -229,10 +228,9 @@ The User's death triggers a change in the validity status of the User's identifi
 Status Update by Wallet Instance
 """"""""""""""""""""""""""""""""
 
-When the User deletes a Digital Credential from the Wallet Instance, the Wallet Instance MUST notify this event to the Credential Issuer and the Credential Issuer MUST revoke the Digital Credential. To notify this event, the Wallet Instance MUST use the *Notification Endpoint* described in Section :ref:`credential-issuance-endpoint:Notification Endpoint` using the parameter ``event`` set with the value ``credential_deleted``.
+When the User deletes a Digital Credential from the Wallet Instance, the Wallet Instance SHALL NOT notify the Credential Issuer of this deletion event. Deleting a Digital Credential from the Wallet Instance only removes the local copy and does not change the validity status at the Issuer. If the User wants the Issuer to revoke a Digital Credential, the User MUST use the Issuer's web portal or other Issuer-provided channels.
 
-When the revoked Credential is the PID, the Credential Issuer MUST send a notification of this event to the User within 24 hours.
-For any other Credential different from the PID, the Credential Issuer SHOULD send a notification of this event to the User. The notification to the User MAY be implemented in several ways, such as using a User's email address, telephone number, or any other verified and secure communication channel. The notification to the User MUST also include all the information about the Credential revocation status. The method used for the notification to the User is out of scope of the current technical implementation profile. When the revocation occurs, the Credential Issuer MUST update the status of the Digital Credential accordingly. When the Notification Response sent by the Credential Issuer is successfully received by the Wallet Instance, the Wallet Instance MUST delete the Digital Credential.
+The Wallet Instance MAY inform the User, prior to deletion, that deletion is a local action and does not imply revocation at the Issuer.
 
 Status Update by Wallet Providers
 """""""""""""""""""""""""""""""""
@@ -284,11 +282,11 @@ Batch Credential Lifecycle Management
 
 When multiple Digital Credentials are issued together in a single batch, their lifecycle remains fully granular:
 
-  * **Grouped triggers, independent updates**: A single batch status update request referencing the batch's ``notification_id`` and sent by any authorized entity (e.g. the Wallet Instance via Notification Endpoint with ``event=credential_deleted``, a Wallet Provider via PDND) is handled as N separate status changes. The Issuer updates each Credential's own status individually (for example, flipping its status-list bit to ``INVALID`` or ``SUSPENDED``).
-  * **Batch-wide revoke**: That same batch update request also serves as a revoke all request. the Issuer marks every Credential in the batch as revoked and emits a single notification for the entire batch.
+  * **Grouped triggers, independent updates**: A single batch status update request referencing the batch's ``notification_id`` and sent by an authorized entity (e.g. a Wallet Provider via PDND) is handled as N separate status changes. The Issuer updates each Credential's own status individually (for example, flipping its status-list bit to ``INVALID`` or ``SUSPENDED``). A Wallet Instance SHALL NOT trigger batch status updates when the User deletes local Credentials.
+  * **Batch-wide revoke**: That same batch update request also serves as a revoke all request. The Issuer marks every Credential in the batch as revoked and MAY emit a single notification for the entire batch according to Issuer policy.
 
 .. note::
-  As the Wallet UI typically surfaces a batch as one Credential (e.g., 3 uses remaining), a User-driven deletion likewise removes the entire batch. It is not possible to delete or revoke just one Credential, any deletion request using the batch's ``notification_id`` applies to all Credentials in that batch.
+  As the Wallet UI typically surfaces a batch as one Credential (e.g., 3 uses remaining), a User-driven deletion in the Wallet removes the entire batch locally. It does not request revocation at the Issuer.
 
 
 

--- a/docs/en/credential-revocation.rst
+++ b/docs/en/credential-revocation.rst
@@ -235,6 +235,9 @@ The Wallet Instance MAY inform the User, prior to deletion, that deletion is a l
 
 If the User wants the Issuer to revoke a Digital Credential, the User SHOULD explicitly confirm this intention via the Wallet Instance’s deletion prompt (when available), which SHALL then notify the Credential Issuer; alternatively, the User MAY use the Issuer's web portal or other Issuer-provided channels.
 
+When the revoked Credential is the PID, the Credential Issuer MUST send a notification of this event to the User within 24 hours.
+For any other Credential different from the PID, the Credential Issuer SHOULD send a notification of this event to the User. The notification to the User MAY be implemented in several ways, such as using a User's email address, telephone number, or any other verified and secure communication channel. The notification to the User MUST also include all the information about the Credential revocation status. The method used for the notification to the User is out of scope of the current technical implementation profile. When the revocation occurs, the Credential Issuer MUST update the status of the Digital Credential accordingly. When the Notification Response sent by the Credential Issuer is successfully received by the Wallet Instance, the Wallet Instance MUST delete the Digital Credential.
+
 Status Update by Wallet Providers
 """""""""""""""""""""""""""""""""
 
@@ -285,7 +288,7 @@ Batch Credential Lifecycle Management
 
 When multiple Digital Credentials are issued together in a single batch, their lifecycle remains fully granular:
 
-  * **Grouped triggers, independent updates**: A single batch status update request referencing the batch's ``notification_id`` and sent by an authorized entity (e.g. a Wallet Provider via PDND) is handled as N separate status changes. The Issuer updates each Credential's own status individually (for example, flipping its status-list bit to ``INVALID`` or ``SUSPENDED``). By default, a Wallet Instance SHALL NOT trigger batch status updates when the User deletes local Credentials. Upon deletion, the Wallet Instance MAY, under the User’s explicit consent, notify the Credential Issuer of the User’s intention to revoke the affected Credential(s); such a notification does not constitute a batch status update request.
+  * **Grouped triggers, independent updates**: A single batch status update request referencing the batch's ``notification_id`` and sent by an authorized entity (e.g. the Wallet Instance via Notification Endpoint with ``event=credential_deleted``, a Wallet Provider via PDND) is handled as N separate status changes. The Issuer updates each Credential's own status individually (for example, flipping its status-list bit to ``INVALID`` or ``SUSPENDED``). By default, a Wallet Instance SHALL NOT trigger batch status updates when the User deletes local Credentials. Upon deletion, the Wallet Instance MAY, under the User’s explicit consent, notify the Credential Issuer of the User’s intention to revoke the affected Credential(s); such a notification does not constitute a batch status update request.
   * **Batch-wide revoke**: That same batch update request also serves as a revoke all request. The Issuer marks every Credential in the batch as revoked and MAY emit a single notification for the entire batch according to Issuer policy.
 
 .. note::

--- a/docs/en/credential-revocation.rst
+++ b/docs/en/credential-revocation.rst
@@ -220,11 +220,11 @@ Users MAY change their Digital Credential validity status by:
 .. note::
   If the User activates another Wallet Instance from the same Wallet Provider and using the same Wallet Solution and obtains a new PID, the previous PID MUST be revoked, and the previous Wallet Instance MUST transition to operational status.
 
-In case of the death of the User, Issuers and Wallet Provider MUST ensure that Digital Credentials and Wallet Instances owned by the User are revoked.
+In case of the death of the User, Issuers MUST ensure that Digital Credentials and Wallet Instances owned by the User are revoked.
 The User's death triggers a change in the validity status of the User's identification attributes contained in the public registry (ANPR). The User's death MUST produce the PID revocation. Therefore, the Authentic Source of the PID (ANPR) MUST notify the PID Provider that the User's attributes are no longer valid due to the death of the User. The Authentic Source and the PID Provider MUST use the mechanisms provided in the Section :ref:`credential-revocation:Status Update by Authentic Sources`.
 
 .. note::
-  Future versions of this technical specification will define how the information to (Q)EAA Issuers and Wallet Providers are propagated, according to national regulation. Moreover, automated procedures for Credential revocation due to illegal activities will be defined in future specifications.
+  Future versions of this technical specification will define how the information to (Q)EAA Issuers are propagated, according to national regulation. Moreover, automated procedures for Credential revocation due to illegal activities will be defined in future specifications.
 
 Status Update by Wallet Instance
 """"""""""""""""""""""""""""""""

--- a/docs/it/credential-revocation.rst
+++ b/docs/it/credential-revocation.rst
@@ -218,11 +218,11 @@ Gli Utenti POSSONO modificare lo stato di validità del loro Attestato Elettroni
 .. note::
   Se l'Utente attiva un'altra Istanza del Wallet dello stesso Fornitore di Wallet e utilizzando la stessa Soluzione di Wallet e ottiene un nuovo PID, il PID precedente DEVE essere revocato e la precedente Istanza del Wallet DEVE passare allo stato operativo.
 
-In caso di morte dell'Utente, i Fornitori di Attestati Elettronici e il Fornitore di Wallet DEVONO garantire che gli Attestati Elettronici e le Istanze del Wallet di proprietà dell'Utente siano revocati.
+In caso di morte dell'Utente, i Fornitori di Attestati Elettronici DEVONO garantire che gli Attestati Elettronici e le Istanze del Wallet di proprietà dell'Utente siano revocati.
 La morte dell'Utente comporta una modifica dello stato di validità degli attributi identificativi dell'Utente contenuti nel registro pubblico (ANPR). La morte dell'Utente DEVE produrre la revoca del PID. Pertanto, la Fonte Autentica del PID (ANPR) DEVE notificare al PID Provider che gli attributi dell'Utente non sono più validi a causa della morte dell'Utente. La Fonte Autentica e il PID Provider DEVONO utilizzare i meccanismi previsti nella Sezione :ref:`credential-revocation:Status Update by Authentic Sources`.
 
 .. note::
-  Le versioni future della presente specifica tecnica definiranno come le informazioni verso i Fornitori di (Q)EAA e i Fornitori di Wallet vengono propagate, in accordo alla normativa nazionale. Inoltre, saranno definite procedure automatizzate per la revoca degli Attestati dovuta ad attività illecite.
+  Le versioni future della presente specifica tecnica definiranno come le informazioni verso i Fornitori di (Q)EAA vengono propagate, in accordo alla normativa nazionale. Inoltre, saranno definite procedure automatizzate per la revoca degli Attestati dovuta ad attività illecite.
 
 Aggiornamento dello Stato da parte dell'Istanza del Wallet
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/docs/it/credential-revocation.rst
+++ b/docs/it/credential-revocation.rst
@@ -205,8 +205,7 @@ Aggiornamento dello Stato relativo all'Utente
 
 Gli Utenti POSSONO modificare lo stato di validità del loro Attestato Elettronico:
 
-  1. Eliminando l'Attestato Elettronico dalla loro Istanza del Wallet: l'Istanza del Wallet DEVE utilizzare l'Endpoint di Notifica fornito dal Fornitore di Attestati Elettronici come descritto nella Sezione :ref:`credential-revocation:Aggiornamento dello Stato da parte dell'Istanza del Wallet`.
-  2. Utilizzando il portale web del Fornitore di Attestati Elettronici:
+  1. Utilizzando il portale web del Fornitore di Attestati Elettronici:
 
     a. Gli Utenti POSSONO accedere ad un'area sicura con almeno lo stesso Livello di Garanzia utilizzato durante la fase di emissione.
     b. Il Fornitore di Attestati Elettronici DEVE consentire agli Utenti di:
@@ -215,78 +214,23 @@ Gli Utenti POSSONO modificare lo stato di validità del loro Attestato Elettroni
       - Verificare l'autenticità dei dati.
       - Visualizzare e aggiornare lo stato di validità (revocare i loro Attestati Elettronici e, se supportato dal Fornitore di Attestati Elettronici, sospenderle).
 
-.. note::
-  Se l'Utente attiva un'altra Istanza del Wallet dallo stesso Fornitore di Wallet utilizzando la stessa Soluzione Wallet e ottiene un nuovo PID, il PID precedente DEVE essere revocato e l'Istanza del Wallet precedente DEVE passare allo stato operativo.
-
-In caso di morte dell'Utente, i Fornitori di Attestati Elettronici e il Fornitore di Wallet DEVONO garantire che gli Attestati Elettronici e le Istanze del Wallet possedute dall'Utente siano revocate.
-La morte dell'Utente attiva un cambiamento nello stato di validità degli attributi di identificazione dell'Utente contenuti nel registro pubblico (ANPR). La morte dell'Utente DEVE produrre la revoca del PID. Pertanto, la Fonte Autentica del PID (ANPR) DEVE notificare al Fornitore di Attestati Elettronici di Dati di Identificazione Personale che gli attributi dell'Utente non sono più validi a causa della morte dell'Utente. La Fonte Autentica e il Fornitore di Attestati Elettronici di Dati di Identificazione Personale DEVONO utilizzare i meccanismi forniti nella Sezione :ref:`credential-revocation:Aggiornamento dello Stato da parte delle Fonti Autentiche`.
-
-.. note::
-  Le versioni future di questa specifica tecnica definiranno come le informazioni vengono propagate ai Fornitori di Attestati Elettronici di Attributi (Q)EAA e ai Fornitori di Wallet, in conformità con la normativa nazionale. Inoltre, le procedure automatizzate per la revoca degli Attestati Elettronici a causa di attività illegali saranno definite nelle specifiche future.
-
 Aggiornamento dello Stato da parte dell'Istanza del Wallet
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""""
 
-Quando l'Utente elimina un Attestato Elettronico dall'Istanza del Wallet, l'Istanza del Wallet DEVE notificare questo evento al Fornitore di Attestati Elettronici e il Fornitore di Attestati Elettronici DEVE revocare l'Attestato Elettronico. Per notificare questo evento, l'Istanza del Wallet DEVE utilizzare l'*Endpoint di Notifica* descritto nella Sezione :ref:`credential-issuance-endpoint:Notification Endpoint` utilizzando il parametro ``event`` impostato con il valore ``credential_deleted``.
+Quando l'Utente elimina un Attestato Elettronico dall'Istanza del Wallet, l'Istanza del Wallet NON DEVE notificare questo evento al Fornitore di Attestati Elettronici. L'eliminazione dall'Istanza del Wallet rimuove solo la copia locale e non modifica lo stato di validità presso il Fornitore di Attestati Elettronici. Se l'Utente desidera che il Fornitore di Attestati Elettronici revochi un Attestato Elettronico, DEVE utilizzare il portale web del Fornitore di Attestati Elettronici o altri canali messi a disposizione dal Fornitore di Attestati Elettronici.
 
-Quando l'Attestato Elettronico revocato è il PID, il Fornitore di Attestati Elettronici DEVE inviare una notifica di questo evento all'Utente entro 24 ore.
-Per qualsiasi altro Attestato Elettronico diverso dal PID, il Fornitore di Attestati Elettronici DOVREBBE inviare una notifica di questo evento all'Utente. La notifica all'Utente potrebbe essere implementata in diversi modi, come l'utilizzo dell'indirizzo email dell'Utente, del numero di telefono o di qualsiasi altro canale di comunicazione verificato e sicuro, e DEVE includere tutte le informazioni sullo stato di revoca dell'Attestato Elettronico. Il metodo utilizzato per la notifica all'Utente è fuori dall'ambito dell'attuale profilo di implementazione tecnica. Quando avviene la revoca, il Fornitore di Attestati Elettronici DEVE aggiornare lo stato dell'Attestato Elettronico di conseguenza. Quando la *Notification Response* inviata dal Fornitore di Attestati Elettronici viene ricevuta con successo dall'Istanza del Wallet, l'Istanza del Wallet DEVE eliminare l'Attestato Elettronico.
-
-Aggiornamento dello Stato da parte dei Fornitori di Wallet
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-In aggiunta a quanto già definito in :ref:`credential-revocation:Ciclo di Vita degli Attestati Elettronici`, il Fornitore di Attestati Elettronici DEVE fornire un servizio web (endpoint di Revoca dell'Istanza del Wallet) definito utilizzando PDND, come specificato nella Sezione :ref:`credential-issuer-endpoint:Catalogo degli e-Service PDND del Credential Issuer`.
-Il Fornitore di Wallet che per qualsiasi motivo revoca un'Istanza del Wallet DEVE inviare una notifica ai Fornitori di Attestati Elettronici utilizzando questo endpoint.
-
-Aggiornamento dello Stato da parte delle Fonti Autentiche
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Le Fonti Autentiche gestiscono gli attributi separatamente dagli Attestati Elettronici, che verificano l'autenticità come i documenti fisici. Perdere un documento fisico non significa perdere i privilegi che rappresenta; significa solo che l'Utente non può provarli. Tuttavia, se un Utente perde i privilegi a causa di un'infrazione grave, la Fonte Autentica revocherà gli attributi correlati. In tali casi, quando gli attributi di un Utente vengono aggiornati, le Fonti Autentiche DEVONO notificare ai Fornitori di Attestati Elettronici di aggiornare lo stato di validità di qualsiasi Attestato Elettronico contenente tali attributi.
-
-Le Fonti Autentiche che utilizzano Signal Hub DEVONO depositare un Segnale tramite il servizio :ref:`signal-hub-endpoint:e-Service di Raccolta Segnali` nei seguenti casi:
-
-  - Il valore di uno o più Attributi contenuti nel database della Fonte Autentica è cambiato.
-  - Lo stato di validità degli Attributi è aggiornato (revoca o sospensione).
-
-In entrambi i casi, il Segnale depositato DEVE avere ``signalType`` valorizzato con ``UPDATE``.
-
-Il Fornitore di Attestati Elettronici che usa Signal Hub DEVE controllare periodicamente l':ref:`signal-hub-endpoint:e-Service di Distribuzione Segnali` per recuperare i Segnali depositati dalle Fonti Autentiche. Quando un Segnale viene recuperato, il Fornitore di Attestati Elettronici compie le azioni descritte nella Sezione :ref:`signal-hub-endpoint:Elaborazione dei Segnali`. Il Fornitore di Attestati Elettronici è in grado di comprendere la natura del Segnale di ``UPDATE`` interagendo con la Fonte Autentica invocando il servizio `get attribute claims` e ispezionando il payload della risposta come descritto nella Sezione :ref:`authentic-source-endpoint:Get Attribute Claims`.
-
-Nel seguente diagramma è illustrato il processo di Alto Livello relativo all'aggiornamento dello stato da parte delle Fonti Autentiche.
-
-.. only:: format_html
-
-  .. figure:: ./images/svg/status-update-as.svg
-    :alt: Processo di aggiornamento dello stato da parte delle Fonti Autentiche
-    :width: 100%
-
-    Processo di aggiornamento dello stato da parte delle Fonti Autentiche
-
-.. only:: format_latex
-
-  .. figure:: ./images/pdf/status-update-as.pdf
-    :alt: Processo di aggiornamento dello stato da parte delle Fonti Autentiche
-    :width: 100%
-
-Il processo inizia nel momento in cui si verifica una variazione sui dati o sulla loro validità nel database della Fonte Autentica. Le modifiche possono essere indotte anche da enti terzi diversi dalla Fonte Autentica, ad esempio in caso di attività illegali notificate dagli Organi di Polizia.
-
-Una volta che avviene un cambiamento nei dati o nella loro validità, la Fonte Autentica notifica il Fornitore di Attestati Elettronici tramite Signal Hub depositando un Segnale nell':ref:`signal-hub-endpoint:e-Service di Raccolta Segnali`. 
-
-Il Fornitore di Attestati Elettronici controlla periodicamente l':ref:`signal-hub-endpoint:e-Service di Distribuzione Segnali` per recuperare i segnali depositati dalle Fonti Autentiche. Quando un Segnale viene recuperato, il Fornitore di Attestati Elettronici compie le azioni descritte nella Sezione :ref:`signal-hub-endpoint:Elaborazione dei Segnali`. In seguito esso provvede all'aggiornamento dello stato dell'Attestato Elettronico secondo la modalità definite per il meccanismo di validità utilizzato. Il Fornitore di Attestati Elettronici PUÒ inviare una notifica all'Utente utilizzando un eventuale canale di comunicazione precedentemente registrato.
-
-L'istanza del Wallet, a seguito dei controlli periodici che effettua sullo stato di validità degli Attestati Elettronici in essa memorizzati, riceve lo stato aggiornato. Nel caso in cui lo Stato dell'Attestato Elettronico venga modificato in INVALID il Fornitore di Attestati Elettronici DEVE informarne l'Utente. Nel caso in cui lo stato dell'Attestato Elettronico venga modificato in UPDATE (equivalentemente 0x03) o ATTRIBUTE_UPDATE (equivalentemente 0x04), il Wallet PUO' procedere alla riemissione dell'Attestato Elettronico Digitale come descritto in :ref:`credential-issuance-low-level:Re-Issuance Flow`.
+L'Istanza del Wallet PUÒ informare l'Utente, prima dell'eliminazione, che l'eliminazione è un'azione locale e non implica la revoca presso il Fornitore di Attestati Elettronici.
 
 Gestione del ciclo di vita delle Credenziali in batch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Quando più Attestati Elettronici vengono emessi insieme in un singolo batch, il loro ciclo di vita rimane completamente granulare:
-Quando più Attestati Elettronici vengono emessi insieme in un singolo batch, il loro ciclo di vita rimane completamente granulare:
 
-* **Trigger raggruppati, aggiornamenti indipendenti**: una singola richiesta di aggiornamento dello stato del batch che fa riferimento al ``notification_id`` del batch e inviata da qualsiasi entità autorizzata (ad esempio, l'Istanza del Wallet tramite il Notification Endpoint con ``event=credential_deleted``, un Wallet Provider tramite PDND) viene gestita come N modifiche di stato separate. Il Credential Issuer aggiorna lo stato di ciascun Attestato Elettronico singolarmente (ad esempio, impostando il bit della status-list su ``INVALID`` o ``SUSPENDED``).
-* **Revoca a livello di batch**: la stessa richiesta di aggiornamento del batch funge anche da richiesta di revoca totale. Il Credential Issuer contrassegna ogni Attestato Elettronico nel batch come revocata ed emette una singola notifica per l'intero batch.
+* **Trigger raggruppati, aggiornamenti indipendenti**: una singola richiesta di aggiornamento dello stato del batch che fa riferimento al ``notification_id`` del batch e inviata da un'entità autorizzata (ad esempio, un Wallet Provider tramite PDND) viene gestita come N modifiche di stato separate. Il Credential Issuer aggiorna lo stato di ciascun Attestato Elettronico singolarmente (ad esempio, impostando il bit della status-list su ``INVALID`` o ``SUSPENDED``). Un'Istanza del Wallet NON DEVE attivare aggiornamenti di stato del batch quando l'Utente elimina Attestati Elettronici localmente.
+* **Revoca a livello di batch**: la stessa richiesta di aggiornamento del batch funge anche da richiesta di revoca totale. Il Credential Issuer contrassegna ogni Attestato Elettronico nel batch come revocato e PUÒ emettere una singola notifica per l'intero batch secondo la propria policy.
 
 .. note::
-  Poiché l'interfaccia utente del Wallet in genere visualizza un batch come un singolo Attestato Elettronico (ad esempio, con 3 utilizzi rimanenti), un'eliminazione da parte dell'utente rimuove anche l'intero batch. Non è possibile eliminare o revocare un solo Attestato Elettronico; qualsiasi richiesta di eliminazione che utilizzi il ``notification_id`` del batch si applica a tutti gli Attestati Elettronici presenti in quel batch.
+  Poiché l'interfaccia utente del Wallet in genere visualizza un batch come un singolo Attestato Elettronico (ad esempio, con 3 utilizzi rimanenti), un'eliminazione da parte dell'utente rimuove l'intero batch localmente. Non richiede la revoca presso il Fornitore di Attestati Elettronici.
 
 
 Meccanismi di Verifica della Validità

--- a/docs/it/credential-revocation.rst
+++ b/docs/it/credential-revocation.rst
@@ -217,20 +217,22 @@ Gli Utenti POSSONO modificare lo stato di validità del loro Attestato Elettroni
 Aggiornamento dello Stato da parte dell'Istanza del Wallet
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-Quando l'Utente elimina un Attestato Elettronico dall'Istanza del Wallet, l'Istanza del Wallet NON DEVE notificare questo evento al Fornitore di Attestati Elettronici. L'eliminazione dall'Istanza del Wallet rimuove solo la copia locale e non modifica lo stato di validità presso il Fornitore di Attestati Elettronici. Se l'Utente desidera che il Fornitore di Attestati Elettronici revochi un Attestato Elettronico, DEVE utilizzare il portale web del Fornitore di Attestati Elettronici o altri canali messi a disposizione dal Fornitore di Attestati Elettronici.
+Quando l'Utente elimina un Attestato Elettronico dall'Istanza del Wallet, per impostazione predefinita l'Istanza del Wallet NON DEVE notificare questo evento al Fornitore di Attestati Elettronici. L'eliminazione dall'Istanza del Wallet rimuove solo la copia locale e non modifica lo stato di validità presso il Fornitore di Attestati Elettronici.
 
-L'Istanza del Wallet PUÒ informare l'Utente, prima dell'eliminazione, che l'eliminazione è un'azione locale e non implica la revoca presso il Fornitore di Attestati Elettronici.
+L'Istanza del Wallet PUÒ informare l'Utente, prima dell'eliminazione, che l'eliminazione è un'azione locale e non implica la revoca presso il Fornitore di Attestati Elettronici, e PUÒ implementare, con il consenso esplicito dell’Utente al momento dell’eliminazione, una funzionalità di notifica per informare il Fornitore di Attestati Elettronici dell’intenzione dell’Utente di revocare l’Attestato Elettronico.
+
+Se l'Utente desidera che il Fornitore di Attestati Elettronici revochi un Attestato Elettronico, DOVREBBE confermare esplicitamente tale intenzione tramite il prompt di eliminazione dell’Istanza del Wallet (quando disponibile), che a sua volta DOVRÀ notificare il Fornitore di Attestati Elettronici; in alternativa, l'Utente PUÒ utilizzare il portale web del Fornitore di Attestati Elettronici o altri canali messi a disposizione.
 
 Gestione del ciclo di vita delle Credenziali in batch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Quando più Attestati Elettronici vengono emessi insieme in un singolo batch, il loro ciclo di vita rimane completamente granulare:
 
-* **Trigger raggruppati, aggiornamenti indipendenti**: una singola richiesta di aggiornamento dello stato del batch che fa riferimento al ``notification_id`` del batch e inviata da un'entità autorizzata (ad esempio, un Wallet Provider tramite PDND) viene gestita come N modifiche di stato separate. Il Credential Issuer aggiorna lo stato di ciascun Attestato Elettronico singolarmente (ad esempio, impostando il bit della status-list su ``INVALID`` o ``SUSPENDED``). Un'Istanza del Wallet NON DEVE attivare aggiornamenti di stato del batch quando l'Utente elimina Attestati Elettronici localmente.
+* **Trigger raggruppati, aggiornamenti indipendenti**: una singola richiesta di aggiornamento dello stato del batch che fa riferimento al ``notification_id`` del batch e inviata da un'entità autorizzata (ad esempio, un Wallet Provider tramite PDND) viene gestita come N modifiche di stato separate. Il Fornitore di Attestati Elettronici aggiorna lo stato di ciascun Attestato Elettronico singolarmente (ad esempio, impostando il bit della status-list su ``INVALID`` o ``SUSPENDED``). Per impostazione predefinita, un'Istanza del Wallet NON DEVE attivare aggiornamenti di stato del batch quando l'Utente elimina Attestati Elettronici localmente. In fase di eliminazione, l’Istanza del Wallet PUÒ, con il consenso esplicito dell’Utente, notificare al Fornitore di Attestati Elettronici l’intenzione dell’Utente di revocare gli Attestati Elettronici interessati; tale notifica non costituisce una richiesta di aggiornamento di stato a livello di batch.
 * **Revoca a livello di batch**: la stessa richiesta di aggiornamento del batch funge anche da richiesta di revoca totale. Il Credential Issuer contrassegna ogni Attestato Elettronico nel batch come revocato e PUÒ emettere una singola notifica per l'intero batch secondo la propria policy.
 
 .. note::
-  Poiché l'interfaccia utente del Wallet in genere visualizza un batch come un singolo Attestato Elettronico (ad esempio, con 3 utilizzi rimanenti), un'eliminazione da parte dell'utente rimuove l'intero batch localmente. Non richiede la revoca presso il Fornitore di Attestati Elettronici.
+  Poiché l'interfaccia utente del Wallet in genere visualizza un batch come un singolo Attestato Elettronico (ad esempio, con 3 utilizzi rimanenti), un'eliminazione da parte dell'utente rimuove l'intero batch localmente. Per impostazione predefinita non richiede la revoca presso il Fornitore di Attestati Elettronici. L’Istanza del Wallet PUÒ offrire all’Utente un prompt opzionale per richiedere la revoca presso il Fornitore di Attestati Elettronici nell’ambito del flusso di eliminazione.
 
 
 Meccanismi di Verifica della Validità

--- a/docs/it/credential-revocation.rst
+++ b/docs/it/credential-revocation.rst
@@ -215,6 +215,15 @@ Gli Utenti POSSONO modificare lo stato di validità del loro Attestato Elettroni
       - Verificare l'autenticità dei dati.
       - Visualizzare e aggiornare lo stato di validità (revocare i loro Attestati Elettronici e, se supportato dal Fornitore di Attestati Elettronici, sospenderle).
 
+.. note::
+  Se l'Utente attiva un'altra Istanza del Wallet dello stesso Fornitore di Wallet e utilizzando la stessa Soluzione di Wallet e ottiene un nuovo PID, il PID precedente DEVE essere revocato e la precedente Istanza del Wallet DEVE passare allo stato operativo.
+
+In caso di morte dell'Utente, i Fornitori di Attestati Elettronici e il Fornitore di Wallet DEVONO garantire che gli Attestati Elettronici e le Istanze del Wallet di proprietà dell'Utente siano revocati.
+La morte dell'Utente comporta una modifica dello stato di validità degli attributi identificativi dell'Utente contenuti nel registro pubblico (ANPR). La morte dell'Utente DEVE produrre la revoca del PID. Pertanto, la Fonte Autentica del PID (ANPR) DEVE notificare al PID Provider che gli attributi dell'Utente non sono più validi a causa della morte dell'Utente. La Fonte Autentica e il PID Provider DEVONO utilizzare i meccanismi previsti nella Sezione :ref:`credential-revocation:Status Update by Authentic Sources`.
+
+.. note::
+  Le versioni future della presente specifica tecnica definiranno come le informazioni verso i Fornitori di (Q)EAA e i Fornitori di Wallet vengono propagate, in accordo alla normativa nazionale. Inoltre, saranno definite procedure automatizzate per la revoca degli Attestati dovuta ad attività illecite.
+
 Aggiornamento dello Stato da parte dell'Istanza del Wallet
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
@@ -226,6 +235,12 @@ Se l'Utente desidera che il Fornitore di Attestati Elettronici revochi un Attest
 
 Quando l'Attestato Elettronico revocato è il PID, il Fornitore di Attestati Elettronici DEVE inviare una notifica di questo evento all'Utente entro 24 ore.
 Per qualsiasi altro Attestato Elettronico diverso dal PID, il Fornitore di Attestati Elettronici DOVREBBE inviare una notifica di questo evento all'Utente. La notifica all'Utente PUÒ essere implementata in diversi modi, ad esempio utilizzando l'indirizzo email dell'Utente, il numero di telefono o qualsiasi altro canale di comunicazione verificato e sicuro. La notifica all'Utente DEVE includere anche tutte le informazioni sullo stato di revoca dell'Attestato Elettronico. Il metodo utilizzato per la notifica all'Utente è fuori dallo scopo del presente profilo tecnico di implementazione. Quando la revoca avviene, il Fornitore di Attestati Elettronici DEVE aggiornare di conseguenza lo stato dell'Attestato Elettronico. Quando la Notification Response inviata dal Fornitore di Attestati Elettronici viene ricevuta con successo dall'Istanza del Wallet, l'Istanza del Wallet DEVE eliminare l'Attestato Elettronico.
+
+Aggiornamento dello Stato da parte dei Fornitori di Wallet
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+In aggiunta a quanto definito in :ref:`credential-revocation:Ciclo di Vita degli Attestati Elettronici`, il Fornitore di Attestati Elettronici DEVE mettere a disposizione un servizio web (endpoint di Revoca dell'Istanza del Wallet) definito utilizzando PDND, come specificato nella Sezione :ref:`credential-issuer-endpoint:e-Service PDND Credential Issuer Catalog`.
+Il Fornitore di Wallet che per qualsiasi motivo revoca un'Istanza del Wallet DEVE inviare una notifica ai Fornitori di Attestati Elettronici utilizzando questo endpoint.
 
 Gestione del ciclo di vita delle Credenziali in batch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/it/credential-revocation.rst
+++ b/docs/it/credential-revocation.rst
@@ -242,6 +242,44 @@ Aggiornamento dello Stato da parte dei Fornitori di Wallet
 In aggiunta a quanto definito in :ref:`credential-revocation:Ciclo di Vita degli Attestati Elettronici`, il Fornitore di Attestati Elettronici DEVE mettere a disposizione un servizio web (endpoint di Revoca dell'Istanza del Wallet) definito utilizzando PDND, come specificato nella Sezione :ref:`credential-issuer-endpoint:e-Service PDND Credential Issuer Catalog`.
 Il Fornitore di Wallet che per qualsiasi motivo revoca un'Istanza del Wallet DEVE inviare una notifica ai Fornitori di Attestati Elettronici utilizzando questo endpoint.
 
+Aggiornamento dello Stato da parte delle Fonti Autentiche
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Le Fonti Autentiche gestiscono gli attributi separatamente dagli Attestati Elettronici, i quali verificano l’autenticità in modo analogo ai documenti fisici. La perdita di un documento fisico non implica la perdita dei diritti che rappresenta; significa solo che l’Utente non può dimostrarli. Tuttavia, se un Utente perde determinati diritti a causa di una grave infrazione, la Fonte Autentica revocherà gli attributi correlati. In tali casi, quando gli attributi di un Utente vengono aggiornati, le Fonti Autentiche DEVONO notificare ai Fornitori di Attestati Elettronici di aggiornare lo stato di validità di qualsiasi Attestato Elettronico che contenga tali attributi.
+
+Le Fonti Autentiche che utilizzano il Signal Hub DEVONO depositare un Signal tramite il :ref:`signal-hub-endpoint:Signal Collection e-Service` nei seguenti casi:
+
+  - Il valore di uno o più Attributi contenuti nel database della Fonte Autentica è cambiato;
+  - Lo stato di validità degli Attributi è aggiornato (revoca o sospensione).
+
+In entrambi i casi, il Signal DEVE avere ``signalType`` impostato a ``UPDATE``.
+
+I Fornitori di Attestati Elettronici DEVONO controllare periodicamente il PDND Signal Hub :ref:`signal-hub-endpoint:Signal Distribution e-Service` per nuovi Signal. Per il flusso di processamento dei Signal, fare riferimento alla Sezione :ref:`signal-hub-endpoint:Signals Processing`. Il Fornitore di Attestati Elettronici è in grado di identificare la natura del ``UPDATE`` Signal interrogando la API `get attribute` della Fonte Autentica e ispezionando il payload della risposta, come descritto nella Sezione :ref:`authentic-source-endpoint:Get Attribute Claims`.
+
+La seguente figura illustra ad alto livello il processo di aggiornamento dello stato da parte delle Fonti Autentiche.
+
+.. only:: format_html
+
+  .. figure:: ./images/svg/status-update-as.svg
+    :alt: Processo di aggiornamento dello stato per le Fonti Autentiche
+    :width: 100%
+
+    Processo di aggiornamento dello stato delle Fonti Autentiche
+
+.. only:: format_latex
+
+  .. figure:: ./images/pdf/status-update-as.pdf
+    :alt: Processo di aggiornamento dello stato per le Fonti Autentiche
+    :width: 100%
+
+Il processo inizia con modifiche ai dati o alla validità dei dati che avvengono presso la Fonte Autentica. Le modifiche possono anche essere avviate da entità terze diverse dalla Fonte Autentica, ad esempio quando le autorità giudiziarie segnalano attività illecite.
+
+Una volta che i dati cambiano, la Fonte Autentica notifica i Fornitori di Attestati Elettronici che hanno ricevuto i dati originali utilizzando il Signal Hub. La Fonte Autentica deposita un Signal nel Signal Collection e-Service. :ref:`signal-hub-endpoint:Signal Collection e-Service`.
+
+Il Fornitore di Attestati Elettronici interroga periodicamente il Signal Hub :ref:`signal-hub-endpoint:Signal Distribution e-Service` per nuovi Signal. Quando viene trovato un nuovo Signal, il Fornitore di Attestati Elettronici lo recupera e lo processa come descritto in :ref:`signal-hub-endpoint:Signals Processing`. Quindi, il Fornitore di Attestati Elettronici aggiorna lo Stato dell’Attestato secondo la modalità definita dal meccanismo di validità. Il Fornitore di Attestati Elettronici PUÒ notificare l’Utente tramite un canale di comunicazione registrato e out-of-band.
+
+L’Istanza del Wallet, a seguito di controlli periodici dello stato di validità degli Attestati Elettronici memorizzati, riceve lo stato aggiornato. Quando lo Stato dell’Attestato viene modificato in INVALID, il Fornitore di Attestati Elettronici DEVE informare l’Utente di tale cambiamento. Nel caso in cui lo stato dell’Attestato venga modificato in UPDATE (risp. 0x03) o ATTRIBUTE_UPDATE (risp. 0x04), l’Istanza del Wallet DOVREBBE procedere alla riemissione dell’Attestato Elettronico, come descritto in :ref:`credential-issuance-low-level:Re-Issuance Flow`.
+
 Gestione del ciclo di vita delle Credenziali in batch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/it/credential-revocation.rst
+++ b/docs/it/credential-revocation.rst
@@ -205,7 +205,7 @@ Aggiornamento dello Stato relativo all'Utente
 
 Gli Utenti POSSONO modificare lo stato di validità del loro Attestato Elettronico:
 
-  1. Eliminando l'Attestato Elettronico dalla propria Istanza del Wallet: l'Istanza del Wallet DOVREBBE proporre all'Utente un prompt per indicare la motivazione dell'eliminazione, da notificare opzionalmente al Fornitore di Attestati Elettronici. Quando l'Utente utilizza questa funzionalità, la notifica da inviare al Fornitore di Attestati Elettronici DEVE utilizzare il Notification Endpoint messo a disposizione dal Fornitore di Attestati Elettronici, come descritto nella Sezione :ref:`credential-revocation:Status Update by Wallet Instance`.
+  1. Eliminando l'Attestato Elettronico dalla propria Istanza del Wallet: l'Istanza del Wallet DOVREBBE proporre all'Utente un prompt per notificare opzionalmente al Fornitore di Attestati Elettronici il desiderio da parte dell'Utente di richiedere la revoca della Credenziale. Quando l'Utente utilizza questa funzionalità, la notifica da inviare al Fornitore di Attestati Elettronici DEVE utilizzare il Notification Endpoint messo a disposizione dal Fornitore di Attestati Elettronici, come descritto nella Sezione :ref:`credential-revocation:Status Update by Wallet Instance`.
   2. Utilizzando il portale web del Fornitore di Attestati Elettronici:
 
     a. Gli Utenti POSSONO accedere ad un'area sicura con almeno lo stesso Livello di Garanzia utilizzato durante la fase di emissione.

--- a/docs/it/credential-revocation.rst
+++ b/docs/it/credential-revocation.rst
@@ -215,7 +215,7 @@ Gli Utenti POSSONO modificare lo stato di validità del loro Attestato Elettroni
       - Visualizzare e aggiornare lo stato di validità (revocare i loro Attestati Elettronici e, se supportato dal Fornitore di Attestati Elettronici, sospenderle).
 
 Aggiornamento dello Stato da parte dell'Istanza del Wallet
-""""""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Quando l'Utente elimina un Attestato Elettronico dall'Istanza del Wallet, l'Istanza del Wallet NON DEVE notificare questo evento al Fornitore di Attestati Elettronici. L'eliminazione dall'Istanza del Wallet rimuove solo la copia locale e non modifica lo stato di validità presso il Fornitore di Attestati Elettronici. Se l'Utente desidera che il Fornitore di Attestati Elettronici revochi un Attestato Elettronico, DEVE utilizzare il portale web del Fornitore di Attestati Elettronici o altri canali messi a disposizione dal Fornitore di Attestati Elettronici.
 


### PR DESCRIPTION
this PR resolves https://github.com/italia/eid-wallet-it-docs/issues/562 and further align it-wallet to EUDIW ARF HRLs, in particular PAD_03

| PAD_03 | If the Wallet Unit deletes a PID or attestation on the User's request, the Wallet Unit SHALL NOT notify the respective PID Provider or Attestation Provider. *Note: This is a matter of User privacy.* |

