### PR TITLE
Clarify JAR mandatory requirement and cross-border interoperability

### DIFF
--- a/docs/en/credential-issuance-low-level.rst
+++ b/docs/en/credential-issuance-low-level.rst
@@ -116,7 +116,8 @@ In case of Issuer Initiated flow, in addition to the Federation Check defined ab
   * MUST use the ``OAuth-Client-Attestation`` and ``OAuth-Client-Attestation-PoP`` parameters according to OAuth 2.0 Attestation-based Client Authentication [`OAUTH-ATTESTATION-CLIENT-AUTH`_], since in this flow the Pushed Authorization Endpoint is a protected endpoint  (:ref:`WP_052b <wallet-credential-issuance-testcases>`).
   * Specifies the types of the requested credentials using the ``authorization_details`` [RAR :rfc:`9396`] parameter and or ``scope`` parameter (:ref:`WP_052d <wallet-credential-issuance-testcases>`).
 
-.. note:: 
+.. note::
+
   JAR [:rfc:`9101`] is mandatory in this technical specification to ensure the end-to-end integrity of the authorization request and all parameters included in the Request Object.
   However, the Wallet Instance may interact with cross-border Credential Issuers whose Authorization Servers do not follow this specification and may not support JAR implementation. To handle this scenario, the Wallet Instance SHOULD check the `require_signed_request_object` parameter in the Authorization Server metadata and decide based on it whether to send the parameters in the signed Request Object or not. For interoperability, the Wallet Instance MAY duplicate the same paramters in the request body.
   Section 10.7 of :rfc:`9101` provides the security requirements on how to manage this duplication properly.

--- a/docs/en/credential-issuance-low-level.rst
+++ b/docs/en/credential-issuance-low-level.rst
@@ -116,6 +116,11 @@ In case of Issuer Initiated flow, in addition to the Federation Check defined ab
   * MUST use the ``OAuth-Client-Attestation`` and ``OAuth-Client-Attestation-PoP`` parameters according to OAuth 2.0 Attestation-based Client Authentication [`OAUTH-ATTESTATION-CLIENT-AUTH`_], since in this flow the Pushed Authorization Endpoint is a protected endpoint  (:ref:`WP_052b <wallet-credential-issuance-testcases>`).
   * Specifies the types of the requested credentials using the ``authorization_details`` [RAR :rfc:`9396`] parameter and or ``scope`` parameter (:ref:`WP_052d <wallet-credential-issuance-testcases>`).
 
+.. note:: 
+  JAR [:rfc:`9101`] is mandatory in this technical specification to ensure the end-to-end integrity of the authorization request and all parameters included in the Request Object.
+  However, the Wallet Instance may interact with cross-border Credential Issuers whose Authorization Servers do not follow this specification and may not support JAR implementation. To handle this scenario, the Wallet Instance SHOULD check the `require_signed_request_object` parameter in the Authorization Server metadata and decide based on it whether to send the parameters in the signed Request Object or not. For interoperability, the Wallet Instance MAY duplicate the same paramters in the request body.
+  Section 10.7 of :rfc:`9101` provides the security requirements on how to manage this duplication properly.
+
 .. note::
    For eID Substantial Authentication with MRTD Verification, the ``authorization_details`` object MUST contain the type ``"it_l2+document_proof"``. For complete protocol specifications, see :ref:`credential-issuance-l2plus:eID Substantial Authentication with MRTD Verification for PID Issuance`.
 

--- a/docs/en/credential-issuance-low-level.rst
+++ b/docs/en/credential-issuance-low-level.rst
@@ -116,10 +116,8 @@ In case of Issuer Initiated flow, in addition to the Federation Check defined ab
   * MUST use the ``OAuth-Client-Attestation`` and ``OAuth-Client-Attestation-PoP`` parameters according to OAuth 2.0 Attestation-based Client Authentication [`OAUTH-ATTESTATION-CLIENT-AUTH`_], since in this flow the Pushed Authorization Endpoint is a protected endpoint  (:ref:`WP_052b <wallet-credential-issuance-testcases>`).
   * Specifies the types of the requested credentials using the ``authorization_details`` [RAR :rfc:`9396`] parameter and or ``scope`` parameter (:ref:`WP_052d <wallet-credential-issuance-testcases>`).
 
-.. note:: 
-  JAR [:rfc:`9101`] is mandatory in this technical specification to ensure the end-to-end integrity of the authorization request and all parameters included in the Request Object.
-  However, the Wallet Instance may interact with cross-border Credential Issuers whose Authorization Servers do not follow this specification and may not support JAR implementation. To handle this scenario, the Wallet Instance SHOULD check the `require_signed_request_object` parameter in the Authorization Server metadata and decide based on it whether to send the parameters in the signed Request Object or not. For interoperability, the Wallet Instance MAY duplicate the same paramters in the request body.
-  Section 10.7 of :rfc:`9101` provides the security requirements on how to manage this duplication properly.
+.. note::
+This specification uses JAR [:rfc:9101] to ensure end-to-end integrity of authorization requests for all Request Object parameters. When interacting with cross-border Credential Issuers whose Authorization Servers may not support JAR, Wallet Instances SHOULD check the ``require_signed_request_object`` parameter in the Authorization Server metadata to determine whether to sign the Request Object. Wallet Solutions supporting both JAR-compliant and non-compliant Authorization Servers may duplicate parameters in both the request body and the signed Request Object. Section 10.7 of :rfc:`9101` provides the security requirements on how to manage this duplication properly.
 
 .. note::
    For eID Substantial Authentication with MRTD Verification, the ``authorization_details`` object MUST contain the type ``"it_l2+document_proof"``. For complete protocol specifications, see :ref:`credential-issuance-l2plus:eID Substantial Authentication with MRTD Verification for PID Issuance`.

--- a/docs/en/credential-issuer-metadata.rst
+++ b/docs/en/credential-issuer-metadata.rst
@@ -47,6 +47,8 @@ The *oauth_authorization_server* metadata MUST contain the following parameters.
     - JSON array containing a list of supported client authentication methods. The Token Endpoint MUST support *attest_jwt_client_auth* as defined in `OAUTH-ATTESTATION-CLIENT-AUTH`_.
   * - **token_endpoint_auth_signing_alg_values_supported**
     - JSON array containing a list of the signing algorithms ("*alg*" values) supported by the token endpoint for the signature on the JWT used to authenticate the client at the Token Endpoint. See :rfc:`8414#section-2`.
+  * - **require_signed_request_object**
+    - Boolean value. It MUST be set to `true` to indicate that the authorization request is protected using a signed Request Object [:rfc:`9101`].
   * - **request_object_signing_alg_values_supported**
     - JSON array containing a list of the signing algorithms ("*alg*" values) supported for Request Objects. See `[openid-connect-discovery-1_0] <https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata>`_.
   * - **dpop_signing_alg_values_supported**

--- a/docs/it/credential-issuance-low-level.rst
+++ b/docs/it/credential-issuance-low-level.rst
@@ -100,6 +100,11 @@ Nel caso del flusso avviato dall'Issuer, oltre al controllo della federazione de
   * Specifica i tipi di Credenziali richieste utilizzando il parametro ``authorization_details`` [RAR :rfc:`9396`] e/o il parametro ``scope`` (:ref:`WP_052d <wallet-credential-issuance-testcases>`).
 
 .. note::
+  JAR [:rfc:`9101`] è obbligatorio in questa specifica tecnica per garantire l'integrità end-to-end della richiesta di autorizzazione e di tutti i parametri inclusi nel Request Object.
+  Tuttavia, la Wallet Instance può interagire con Credential Issuer cross-border i cui Authorization Server non seguono questa specifica e potrebbero non supportare l'implementazione di JAR. Per gestire questo scenario, la Wallet Instance DOVREBBE verificare il parametro `require_signed_request_object` nei metadata dell'Authorization Server e decidere in base ad esso se inviare i parametri nel signed Request Object o meno. Per interoperabilità, la Wallet Instance PUÒ duplicare gli stessi parametri nel corpo della richiesta.
+  La Sezione 10.7 di :rfc:`9101` fornisce i requisiti di sicurezza su come gestire correttamente questa duplicazione.
+
+.. note::
    Per l'Autenticazione eID Substantial con Verifica MRTD, l'oggetto ``authorization_details`` DEVE contenere il valore ``"it_l2+document_proof"``. Per le specifiche complete del protocollo, vedere :ref:`credential-issuance-l2plus:Autenticazione eID Substantial con Verifica MRTD per Emissione PID`.
 
 Il Credential Issuer esegue i seguenti controlli alla ricezione della `PAR Request`:

--- a/docs/it/credential-issuer-metadata.rst
+++ b/docs/it/credential-issuer-metadata.rst
@@ -47,6 +47,8 @@ I Metadata *oauth_authorization_server* DEVONO contenere i seguenti parametri.
     - Array JSON contenente un elenco dei metodi di *client authentication* supportati. Il *token endpoint* DEVE supportare *attest_jwt_client_auth* come definito in `OAUTH-ATTESTATION-CLIENT-AUTH`_.
   * - **token_endpoint_auth_signing_alg_values_supported**
     - Array JSON contenente un elenco degli algoritmi di firma ("valori *alg*") supportati dal *token endpoint* per la firma sul JWT utilizzato per autenticare il client al *token endpoint*. Vedi :rfc:`8414#section-2`.
+  * - **require_signed_request_object**
+    - Booleano. DEVE essere impostato a `true` per indicare che la richiesta di autorizzazione è protetta usando un Request Object firmato [:rfc:`9101`].
   * - **request_object_signing_alg_values_supported**
     - Array JSON contenente un elenco degli algoritmi di firma ("valori *alg*") supportati per i *Request Objects*. Vedi `[openid-connect-discovery-1_0] <https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata>`_.
   * - **dpop_signing_alg_values_supported**


### PR DESCRIPTION
This PR closes #803

- A clarification note is added in step 1-2 (PAR) of Issuance Low-Level Flow according to [this comment](https://github.com/italia/eid-wallet-it-docs/issues/803#issuecomment-3480109931). It includes an implementation strategy to handle cross-border interoperability scenarios.
- A new parameter `require_signed_request_object` is added in the Authorization Server Metadata according to [Section 9.2 of RFC9101](https://www.rfc-editor.org/rfc/rfc9101.html#section-9.2).
