### PR TITLE
Credential Offer enhancements + Response mode cleanup

### DIFF
--- a/docs/en/credential-issuance-endpoint.rst
+++ b/docs/en/credential-issuance-endpoint.rst
@@ -1,43 +1,5 @@
 .. include:: ../common/common_definitions.rst
 
-Credential Offer Endpoint
-"""""""""""""""""""""""""
-
-The Credential Offer endpoint of a Wallet is used by Credential Issuer to interact with the User to initiate a Credential Issuance. The custom URL scheme ``openid-credential-offer://`` MUST be used.
-
-Credential Offer
-................
-
-The Credential Offer made by Credential Issuer consists of a single URI query parameter ``credential_offer``. The Credential Offer URL MAY be included in a QR Code or in an html page with an href button and MUST contain the following mandatory parameters:
-
-.. _table_credential_offer_claim:
-.. list-table::
-  :class: longtable
-  :widths: 20 60 20
-  :header-rows: 1
-
-  * - **Claim**
-    - **Description**
-    - **Reference**
-  * - **credential_issuer**
-    - It MUST be set with an HTTPS URL that uniquely identifies the Credential Issuer. The Wallet uses this parameter value to obtain the Credential Issuer's metadata.
-    - Section 4.1.1 of [`OpenID4VCI`_].
-  * - **credential_configuration_ids**
-    - Array of Strings, each of them specifying a unique identifier of the Credential being described in the ``credential_configurations_supported`` map in the Credential Issuer Metadata (:ref:`WP_050b <wallet-credential-issuance-testcases>`).
-    - Section 4.1.1 of [`OpenID4VCI`_].
-  * - **grants**
-    - It MUST contain ``authorization_code`` object with the following parameters:
-
-        - **issuer_state**: REQUIRED. Opaque string created by the Credential Issuer used to bind the subsequent Authorization Request with the Credential Issuer. The Wallet MUST include it in the subsequent Authorization Request.
-        - **authorization_server**: REQUIRED when the Credential Issuer uses more than one authorization server in its Issuer Solution. String identifying the Authorization Server to use. The value MUST match with one of the values mapped in the ``authorization_servers`` array of the Credential Issuer metadata. It MUST NOT be used if ``authorization_servers`` is absent or it has no multiple entries.
-    - Section 4.1.1 of [`OpenID4VCI`_].
-
-
-Credential Offer Response
-.........................
-No response is expected from the Wallet.
-
-
 Pushed Authorization Request Endpoint
 """""""""""""""""""""""""""""""""""""
 

--- a/docs/en/credential-issuance-endpoint.rst
+++ b/docs/en/credential-issuance-endpoint.rst
@@ -91,9 +91,6 @@ The ``request`` JWT payload contained in the HTTP POST message is given with the
     * - **response_type**
       - MUST be set to ``code``.
       - :rfc:`6749`
-    * - **response_mode**
-      - It MUST be a string indicating the "*response_mode*", as specified in [`OAUTH-MULT-RESP-TYPE`_]. The supported value MUST be *query* and it MUST be also the supported value (*response_modes_supported*) provided in the metadata of the Credential Issuer. It informs the Credential Issuer of the mechanism to be used for returning parameters from the Authorization Endpoint. The Authorization Response parameters are encoded in the query string added to the ``redirect_uri`` when redirecting back to the Wallet Instance.
-      - See [`OAUTH-MULT-RESP-TYPE`_].
     * - **client_id**
       - It MUST be set as in the :ref:`Table of the HTTP parameters <table_http_request_claim>`.
       - See :ref:`Table of the HTTP parameters <table_http_request_claim>`.

--- a/docs/en/credential-issuance-low-level.rst
+++ b/docs/en/credential-issuance-low-level.rst
@@ -678,7 +678,7 @@ The Credential Offer object is a JSON object containing the parameters defined i
     - REQUIRED. It MUST contain ``authorization_code`` object with the following parameters:
 
         - **issuer_state**: OPTIONAL. Opaque string created by the Credential Issuer used to bind the subsequent Authorization Request with the Credential Issuer. The Wallet MUST include it in the subsequent Authorization Request when present.
-        - **authorization_server**: REQUIRED when the Credential Issuer uses more than one authorization server in its Issuer Solution. String identifying the Authorization Server to use. The value MUST match with one of the values mapped in the ``authorization_servers`` array of the Credential Issuer metadata. It MUST NOT be used if ``authorization_servers`` is absent or it has no multiple entries.
+        - **authorization_server**: REQUIRED when the Credential Issuer uses more than one authorization server in its Issuer Solution. This string identifies the Authorization Server to use. The value MUST match with one of the values mapped in the ``authorization_servers`` array of the Credential Issuer metadata. It MUST NOT be used if ``authorization_servers`` is absent or it has no multiple entries.
         - **scope**: REQUIRED. String value that maps to a specific Credential type. The Wallet MUST use this scope value in the Authorization Request. See Section 4.1 of [`OPENID4VC-HAIP`_] for details.
     - Section 4.1.1 of [`OpenID4VCI`_] and Section 4.1 of [`OPENID4VC-HAIP`_].
 

--- a/docs/en/credential-issuance-low-level.rst
+++ b/docs/en/credential-issuance-low-level.rst
@@ -19,12 +19,12 @@ The Credential Issuance flow is based on [`OpenID4VCI`_] and the following main 
 The Credential Issuer MUST use *OAuth 2.0 Authorization Server* based on :rfc:`6749` to authorize the User to obtain a Credential. Credential Issuers MUST support:
 
   * **Authorization Code Flow**: The Credential Issuer requires User authentication and consent at the Authorization Endpoint before collecting User information to create and provide a Credential.
-  * **Wallet Initiated Flow**: The request from the Wallet Instance is sent to the Credential Issuer without any input from the Credential Issuer.
+  * **Wallet Initiated Flow**: The request from the Wallet Instance is sent to the Credential Issuer without any input from the Credential Issuer or a Third Party (i.e. via Credential Offer support).
   * **Immediate Issuance Flow**: The Credential Issuer issues the Credential directly in response to the Credential Request.
 
 In addition, the Credential Issuers MAY support:
 
-  * **Issuer Initiated Flow**: The Wallet Instance sends its request to the Credential Issuer based on the input provided by the Credential Issuer.
+  * **Third-Party Initiated Flow**: The Wallet Instance sends its request to the Credential Issuer based on the input provided by the Credential Issuer or a Third Party (for example an Authentic Source) supporting Credential Offer mechanism as defined in [`OpenID4VCI`_].
 
     * **Same-device Issuance Flow**: The User receives the Credential on the same device used to initiate the flow.
     * **Cross-device Issuance Flow**: The User receives the Credential on another device than the one that initiated the flow.

--- a/docs/en/credential-issuance-low-level.rst
+++ b/docs/en/credential-issuance-low-level.rst
@@ -56,7 +56,7 @@ The following diagram shows the *User request flow*.
 .. plantuml:: plantuml/credential-user-request-flow.puml
     :width: 99%
     :alt: The figure illustrates the Credential Request Flow by the User.
-    :caption: `Credential Request by the User - Detailed flow. <https://www.plantuml.com/plantuml/svg/hP9FJzj04CNlyob6uT3sG14zve20XAgHAWKA5PTUrkknFMAzQ-sV6BvzPpTkapHLAoGkLkJClFTxptCPel8nzGPKYiwclYAFvn_F0GPvpve7PIFElWVoCrG14q3bdhSltWKClKmDdRCqmvElt7RnsYGwtBtsRlorNld3_nwLCHHnPGN3QYep8v2jKLmEhUWvahVAO4qRrjblxPLj_sb6Ewc3gOMdccnaKLk5aAPv1b0c8ZVu6ujb9bADduqR0HAUNk0un_L05cD7-0S-gc7uOOtJefk40gNJBlje5TbPK3hoHlGaufYbqXnT5HLRV779uv9RZhAweykEMyiN2W3UEbbs6r4UyUJno-hX1jP5eD0O3X5TKtu_-1Go-57Ia2ifGW3ZwOKWQ6SRzdrP2sH8PrRHETu5I88ZDEu9eAQzE40ca3Gt3HurjtTSd_9nbIPvQl9sjJnxV_VXxERg2c-zst2T0r8LM23vDKNnLDJq6HVUXO3BSYyJI96hFCsnYxt1GRM2px73ksyBLrCk8_kmRVVZhvj6qilQ17FVkJ7tDMqLcOpmjkSnYf5MLammkm3iQhvNFVqrs56kpbFpdrHJA6rOFnNkibEb60KAtZHNFhxjur8UgJS_0G00>`_
+    :caption: `Credential Request by the User - Detailed flow. <https://www.plantuml.com/plantuml/svg/hLDDJzj04BtlhnZ1WI814ZroG1HerKYLqf9KNBYirsDxn7hNtPsDoR_lUECq3a7za7gn8dlUntipkOci0wVMmbt04XsJjl20Fn96Xa_Mzr2iWHk4xn63qeczIss10IulBfNg14k6EkqOZeQ98z0HabA5VzcyE8aGMvdg6k_m28w_KDtmhKsuZxqDlj_2Yx3_xL5RYmmp9rQTmJpJAtGbYCg-5Bum1YS9IboH6VJcGRlwjsAuezgRMZOKIlWghzR2t6CHYJVYf9Is35J1BsialJ6MkJ6b4fnVGty5ymvTBkzL1D1Tz-IiD-8qYHFGIQQSQ6icxvGsJ2lXavZzG9Mkm1UioS7Qfm3tL1FhwSO6nOta6gDImNa1-vKmzt3y-7cs_AZccI2xiHGPV9L_BqEAOdow_LcC2KCSQib4IlNdrsB1U5THQ3CieaKpU1MUGwmq87R4ZNzMgiH978KseZGt3XuqDpcmznUNOvCqDZdPo7OVJ-xTWVePVDZM2Glfo-2PN7GjeSFw393DnQcYVwcLnbh7fTy57oFSvmiRRMUw8k0LDDnQw7GjOOaR-FPmvqiSgXjqoDNJikPLXK49R3IpQ7oVsnrH0yrkimkZdNo1_4bofpZG6TrYqE33MpTs-fT7TW8z78gysjnkTmlHV3F_GVmcOFM7y6DsOyayv_0PKoHcyPWFuB_zbuQBtZnkv95Q-nC0>`_
 
 
 **Steps 1.1-1.4 (Wallet Initiated Flow):** The User, using the Wallet Instance, selects the Credential Issuer from those listed in the list of trustworthy entities.
@@ -67,11 +67,7 @@ The following diagram shows the *User request flow*.
 
 **Steps 2.7-2.10 (Same-Device):** The Credential Offer is presented as an href button containing the URL that allows the User to invoke the Wallet Instance using the Credential Offer Endpoint.
 
-Below a non-normative example of a URL related to a Credential Offer that can be included in a QR Code or in HTML page with an href button:
-
-.. code-block:: text
-
-  openid-credential-offer://?credential_offer%3D%7B%22credential_issuer%22%3A%22https%3A%2F%2Feaa-provider.example.org%22%2C%22credential_configuration_ids%22%3A%5B%22dc_sd_jwt_Education_degree%22%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%22issuer_state%22%3A%22oaKazRN8I0IbtZ0C7JuMn5%22%7D%7D%7D
+The Credential Offer can be sent by value (using the ``credential_offer`` parameter) or by reference (using the ``credential_offer_uri`` parameter) as defined in Section 4 of [`OpenID4VCI`_]. Additional details and non-normative examples are provided in Section :ref:`credential-issuance-low-level:Credential Offer Flow`.
 
 
 The following diagram shows the *Issuance flow*.
@@ -642,4 +638,148 @@ To ensure the integrity and security of the re-issuance process, the following s
   - Credential expiry: The Credential Issuer MUST set the same expiry date for the re-issued Digital Credential as the previous one. This prevents indefinite Credential renewals without proper User authentication.
   - User consent: For re-issuance processes triggered by attribute changes, User consent MUST be obtained before storing the new Digital Credential. This ensures that the User is aware of and agrees to the updated information.
   - Sender-constrained Refresh Token: Refresh Tokens MUST be cryptographically bound to the Wallet Instance using DPoP protocol. This mitigates the risk of token misuse by ensuring that only the intended Wallet Instance (the same that originally has obtained the Digital Credential) can use that Refresh Token.
+
+
+Credential Offer Flow
+-----------------------
+
+A Credential Issuer or Third Party (e.g., Authentic Source, Registry, Catalogue) initiates Credential Issuance by sending a Credential Offer to the Wallet Instance.
+
+The Wallet Instance invocation mechanism depends on the availability of the ``credential_offer_endpoint`` parameter in the Wallet metadata:
+
+- If ``credential_offer_endpoint`` is available and contains an HTTPS URL (Universal Link), the Credential Issuer or Third Party SHOULD use that endpoint.
+- Otherwise, the Credential Issuer or Third Party MUST use one of the custom URL schemes: ``openid-credential-offer://`` (as defined in Section 4 of [`OpenID4VCI`_]) or ``haip://`` (as defined in Section 5.1.1 of [`OPENID4VC-HAIP`_]).
+
+The Wallet Instance MUST support both custom URL schemes.
+
+The Credential Offer can be transmitted by value or by reference:
+
+- **By value** (``credential_offer`` parameter): the Credential Offer object is directly embedded in the URI as a JSON-encoded string.
+- **By reference** (``credential_offer_uri`` parameter): the URI points to a resource hosted by the Credential Issuer or Third Party. The Wallet Instance retrieves the Credential Offer object by sending an HTTP GET request to that URI.
+
+The Credential Offer object is a JSON object containing the parameters defined in Section 4.1.1 of [`OpenID4VCI`_]. The table below specifies the parameters with IT-Wallet specific requirements:
+
+.. _table_credential_offer_claim:
+.. list-table::
+  :class: longtable
+  :widths: 20 60 20
+  :header-rows: 1
+
+  * - **Claim**
+    - **Description**
+    - **Reference**
+  * - **credential_issuer**
+    - It MUST be set with an HTTPS URL that uniquely identifies the Credential Issuer. The Wallet uses this parameter value to obtain the Credential Issuer's metadata.
+    - Section 4.1.1 of [`OpenID4VCI`_].
+  * - **credential_configuration_ids**
+    - Array of Strings, each of them specifying a unique identifier of the Credential being described in the ``credential_configurations_supported`` map in the Credential Issuer Metadata (:ref:`WP_050b <wallet-credential-issuance-testcases>`).
+    - Section 4.1.1 of [`OpenID4VCI`_].
+  * - **grants**
+    - REQUIRED. It MUST contain ``authorization_code`` object with the following parameters:
+
+        - **issuer_state**: OPTIONAL. Opaque string created by the Credential Issuer used to bind the subsequent Authorization Request with the Credential Issuer. The Wallet MUST include it in the subsequent Authorization Request when present.
+        - **authorization_server**: REQUIRED when the Credential Issuer uses more than one authorization server in its Issuer Solution. String identifying the Authorization Server to use. The value MUST match with one of the values mapped in the ``authorization_servers`` array of the Credential Issuer metadata. It MUST NOT be used if ``authorization_servers`` is absent or it has no multiple entries.
+        - **scope**: REQUIRED. String value that maps to a specific Credential type. The Wallet MUST use this scope value in the Authorization Request. See Section 4.1 of [`OPENID4VC-HAIP`_] for details.
+    - Section 4.1.1 of [`OpenID4VCI`_] and Section 4.1 of [`OPENID4VC-HAIP`_].
+
+.. note::
+  When using ``credential_offer_uri`` (by reference), the Credential Issuer or Third Party SHOULD use a unique URI for each Credential Offer or otherwise prevent caching of the URI, as recommended in Section 4.1.3 of [`OpenID4VCI`_].
+
+
+Non-normative Examples
+^^^^^^^^^^^^^^^^^^^^^^^
+
+**Example 1: Credential Offer by value**
+
+The Credential Offer can be transmitted by value using any supported invocation method (custom URL scheme or Universal Link):
+
+.. code-block:: text
+
+  openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A//credential-issuer.example.org%22%2C%22credential_configuration_ids%22%3A%5B%22dc_sd_jwt_Education_degree%22%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%22scope%22%3A%22Education_degree%22%7D%7D%7D
+
+The decoded Credential Offer object:
+
+.. code-block:: json
+
+  {
+    "credential_issuer": "https://credential-issuer.example.org",
+    "credential_configuration_ids": ["dc_sd_jwt_Education_degree"],
+    "grants": {
+      "authorization_code": {
+        "scope": "Education_degree"
+      }
+    }
+  }
+
+**Example 2: Credential Offer by reference from Credential Issuer**
+
+The QR Code contains:
+
+.. code-block:: text
+
+  openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fcredential-issuer.example.org%2Foffers%2F8f3a2b1c
+
+The Wallet Instance sends an HTTP GET request:
+
+.. code-block:: http
+
+  GET /offers/8f3a2b1c HTTP/1.1
+  Host: credential-issuer.example.org
+  Accept: application/json
+
+The Credential Issuer responds:
+
+.. code-block:: http
+
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+  Cache-Control: no-store
+
+  {
+    "credential_issuer": "https://credential-issuer.example.org",
+    "credential_configuration_ids": ["dc_sd_jwt_EuropeanDisabilityCard"],
+    "grants": {
+      "authorization_code": {
+        "issuer_state": "eyJhbGciOiJSU0Et...F77QK8",
+        "scope": "EuropeanDisabilityCard"
+      }
+    }
+  }
+
+**Example 3: Credential Offer by reference from Third Party**
+
+A Third Party, such as an Authentic Source, generates a Credential Offer for a Credential Issuer.
+
+The QR Code contains:
+
+.. code-block:: text
+
+  openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fauthentic-source.gov.example%2Fcredential-offers%2Fabc123
+
+The Wallet Instance sends:
+
+.. code-block:: http
+
+  GET /credential-offers/abc123 HTTP/1.1
+  Host: authentic-source.gov.example
+  Accept: application/json
+
+The Authentic Source responds:
+
+.. code-block:: http
+
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+  Cache-Control: no-store
+
+  {
+    "credential_issuer": "https://credential-issuer.example.org",
+    "credential_configuration_ids": ["mso_mdoc_mDL"],
+    "grants": {
+      "authorization_code": {
+        "scope": "mDL"
+      }
+    }
+  }
+
 

--- a/docs/en/credential-issuance-low-level.rst
+++ b/docs/en/credential-issuance-low-level.rst
@@ -58,19 +58,14 @@ The following diagram shows the *User request flow*.
     :alt: The figure illustrates the Credential Request Flow by the User.
     :caption: `Credential Request by the User - Detailed flow. <https://www.plantuml.com/plantuml/svg/hP9FJzj04CNlyob6uT3sG14zve20XAgHAWKA5PTUrkknFMAzQ-sV6BvzPpTkapHLAoGkLkJClFTxptCPel8nzGPKYiwclYAFvn_F0GPvpve7PIFElWVoCrG14q3bdhSltWKClKmDdRCqmvElt7RnsYGwtBtsRlorNld3_nwLCHHnPGN3QYep8v2jKLmEhUWvahVAO4qRrjblxPLj_sb6Ewc3gOMdccnaKLk5aAPv1b0c8ZVu6ujb9bADduqR0HAUNk0un_L05cD7-0S-gc7uOOtJefk40gNJBlje5TbPK3hoHlGaufYbqXnT5HLRV779uv9RZhAweykEMyiN2W3UEbbs6r4UyUJno-hX1jP5eD0O3X5TKtu_-1Go-57Ia2ifGW3ZwOKWQ6SRzdrP2sH8PrRHETu5I88ZDEu9eAQzE40ca3Gt3HurjtTSd_9nbIPvQl9sjJnxV_VXxERg2c-zst2T0r8LM23vDKNnLDJq6HVUXO3BSYyJI96hFCsnYxt1GRM2px73ksyBLrCk8_kmRVVZhvj6qilQ17FVkJ7tDMqLcOpmjkSnYf5MLammkm3iQhvNFVqrs56kpbFpdrHJA6rOFnNkibEb60KAtZHNFhxjur8UgJS_0G00>`_
 
-.. .. figure:: ../../images/Low-Level-Flow-ITWallet-PID-QEAA-User-Request.svg
-..     :figwidth: 100%
-..     :align: center
-..     :target: https://www.plantuml.com/plantuml/svg/hP9FJzj04CNlyob6uT3sG14zve20XAgHAWKA5PTUrkknFMAzQ-sV6BvzPpTkapHLAoGkLkJClFTxptCPel8nzGPKYiwclYAFvn_F0GPvpve7PIFElWVoCrG14q3bdhSltWKClKmDdRCqmvElt7RnsYGwtBtsRlorNld3_nwLCHHnPGN3QYep8v2jKLmEhUWvahVAO4qRrjblxPLj_sb6Ewc3gOMdccnaKLk5aAPv1b0c8ZVu6ujb9bADduqR0HAUNk0un_L05cD7-0S-gc7uOOtJefk40gNJBlje5TbPK3hoHlGaufYbqXnT5HLRV779uv9RZhAweykEMyiN2W3UEbbs6r4UyUJno-hX1jP5eD0O3X5TKtu_-1Go-57Ia2ifGW3ZwOKWQ6SRzdrP2sH8PrRHETu5I88ZDEu9eAQzE40ca3Gt3HurjtTSd_9nbIPvQl9sjJnxV_VXxERg2c-zst2T0r8LM23vDKNnLDJq6HVUXO3BSYyJI96hFCsnYxt1GRM2px73ksyBLrCk8_kmRVVZhvj6qilQ17FVkJ7tDMqLcOpmjkSnYf5MLammkm3iQhvNFVqrs56kpbFpdrHJA6rOFnNkibEb60KAtZHNFhxjur8UgJS_0G00
-
 
 **Steps 1.1-1.4 (Wallet Initiated Flow):** The User, using the Wallet Instance, selects the Credential Issuer from those listed in the list of trustworthy entities.
 
 **Steps 2.1-2.3 (Issuer Initiated Flow):** The User while browsing the Credential Issuer website finds a link to obtain a Digital Credential.
 
-**Steps 2.4-2.7 (Cross-Device):** The Credential Offer is presented as a QR Code displayed to the User. The User scans the QR Code using the Wallet Instance, which retrieves the parameters defined in the :ref:`Table of Credential Offer parameters <table_credential_offer_claim>` (:ref:`WP_047–048 <wallet-credential-issuance-testcases>`).
+**Steps 2.4-2.6 (Cross-Device):** The Credential Offer is presented as a QR Code. The User scans it with the device camera or with the Wallet Instance's built-in scanner, triggering the Wallet Instance to retrieve the parameters defined in the :ref:`Table of Credential Offer parameters <table_credential_offer_claim>` (:ref:`WP_047-048 <wallet-credential-issuance-testcases>`).
 
-**Steps 2.8-2.10 (Same-Device):** The Credential Offer is presented as an href button containing the URL that allows the User to invoke the Wallet Instance using the Credential Offer Endpoint.
+**Steps 2.7-2.10 (Same-Device):** The Credential Offer is presented as an href button containing the URL that allows the User to invoke the Wallet Instance using the Credential Offer Endpoint.
 
 Below a non-normative example of a URL related to a Credential Offer that can be included in a QR Code or in HTML page with an href button:
 

--- a/docs/en/credential-issuance-low-level.rst
+++ b/docs/en/credential-issuance-low-level.rst
@@ -56,12 +56,12 @@ The following diagram shows the *User request flow*.
 .. plantuml:: plantuml/credential-user-request-flow.puml
     :width: 99%
     :alt: The figure illustrates the Credential Request Flow by the User.
-    :caption: `Credential Request by the User - Detailed flow. <https://www.plantuml.com/plantuml/svg/hLDDJzj04BtlhnZ1WI814ZroG1HerKYLqf9KNBYirsDxn7hNtPsDoR_lUECq3a7za7gn8dlUntipkOci0wVMmbt04XsJjl20Fn96Xa_Mzr2iWHk4xn63qeczIss10IulBfNg14k6EkqOZeQ98z0HabA5VzcyE8aGMvdg6k_m28w_KDtmhKsuZxqDlj_2Yx3_xL5RYmmp9rQTmJpJAtGbYCg-5Bum1YS9IboH6VJcGRlwjsAuezgRMZOKIlWghzR2t6CHYJVYf9Is35J1BsialJ6MkJ6b4fnVGty5ymvTBkzL1D1Tz-IiD-8qYHFGIQQSQ6icxvGsJ2lXavZzG9Mkm1UioS7Qfm3tL1FhwSO6nOta6gDImNa1-vKmzt3y-7cs_AZccI2xiHGPV9L_BqEAOdow_LcC2KCSQib4IlNdrsB1U5THQ3CieaKpU1MUGwmq87R4ZNzMgiH978KseZGt3XuqDpcmznUNOvCqDZdPo7OVJ-xTWVePVDZM2Glfo-2PN7GjeSFw393DnQcYVwcLnbh7fTy57oFSvmiRRMUw8k0LDDnQw7GjOOaR-FPmvqiSgXjqoDNJikPLXK49R3IpQ7oVsnrH0yrkimkZdNo1_4bofpZG6TrYqE33MpTs-fT7TW8z78gysjnkTmlHV3F_GVmcOFM7y6DsOyayv_0PKoHcyPWFuB_zbuQBtZnkv95Q-nC0>`_
+    :caption: `Credential Request by the User - Detailed flow. <https://www.plantuml.com/plantuml/svg/hLDDJzjC4BxFhnZ1WHSf8F4USq0KQDL8bTAIL5ouhDTZUyHwrzgFcFpxZjUaSGZgXzIB5Utky_4yCxa9KVcOMWCgHMTJMv37gyihW4xEMNEdRCIJxu7y2Qg02Q1mB-F1MS3GogkkSPPEyFGBrqsyDOaEiRVUzJjuuG_l7fKn575XnORLbD_qGBP4KJcKefT8tYg39MrO3tfBhspzIp7QKnsyMZViI_mgHrjXxga874Tn1b0c8bVuqnf7Lf5A_6HS3v3muXhxEIuxiXWRmZSHK7NTapLEYzCaJb0bUML5MqLs5fIEl14-YTaFL6cEheYABMvTydZFDKU1tdag1vGoW-8ekQK0uAqJiDkGnnvF7pylrXzXcGco6yCXegloxxLFGOnFk70HGY8VXbeo4K1_SIqMjBCL-pR30XdIWrVXESO29B4ZRjmpG4cJE40cqD3SfDsZ-YPRzhzisLWdZtLEWRkXFDd_ZYpCyCEkKrn9QPfc-42r9FVR6LBKb-V0VzCjvsvtavTx5mBUvpKRROzqXQSvDh4rsAcQiEVOuBU7ErVIqD-WmxQUDhQiAl8Wi5SpgyRrkU8HbMdsurrfPUK6yvNaJc6Wqwebhz3vznRj_0ytxGnxF1PvCxxz05UY-Mx-e_YDf-etuL-pQyFwEOVFc2B5A1xp0lopFzImrkFdHZwfDJy0>`_
 
 
 **Steps 1.1-1.4 (Wallet Initiated Flow):** The User, using the Wallet Instance, selects the Credential Issuer from those listed in the list of trustworthy entities.
 
-**Steps 2.1-2.3 (Issuer Initiated Flow):** The User while browsing the Credential Issuer website finds a link to obtain a Digital Credential.
+**Steps 2.1-2.3 (Third Party Initiated Flow):** The User while browsing the Credential Issuer website or a Third Party website supporting the Credential Offer mechanism (for example an Authentic Source) finds a link to obtain a Digital Credential.
 
 **Steps 2.4-2.6 (Cross-Device):** The Credential Offer is presented as a QR Code. The User scans it with the device camera or with the Wallet Instance's built-in scanner, triggering the Wallet Instance to retrieve the parameters defined in the :ref:`Table of Credential Offer parameters <table_credential_offer_claim>` (:ref:`WP_047-048 <wallet-credential-issuance-testcases>`).
 
@@ -713,7 +713,7 @@ The decoded Credential Offer object:
 
 **Example 2: Credential Offer by reference from Credential Issuer**
 
-The QR Code contains:
+The QR Code or the href button contains:
 
 .. code-block:: text
 

--- a/docs/en/credential-issuance-low-level.rst
+++ b/docs/en/credential-issuance-low-level.rst
@@ -19,12 +19,12 @@ The Credential Issuance flow is based on [`OpenID4VCI`_] and the following main 
 The Credential Issuer MUST use *OAuth 2.0 Authorization Server* based on :rfc:`6749` to authorize the User to obtain a Credential. Credential Issuers MUST support:
 
   * **Authorization Code Flow**: The Credential Issuer requires User authentication and consent at the Authorization Endpoint before collecting User information to create and provide a Credential.
-  * **Wallet Initiated Flow**: The request from the Wallet Instance is sent to the Credential Issuer without any input from the Credential Issuer or a Third Party (i.e. via Credential Offer support).
+  * **Wallet Initiated Flow**: The request from the Wallet Instance is sent to the Credential Issuer without any input from the Credential Issuer or a third party (i.e. via Credential Offer support).
   * **Immediate Issuance Flow**: The Credential Issuer issues the Credential directly in response to the Credential Request.
 
 In addition, the Credential Issuers MAY support:
 
-  * **Third-Party Initiated Flow**: The Wallet Instance sends its request to the Credential Issuer based on the input provided by the Credential Issuer or a Third Party (for example an Authentic Source) supporting Credential Offer mechanism as defined in [`OpenID4VCI`_].
+  * **Third-Party Initiated Flow**: The Wallet Instance sends its request to the Credential Issuer based on the input provided by the Credential Issuer or a third party (for example an Authentic Source) supporting Credential Offer mechanism as defined in [`OpenID4VCI`_].
 
     * **Same-device Issuance Flow**: The User receives the Credential on the same device used to initiate the flow.
     * **Cross-device Issuance Flow**: The User receives the Credential on another device than the one that initiated the flow.
@@ -643,19 +643,19 @@ To ensure the integrity and security of the re-issuance process, the following s
 Credential Offer Flow
 -----------------------
 
-A Credential Issuer or Third Party (e.g., Authentic Source, Registry, Catalogue) initiates Credential Issuance by sending a Credential Offer to the Wallet Instance.
+A Credential Issuer or third party (e.g., Authentic Source, Registry, Catalogue) initiates Credential Issuance by sending a Credential Offer to the Wallet Instance.
 
 The Wallet Instance invocation mechanism depends on the availability of the ``credential_offer_endpoint`` parameter in the Wallet metadata:
 
-- If ``credential_offer_endpoint`` is available and contains an HTTPS URL (Universal Link), the Credential Issuer or Third Party SHOULD use that endpoint.
-- Otherwise, the Credential Issuer or Third Party MUST use one of the custom URL schemes: ``openid-credential-offer://`` (as defined in Section 4 of [`OpenID4VCI`_]) or ``haip://`` (as defined in Section 5.1.1 of [`OPENID4VC-HAIP`_]).
+- If ``credential_offer_endpoint`` is available and contains an HTTPS URL (Universal Link), the Credential Issuer or third party SHOULD use that endpoint.
+- Otherwise, the Credential Issuer or third party MUST use one of the custom URL schemes: ``openid-credential-offer://`` (as defined in Section 4 of [`OpenID4VCI`_]) or ``haip://`` (as defined in Section 5.1.1 of [`OPENID4VC-HAIP`_]).
 
 The Wallet Instance MUST support both custom URL schemes.
 
 The Credential Offer can be transmitted by value or by reference:
 
 - **By value** (``credential_offer`` parameter): the Credential Offer object is directly embedded in the URI as a JSON-encoded string.
-- **By reference** (``credential_offer_uri`` parameter): the URI points to a resource hosted by the Credential Issuer or Third Party. The Wallet Instance retrieves the Credential Offer object by sending an HTTP GET request to that URI.
+- **By reference** (``credential_offer_uri`` parameter): the URI points to a resource hosted by the Credential Issuer or third party. The Wallet Instance retrieves the Credential Offer object by sending an HTTP GET request to that URI.
 
 The Credential Offer object is a JSON object containing the parameters defined in Section 4.1.1 of [`OpenID4VCI`_]. The table below specifies the parameters with IT-Wallet specific requirements:
 
@@ -683,7 +683,7 @@ The Credential Offer object is a JSON object containing the parameters defined i
     - Section 4.1.1 of [`OpenID4VCI`_] and Section 4.1 of [`OPENID4VC-HAIP`_].
 
 .. note::
-  When using ``credential_offer_uri`` (by reference), the Credential Issuer or Third Party SHOULD use a unique URI for each Credential Offer or otherwise prevent caching of the URI, as recommended in Section 4.1.3 of [`OpenID4VCI`_].
+  When using ``credential_offer_uri`` (by reference), the Credential Issuer or third party SHOULD use a unique URI for each Credential Offer or otherwise prevent caching of the URI, as recommended in Section 4.1.3 of [`OpenID4VCI`_].
 
 
 Non-normative Examples
@@ -746,9 +746,9 @@ The Credential Issuer responds:
     }
   }
 
-**Example 3: Credential Offer by reference from Third Party**
+**Example 3: Credential Offer by reference from third party**
 
-A Third Party, such as an Authentic Source, generates a Credential Offer for a Credential Issuer.
+A third party, such as an Authentic Source, generates a Credential Offer for a Credential Issuer.
 
 The QR Code contains:
 

--- a/docs/en/credential-issuer-metadata.rst
+++ b/docs/en/credential-issuer-metadata.rst
@@ -35,8 +35,6 @@ The *oauth_authorization_server* metadata MUST contain the following parameters.
       - `https://trust-anchor.eid-wallet.example.it/loa/high`
   * - **scopes_supported**
     - JSON array containing a list of the supported *scope* values. See :rfc:`8414#section-2`.
-  * - **response_modes_supported**
-    - JSON array containing a list of the supported "response_mode" values, as specified in `OAuth 2.0 Multiple Response Type Encoding Practices <https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html>`_. The supported value MUST be *query*.
   * - **response_types_supported**
     - JSON array containing a list of the supported "response_type" values, as specified in :rfc:`8414`. The supported value MUST be *code*.
   * - **authorization_signing_alg_values_supported**

--- a/docs/en/plantuml/credential-user-request-flow.puml
+++ b/docs/en/plantuml/credential-user-request-flow.puml
@@ -12,7 +12,7 @@ box "User's external device" #Orange
 participant "Browser" as bre
 end box
 
-participant "Credential Issuer" as i
+participant "Third Party's website" as i
 
 alt if Wallet Initiated Flow
 
@@ -35,7 +35,7 @@ else if Issuer Initiated Flow
 
 autonumber 2.1
 
-u -> i: Open PID/(Q)/EAA Provider website
+u -> i: Open Third Party website\n(Credential Issuer, Authentic Source, Registry, etc.)
 i -> u: obtain your Digital Credential
 u --> i: yes
 
@@ -43,9 +43,10 @@ alt if Cross Device Flow
 
 i -> bre: html page with QRCode containing Credential Offer
 bre -> u: Show the QRCode page
-u --> w: Open the Wallet Instance app\nlocal user authentication
+u --> w: Scan QR Code \n(using camera or Wallet Instance app)\nlocal user authentication
 activate w
-w -> w: Scan QR Code
+' w -> w: Scan QR Code
+deactivate w
 
 
 

--- a/docs/en/plantuml/credential-user-request-flow.puml
+++ b/docs/en/plantuml/credential-user-request-flow.puml
@@ -31,7 +31,7 @@ u-->w: ok
 
 deactivate w
 
-else if Issuer Initiated Flow
+else if third party Initiated Flow
 
 autonumber 2.1
 

--- a/docs/en/test-plans-wallet-provider.rst
+++ b/docs/en/test-plans-wallet-provider.rst
@@ -369,11 +369,11 @@ This section lists the test cases from Sections:
    * - WP_047
      - Issuance, Interoperability
      - Third-Party-Initiated flow: Credential Offer QR scan & decode
-     - In an Third-Party-Initiated cross-device flow, Wallet Instance successfully scans the QR code, and decodes the ``credential_offer`` URL.
+     - In a Third-Party-Initiated cross-device flow, Wallet Instance successfully scans the QR code, and retrieves the ``credential_offer`` or the ``credential_offer_uri`` parameter.
    * - WP_048
      - Issuance, Interoperability
      - Third-Party-Initiated flow: Credential Offer parsing
-     - In an Third-Party-Initiated flow, Wallet Instance extracts and validates all required parameters present (``iss``, ``credential_offer``, etc.) in the URL-decoded ``credential_offer``.
+     - In a Third-Party-Initiated flow, Wallet Instance extracts and validates all required parameters present in the Credential Offer.
    * - WP_049
      - Issuance, Interoperability
      - Issuer-Initiated flow: Authorization Server identifier check

--- a/docs/en/test-plans-wallet-provider.rst
+++ b/docs/en/test-plans-wallet-provider.rst
@@ -368,12 +368,12 @@ This section lists the test cases from Sections:
      - Wallet Instance builds and verifies the full Trust Chain from the Credential Issuer through Intermediaries to the root Trust Anchor, ensuring each signature is valid and confirms the root.
    * - WP_047
      - Issuance, Interoperability
-     - Issuer-Initiated flow: Credential Offer QR scan & decode
-     - In an Issuer-Initiated cross-device flow, Wallet Instance successfully scans the QR code, and decodes the ``credential_offer`` URL.
+     - Third-Party-Initiated flow: Credential Offer QR scan & decode
+     - In an Third-Party-Initiated cross-device flow, Wallet Instance successfully scans the QR code, and decodes the ``credential_offer`` URL.
    * - WP_048
      - Issuance, Interoperability
-     - Issuer-Initiated flow: Credential Offer parsing
-     - In an Issuer-Initiated flow, Wallet Instance extracts and validates all required parameters present (``iss``, ``credential_offer``, etc.) in the URL-decoded ``credential_offer``.
+     - Third-Party-Initiated flow: Credential Offer parsing
+     - In an Third-Party-Initiated flow, Wallet Instance extracts and validates all required parameters present (``iss``, ``credential_offer``, etc.) in the URL-decoded ``credential_offer``.
    * - WP_049
      - Issuance, Interoperability
      - Issuer-Initiated flow: Authorization Server identifier check

--- a/docs/it/credential-issuance-endpoint.rst
+++ b/docs/it/credential-issuance-endpoint.rst
@@ -91,9 +91,6 @@ Il payload del JWT ``request`` contenuto nel messaggio HTTP POST contiene i segu
     * - **response_type**
       - DEVE essere valorizzato con ``code``.
       - :rfc:`6749`
-    * - **response_mode**
-      - DEVE essere una stringa che indica il "*response_mode*", come specificato in [`OAUTH-MULT-RESP-TYPE`_]. DEVE essere valorizzato con uno dei valori supportati (*response_modes_supported*) forniti nei Metadata del Credential Issuer. Tale claim informa il Credential Issuer sul meccanismo da utilizzare per la restituizione dei parametri da parte dell' Authorization Endpoint. In caso di *HTTP 302 Redirect Response* il valore DEVE essere *query*. In questa modalità, i parametri dell'Authorization Response sono codificati nella stringa di query aggiunta al ``redirect_uri`` durante il redirect all'Istanza del Wallet.
-      - Vedi [`OAUTH-MULT-RESP-TYPE`_].
     * - **client_id**
       - DEVE essere valorizzato come indicato nella :ref:`Tabella dei parametri HTTP <table_http_request_claim>`.
       - Vedi :ref:`Tabella dei parametri HTTP <table_http_request_claim>`.

--- a/docs/it/credential-issuance-endpoint.rst
+++ b/docs/it/credential-issuance-endpoint.rst
@@ -1,43 +1,5 @@
 .. include:: ../common/common_definitions.rst
 
-Credential Offer Endpoint 
-"""""""""""""""""""""""""""""""""""""
-
-Il Credential Offer Endpoint di un Wallet è utilizzato dal Credential Issuer per interagire con l'Utente al fine di avviare un'Emissione di un Attestato Elettronico. DEVE essere utilizzato il *custom URL* ``openid-credential-offer://``.
-
-Credential Offer
-......................
-
-La Credential Offer effettuata dal Credential Issuer consiste in un singolo parametro da inviare in query URI ``credential_offer``. L'URL rappresentativa della Credential Offer PUÒ essere inclusa in un QR Code o in una pagina html con un pulsante href e DEVE contenere i seguenti parametri obbligatori:
-
-.. _table_credential_offer_claim:
-.. list-table::
-  :class: longtable
-  :widths: 20 60 20
-  :header-rows: 1
-
-  * - **Claim**
-    - **Descrizione**
-    - **Riferimento**
-  * - **credential_issuer**
-    - DEVE essere valorizzato con una URL HTTPS che identifica in modo univoco il Credential Issuer. Il Wallet utilizza il valore di questo parametro per ottenere i Metadata del Credential Issuer.
-    - Sezione 4.1.1 di [`OpenID4VCI`_].
-  * - **credential_configuration_ids**
-    - Array di Stringhe, ciascuna delle quali specifica un identificativo univoco dell'Attestato Elettronico descritta nel claim ``credential_configurations_supported`` presente nei Metadata del Credential Issuer (:ref:`WP_050b <wallet-credential-issuance-testcases>`).
-    - Sezione 4.1.1 di [`OpenID4VCI`_].
-  * - **grants**
-    - DEVE contenere un oggetto ``authorization_code`` con i seguenti parametri:
-
-        - **issuer_state**: OBBLIGATORIO. Stringa opaca creata dal Credential Issuer utilizzata per correlare la successiva Authorization Request con il Credential Issuer. Il Wallet DEVE includerla nella successiva Authorization Request.
-        - **authorization_server**: OBBLIGATORIO se il Credential Issuer utilizza più di un authorization server nella sua Soluzione di Fornitore di Attestati Elettronici. Stringa che identifica l'Authorization Server da utilizzare. Il valore DEVE corrispondere a uno dei valori censiti nell'array ``authorization_servers`` dei Metadata del Credential Issuer. NON DEVE essere utilizzato se ``authorization_servers`` è assente o non ha voci.
-    - Sezione 4.1.1 di [`OpenID4VCI`_].
-
-
-Credential Offer Response
-...................................
-Non è prevista alcuna response da parte del Wallet.
-
-
 Pushed Authorization Request Endpoint
 """"""""""""""""""""""""""""""""""""""""""""""""""
 

--- a/docs/it/credential-issuance-low-level.rst
+++ b/docs/it/credential-issuance-low-level.rst
@@ -19,12 +19,12 @@ Il flusso di emissione degli Attestati Elettronici (Issuance Flow) è basato su 
 Il Credential Issuer DEVE utilizzare un *OAuth 2.0 Authorization Server* basato su :rfc:`6749` per autorizzare l'Utente a ottenere un Attestato Elettronico. I Credential Issuer DEVONO supportare:
 
   * **Authorization Code Flow**: Il Credential Issuer richiede l'autenticazione dell'Utente e il consenso all'Authorization Endpoint prima di raccogliere le informazioni dell'Utente per creare e rilasciare un Attestato Elettronico.
-  * **Wallet Initiated Flow**: La richiesta dell'Istanza del Wallet viene inviata al Credential Issuer senza alcun input dal Credential Issuer.
+  * **Wallet Initiated Flow**: La richiesta dell'Istanza del Wallet viene inviata al Credential Issuer senza alcun input dal Credential Issuer o una Terza Parte (i.e. tramite supporto al Credential Offer).
   * **Immediate Issuance Flow**: Il Credential Issuer rilascia l'Attestato Elettronico direttamente in risposta alla Credential Request.
 
 In aggiunta, i Credential Issuer POSSONO supportare:
 
-  * **Issuer Initiated Flow**: L'Istanza del Wallet invia la sua richiesta al Credential Issuer in base all'input fornito dal Credential Issuer.
+  * **Third-Party Initiated Flow**: L'Istanza del Wallet invia la sua richiesta al Credential Issuer in base all'input fornito dal Credential Issuer o da una Terza Parte (per esempio una Fonte Autentica) che supporta il meccanismo di Credential Offer definito in [`OpenID4VCI`_]..
 
     * **Same-device Issuance Flow**: L'Utente riceve l'Attestato Elettronico sullo stesso dispositivo utilizzato per avviare il flusso.
     * **Cross-device Issuance Flow**: L'Utente riceve l'Attestato Elettronico su un dispositivo diverso da quello su cui ha avviato il flusso.

--- a/docs/it/credential-issuance-low-level.rst
+++ b/docs/it/credential-issuance-low-level.rst
@@ -19,12 +19,12 @@ Il flusso di emissione degli Attestati Elettronici (Issuance Flow) è basato su 
 Il Credential Issuer DEVE utilizzare un *OAuth 2.0 Authorization Server* basato su :rfc:`6749` per autorizzare l'Utente a ottenere un Attestato Elettronico. I Credential Issuer DEVONO supportare:
 
   * **Authorization Code Flow**: Il Credential Issuer richiede l'autenticazione dell'Utente e il consenso all'Authorization Endpoint prima di raccogliere le informazioni dell'Utente per creare e rilasciare un Attestato Elettronico.
-  * **Wallet Initiated Flow**: La richiesta dell'Istanza del Wallet viene inviata al Credential Issuer senza alcun input dal Credential Issuer o una Terza Parte (i.e. tramite supporto al Credential Offer).
+  * **Wallet Initiated Flow**: La richiesta dell'Istanza del Wallet viene inviata al Credential Issuer senza alcun input dal Credential Issuer o una terza parte (i.e. tramite supporto al Credential Offer).
   * **Immediate Issuance Flow**: Il Credential Issuer rilascia l'Attestato Elettronico direttamente in risposta alla Credential Request.
 
 In aggiunta, i Credential Issuer POSSONO supportare:
 
-  * **Third-Party Initiated Flow**: L'Istanza del Wallet invia la sua richiesta al Credential Issuer in base all'input fornito dal Credential Issuer o da una Terza Parte (per esempio una Fonte Autentica) che supporta il meccanismo di Credential Offer definito in [`OpenID4VCI`_]..
+  * **Third-Party Initiated Flow**: L'Istanza del Wallet invia la sua richiesta al Credential Issuer in base all'input fornito dal Credential Issuer o da una terza parte (per esempio una Fonte Autentica) che supporta il meccanismo di Credential Offer definito in [`OpenID4VCI`_]..
 
     * **Same-device Issuance Flow**: L'Utente riceve l'Attestato Elettronico sullo stesso dispositivo utilizzato per avviare il flusso.
     * **Cross-device Issuance Flow**: L'Utente riceve l'Attestato Elettronico su un dispositivo diverso da quello su cui ha avviato il flusso.
@@ -602,19 +602,19 @@ Per garantire l'integrità e la sicurezza del Re-issuance Flow, si applicano le 
 Flusso Credential Offer
 -----------------------
 
-Un Credential Issuer o una Terza Parte (ad esempio, Authentic Source, Registro, Catalogo) avvia l'emissione di Attestati Elettronici inviando una Credential Offer all'Istanza del Wallet.
+Un Credential Issuer o una terza parte (ad esempio, Authentic Source, Registro, Catalogo) avvia l'emissione di Attestati Elettronici inviando una Credential Offer all'Istanza del Wallet.
 
 Il meccanismo di invocazione dell'Istanza del Wallet dipende dalla disponibilità del parametro ``credential_offer_endpoint`` nei metadata del Wallet:
 
-- Se ``credential_offer_endpoint`` è disponibile e contiene un URL HTTPS (Universal Link), il Credential Issuer o la Terza Parte DOVREBBE utilizzare quell'endpoint.
-- Altrimenti, il Credential Issuer o la Terza Parte DEVE utilizzare uno degli schemi URL personalizzati: ``openid-credential-offer://`` (come definito nella Sezione 4 di [`OpenID4VCI`_]) o ``haip://`` (come definito nella Sezione 5.1.1 di [`OPENID4VC-HAIP`_]).
+- Se ``credential_offer_endpoint`` è disponibile e contiene un URL HTTPS (Universal Link), il Credential Issuer o la terza parte DOVREBBE utilizzare quell'endpoint.
+- Altrimenti, il Credential Issuer o la terza parte DEVE utilizzare uno degli schemi URL personalizzati: ``openid-credential-offer://`` (come definito nella Sezione 4 di [`OpenID4VCI`_]) o ``haip://`` (come definito nella Sezione 5.1.1 di [`OPENID4VC-HAIP`_]).
 
 L'Istanza del Wallet DEVE supportare entrambi gli schemi URL personalizzati.
 
 La Credential Offer può essere trasmessa per valore o per riferimento:
 
 - **Per valore** (parametro ``credential_offer``): l'oggetto Credential Offer è incorporato direttamente nell'URI come stringa codificata JSON.
-- **Per riferimento** (parametro ``credential_offer_uri``): l'URI punta a una risorsa ospitata dal Credential Issuer o dalla Terza Parte. L'Istanza del Wallet recupera l'oggetto Credential Offer inviando una richiesta HTTP GET a quell'URI.
+- **Per riferimento** (parametro ``credential_offer_uri``): l'URI punta a una risorsa ospitata dal Credential Issuer o dalla terza parte. L'Istanza del Wallet recupera l'oggetto Credential Offer inviando una richiesta HTTP GET a quell'URI.
 
 L'oggetto Credential Offer è un oggetto JSON contenente i parametri definiti nella Sezione 4.1.1 di [`OpenID4VCI`_]. La tabella seguente specifica i parametri con requisiti specifici IT-Wallet:
 
@@ -642,7 +642,7 @@ L'oggetto Credential Offer è un oggetto JSON contenente i parametri definiti ne
     - Sezione 4.1.1 di [`OpenID4VCI`_] e Sezione 4.1 di [`OPENID4VC-HAIP`_].
 
 .. note::
-  Quando si utilizza ``credential_offer_uri`` (per riferimento), il Credential Issuer o la Terza Parte DOVREBBE utilizzare un URI univoco per ogni Credential Offer o altrimenti prevenire il caching dell'URI, come raccomandato nella Sezione 4.1.3 di [`OpenID4VCI`_].
+  Quando si utilizza ``credential_offer_uri`` (per riferimento), il Credential Issuer o la terza parte DOVREBBE utilizzare un URI univoco per ogni Credential Offer o altrimenti prevenire il caching dell'URI, come raccomandato nella Sezione 4.1.3 di [`OpenID4VCI`_].
 
 
 Esempi non normativi
@@ -705,9 +705,9 @@ Il Credential Issuer risponde:
     }
   }
 
-**Esempio 3: Credential Offer per riferimento da Terza Parte**
+**Esempio 3: Credential Offer per riferimento da terza parte**
 
-Una Terza Parte, come un'Authentic Source, genera una Credential Offer per un Credential Issuer.
+Una terza parte, come un'Authentic Source, genera una Credential Offer per un Credential Issuer.
 
 Il codice QR contiene:
 

--- a/docs/it/credential-issuance-low-level.rst
+++ b/docs/it/credential-issuance-low-level.rst
@@ -55,7 +55,7 @@ Il seguente diagramma mostra il *flusso di richiesta dell'Utente*.
 .. plantuml:: plantuml/credential-user-request-flow.puml
     :width: 99%
     :alt: La figura illustra il flusso di richiesta dell'Attestato Elettronico da parte dell'Utente.
-    :caption: `Richiesta dell'Attestato Elettronico da parte dell'Utente - Flusso dettagliato. <https://www.plantuml.com/plantuml/svg/hP9FJzj04CNlyob6uT3sG14zve20XAgHAWKA5PTUrkknFMAzQ-sV6BvzPpTkapHLAoGkLkJClFTxptCPel8nzGPKYiwclYAFvn_F0GPvpve7PIFElWVoCrG14q3bdhSltWKClKmDdRCqmvElt7RnsYGwtBtsRlorNld3_nwLCHHnPGN3QYep8v2jKLmEhUWvahVAO4qRrjblxPLj_sb6Ewc3gOMdccnaKLk5aAPv1b0c8ZVu6ujb9bADduqR0HAUNk0un_L05cD7-0S-gc7uOOtJefk40gNJBlje5TbPK3hoHlGaufYbqXnT5HLRV779uv9RZhAweykEMyiN2W3UEbbs6r4UyUJno-hX1jP5eD0O3X5TKtu_-1Go-57Ia2ifGW3ZwOKWQ6SRzdrP2sH8PrRHETu5I88ZDEu9eAQzE40ca3Gt3HurjtTSd_9nbIPvQl9sjJnxV_VXxERg2c-zst2T0r8LM23vDKNnLDJq6HVUXO3BSYyJI96hFCsnYxt1GRM2px73ksyBLrCk8_kmRVVZhvj6qilQ17FVkJ7tDMqLcOpmjkSnYf5MLammkm3iQhvNFVqrs56kpbFpdrHJA6rOFnNkibEb60KAtZHNFhxjur8UgJS_0G00>`_
+    :caption: `Richiesta dell'Attestato Elettronico da parte dell'Utente - Flusso dettagliato. <https://www.plantuml.com/plantuml/svg/hLDDJzj04BtlhnZ1WI814ZroG1HerKYLqf9KNBYirsDxn7hNtPsDoR_lUECq3a7za7gn8dlUntipkOci0wVMmbt04XsJjl20Fn96Xa_Mzr2iWHk4xn63qeczIss10IulBfNg14k6EkqOZeQ98z0HabA5VzcyE8aGMvdg6k_m28w_KDtmhKsuZxqDlj_2Yx3_xL5RYmmp9rQTmJpJAtGbYCg-5Bum1YS9IboH6VJcGRlwjsAuezgRMZOKIlWghzR2t6CHYJVYf9Is35J1BsialJ6MkJ6b4fnVGty5ymvTBkzL1D1Tz-IiD-8qYHFGIQQSQ6icxvGsJ2lXavZzG9Mkm1UioS7Qfm3tL1FhwSO6nOta6gDImNa1-vKmzt3y-7cs_AZccI2xiHGPV9L_BqEAOdow_LcC2KCSQib4IlNdrsB1U5THQ3CieaKpU1MUGwmq87R4ZNzMgiH978KseZGt3XuqDpcmznUNOvCqDZdPo7OVJ-xTWVePVDZM2Glfo-2PN7GjeSFw393DnQcYVwcLnbh7fTy57oFSvmiRRMUw8k0LDDnQw7GjOOaR-FPmvqiSgXjqoDNJikPLXK49R3IpQ7oVsnrH0yrkimkZdNo1_4bofpZG6TrYqE33MpTs-fT7TW8z78gysjnkTmlHV3F_GVmcOFM7y6DsOyayv_0PKoHcyPWFuB_zbuQBtZnkv95Q-nC0>`_
 
 **Passi 1.1-1.4 (Flusso Avviato dal Wallet):** L'Utente, utilizzando l'Istanza del Wallet, seleziona il Credential Issuer tra quelli elencati nella lista delle entità affidabili.
 
@@ -65,11 +65,7 @@ Il seguente diagramma mostra il *flusso di richiesta dell'Utente*.
 
 **Passi 2.7-2.10 (Same-Device):** La Credential Offer viene presentata come un pulsante href contenente l'URL che consente all'Utente di invocare l'Istanza del Wallet utilizzando il Credential Offer Endpoint.
 
-Di seguito un esempio non normativo di un URL relativo a una Credential Offer che può essere incluso in un codice QR o in una pagina HTML con un pulsante href:
-
-.. code-block:: text
-
-  openid-credential-offer://?credential_offer%3D%7B%22credential_issuer%22%3A%22https%3A%2F%2Feaa-provider.example.org%22%2C%22credential_configuration_ids%22%3A%5B%22dc_sd_jwt_Education_degree%22%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%22issuer_state%22%3A%22oaKazRN8I0IbtZ0C7JuMn5%22%7D%7D%7D
+La Credential Offer può essere inviata per valore (utilizzando il parametro ``credential_offer``) o per riferimento (utilizzando il parametro ``credential_offer_uri``) come definito nella Sezione 4 di [`OpenID4VCI`_]. Ulteriori dettagli ed esempi non normativi sono forniti nella Sezione :ref:`credential-issuance-low-level:Flusso Credential Offer`.
 
 Il seguente diagramma mostra il *flusso di emissione*.
 
@@ -601,3 +597,146 @@ Per garantire l'integrità e la sicurezza del Re-issuance Flow, si applicano le 
   - Scadenza dell'Attestato Elettronico: Il Credential Issuer DEVE impostare per l'Attestato Elettronico riemesso la stessa data di scadenza del precedente. Ciò impedisce rinnovi indefiniti dell'Attestato Elettronico senza una corretta autenticazione dell'Utente.
   - Consenso dell'Utente: Per i Re-issuance Flow attivati da modifiche agli attributi, il consenso dell'Utente DEVE essere ottenuto prima di memorizzare il nuovo Attestato Elettronico.
   - Refresh Token vincolato al mittente: I Refresh Token DEVONO essere crittograficamente vincolati all'Istanza del Wallet utilizzando il protocollo DPoP. Ciò mitiga il rischio di uso improprio del token, garantendo che solo l'Istanza del Wallet prevista possa utilizzarlo.
+
+
+Flusso Credential Offer
+-----------------------
+
+Un Credential Issuer o una Terza Parte (ad esempio, Authentic Source, Registro, Catalogo) avvia l'emissione di Attestati Elettronici inviando una Credential Offer all'Istanza del Wallet.
+
+Il meccanismo di invocazione dell'Istanza del Wallet dipende dalla disponibilità del parametro ``credential_offer_endpoint`` nei metadata del Wallet:
+
+- Se ``credential_offer_endpoint`` è disponibile e contiene un URL HTTPS (Universal Link), il Credential Issuer o la Terza Parte DOVREBBE utilizzare quell'endpoint.
+- Altrimenti, il Credential Issuer o la Terza Parte DEVE utilizzare uno degli schemi URL personalizzati: ``openid-credential-offer://`` (come definito nella Sezione 4 di [`OpenID4VCI`_]) o ``haip://`` (come definito nella Sezione 5.1.1 di [`OPENID4VC-HAIP`_]).
+
+L'Istanza del Wallet DEVE supportare entrambi gli schemi URL personalizzati.
+
+La Credential Offer può essere trasmessa per valore o per riferimento:
+
+- **Per valore** (parametro ``credential_offer``): l'oggetto Credential Offer è incorporato direttamente nell'URI come stringa codificata JSON.
+- **Per riferimento** (parametro ``credential_offer_uri``): l'URI punta a una risorsa ospitata dal Credential Issuer o dalla Terza Parte. L'Istanza del Wallet recupera l'oggetto Credential Offer inviando una richiesta HTTP GET a quell'URI.
+
+L'oggetto Credential Offer è un oggetto JSON contenente i parametri definiti nella Sezione 4.1.1 di [`OpenID4VCI`_]. La tabella seguente specifica i parametri con requisiti specifici IT-Wallet:
+
+.. _table_credential_offer_claim:
+.. list-table::
+  :class: longtable
+  :widths: 20 60 20
+  :header-rows: 1
+
+  * - **Claim**
+    - **Descrizione**
+    - **Riferimento**
+  * - **credential_issuer**
+    - DEVE essere impostato con un URL HTTPS che identifica univocamente il Credential Issuer. Il Wallet utilizza questo valore del parametro per ottenere i metadata del Credential Issuer.
+    - Sezione 4.1.1 di [`OpenID4VCI`_].
+  * - **credential_configuration_ids**
+    - Array di stringhe, ciascuna delle quali specifica un identificatore univoco dell'Attestato Elettronico descritto nella mappa ``credential_configurations_supported`` nei Metadata del Credential Issuer (:ref:`WP_050b <wallet-credential-issuance-testcases>`).
+    - Sezione 4.1.1 di [`OpenID4VCI`_].
+  * - **grants**
+    - REQUIRED. DEVE contenere l'oggetto ``authorization_code`` con i seguenti parametri:
+
+        - **issuer_state**: OPZIONALE. Stringa opaca creata dal Credential Issuer utilizzata per legare la successiva Authorization Request con il Credential Issuer. Il Wallet DEVE includerlo nella successiva Authorization Request quando presente.
+        - **authorization_server**: REQUIRED quando il Credential Issuer utilizza più di un authorization server nella sua soluzione. Stringa che identifica l'Authorization Server da utilizzare. Il valore DEVE corrispondere a uno dei valori mappati nell'array ``authorization_servers`` dei metadata del Credential Issuer. NON DEVE essere utilizzato se ``authorization_servers`` è assente o non ha voci multiple.
+        - **scope**: REQUIRED. Valore stringa che mappa a uno specifico tipo di Attestato Elettronico. Il Wallet DEVE utilizzare questo valore di scope nell'Authorization Request. Vedere Sezione 4.1 di [`OPENID4VC-HAIP`_] per i dettagli.
+    - Sezione 4.1.1 di [`OpenID4VCI`_] e Sezione 4.1 di [`OPENID4VC-HAIP`_].
+
+.. note::
+  Quando si utilizza ``credential_offer_uri`` (per riferimento), il Credential Issuer o la Terza Parte DOVREBBE utilizzare un URI univoco per ogni Credential Offer o altrimenti prevenire il caching dell'URI, come raccomandato nella Sezione 4.1.3 di [`OpenID4VCI`_].
+
+
+Esempi non normativi
+^^^^^^^^^^^^^^^^^^^^^^^
+
+**Esempio 1: Credential Offer per valore**
+
+La Credential Offer può essere trasmessa per valore utilizzando qualsiasi metodo di invocazione supportato (schema URL personalizzato o Universal Link):
+
+.. code-block:: text
+
+  openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A//credential-issuer.example.org%22%2C%22credential_configuration_ids%22%3A%5B%22dc_sd_jwt_Education_degree%22%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%22scope%22%3A%22Education_degree%22%7D%7D%7D
+
+L'oggetto Credential Offer decodificato:
+
+.. code-block:: json
+
+  {
+    "credential_issuer": "https://credential-issuer.example.org",
+    "credential_configuration_ids": ["dc_sd_jwt_Education_degree"],
+    "grants": {
+      "authorization_code": {
+        "scope": "Education_degree"
+      }
+    }
+  }
+
+**Esempio 2: Credential Offer per riferimento da Credential Issuer**
+
+Il codice QR contiene:
+
+.. code-block:: text
+
+  openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fcredential-issuer.example.org%2Foffers%2F8f3a2b1c
+
+L'Istanza del Wallet invia una richiesta HTTP GET:
+
+.. code-block:: http
+
+  GET /offers/8f3a2b1c HTTP/1.1
+  Host: credential-issuer.example.org
+  Accept: application/json
+
+Il Credential Issuer risponde:
+
+.. code-block:: http
+
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+  Cache-Control: no-store
+
+  {
+    "credential_issuer": "https://credential-issuer.example.org",
+    "credential_configuration_ids": ["dc_sd_jwt_EuropeanDisabilityCard"],
+    "grants": {
+      "authorization_code": {
+        "issuer_state": "eyJhbGciOiJSU0Et...F77QK8",
+        "scope": "EuropeanDisabilityCard"
+      }
+    }
+  }
+
+**Esempio 3: Credential Offer per riferimento da Terza Parte**
+
+Una Terza Parte, come un'Authentic Source, genera una Credential Offer per un Credential Issuer.
+
+Il codice QR contiene:
+
+.. code-block:: text
+
+  openid-credential-offer://?credential_offer_uri=https%3A%2F%2Fauthentic-source.gov.example%2Fcredential-offers%2Fabc123
+
+L'Istanza del Wallet invia:
+
+.. code-block:: http
+
+  GET /credential-offers/abc123 HTTP/1.1
+  Host: authentic-source.gov.example
+  Accept: application/json
+
+L'Authentic Source risponde:
+
+.. code-block:: http
+
+  HTTP/1.1 200 OK
+  Content-Type: application/json
+  Cache-Control: no-store
+
+  {
+    "credential_issuer": "https://credential-issuer.example.org",
+    "credential_configuration_ids": ["mso_mdoc_mDL"],
+    "grants": {
+      "authorization_code": {
+        "scope": "mDL"
+      }
+    }
+  }

--- a/docs/it/credential-issuance-low-level.rst
+++ b/docs/it/credential-issuance-low-level.rst
@@ -61,9 +61,9 @@ Il seguente diagramma mostra il *flusso di richiesta dell'Utente*.
 
 **Passi 2.1-2.3 (Flusso Avviato dall'Issuer):** L'Utente, mentre naviga sul sito web del Credential Issuer, trova un link per ottenere un Attestato Elettronico.
 
-**Passi 2.4-2.7 (Cross-Device):** La Credential Offer viene presentata come un codice QR mostrato all'Utente. L'Utente scansiona il codice QR utilizzando l'Istanza del Wallet, che recupera i parametri definiti nella :ref:`Tabella dei parametri della Credential Offer <table_credential_offer_claim>` (:ref:`WP_047–048 <wallet-credential-issuance-testcases>`).
+**Passi 2.4-2.6 (Cross-Device):** La Credential Offer viene presentata come un codice QR. L'Utente lo scansiona con la fotocamera del dispositivo o con lo scanner integrato dell'Istanza del Wallet, attivando l'Istanza del Wallet per recuperare i parametri definiti nella :ref:`Tabella dei parametri della Credential Offer <table_credential_offer_claim>` (:ref:`WP_047-048 <wallet-credential-issuance-testcases>`).
 
-**Passi 2.8-2.10 (Same-Device):** La Credential Offer viene presentata come un pulsante href contenente l'URL che consente all'Utente di invocare l'Istanza del Wallet utilizzando il Credential Offer Endpoint.
+**Passi 2.7-2.10 (Same-Device):** La Credential Offer viene presentata come un pulsante href contenente l'URL che consente all'Utente di invocare l'Istanza del Wallet utilizzando il Credential Offer Endpoint.
 
 Di seguito un esempio non normativo di un URL relativo a una Credential Offer che può essere incluso in un codice QR o in una pagina HTML con un pulsante href:
 

--- a/docs/it/credential-issuance-low-level.rst
+++ b/docs/it/credential-issuance-low-level.rst
@@ -55,11 +55,11 @@ Il seguente diagramma mostra il *flusso di richiesta dell'Utente*.
 .. plantuml:: plantuml/credential-user-request-flow.puml
     :width: 99%
     :alt: La figura illustra il flusso di richiesta dell'Attestato Elettronico da parte dell'Utente.
-    :caption: `Richiesta dell'Attestato Elettronico da parte dell'Utente - Flusso dettagliato. <https://www.plantuml.com/plantuml/svg/hLDDJzj04BtlhnZ1WI814ZroG1HerKYLqf9KNBYirsDxn7hNtPsDoR_lUECq3a7za7gn8dlUntipkOci0wVMmbt04XsJjl20Fn96Xa_Mzr2iWHk4xn63qeczIss10IulBfNg14k6EkqOZeQ98z0HabA5VzcyE8aGMvdg6k_m28w_KDtmhKsuZxqDlj_2Yx3_xL5RYmmp9rQTmJpJAtGbYCg-5Bum1YS9IboH6VJcGRlwjsAuezgRMZOKIlWghzR2t6CHYJVYf9Is35J1BsialJ6MkJ6b4fnVGty5ymvTBkzL1D1Tz-IiD-8qYHFGIQQSQ6icxvGsJ2lXavZzG9Mkm1UioS7Qfm3tL1FhwSO6nOta6gDImNa1-vKmzt3y-7cs_AZccI2xiHGPV9L_BqEAOdow_LcC2KCSQib4IlNdrsB1U5THQ3CieaKpU1MUGwmq87R4ZNzMgiH978KseZGt3XuqDpcmznUNOvCqDZdPo7OVJ-xTWVePVDZM2Glfo-2PN7GjeSFw393DnQcYVwcLnbh7fTy57oFSvmiRRMUw8k0LDDnQw7GjOOaR-FPmvqiSgXjqoDNJikPLXK49R3IpQ7oVsnrH0yrkimkZdNo1_4bofpZG6TrYqE33MpTs-fT7TW8z78gysjnkTmlHV3F_GVmcOFM7y6DsOyayv_0PKoHcyPWFuB_zbuQBtZnkv95Q-nC0>`_
+    :caption: `Richiesta dell'Attestato Elettronico da parte dell'Utente - Flusso dettagliato. <https://www.plantuml.com/plantuml/svg/hLDDJzjC4BxFhnZ1WHSf8F4USq0KQDL8bTAIL5ouhDTZUyHwrzgFcFpxZjUaSGZgXzIB5Utky_4yCxa9KVcOMWCgHMTJMv37gyihW4xEMNEdRCIJxu7y2Qg02Q1mB-F1MS3GogkkSPPEyFGBrqsyDOaEiRVUzJjuuG_l7fKn575XnORLbD_qGBP4KJcKefT8tYg39MrO3tfBhspzIp7QKnsyMZViI_mgHrjXxga874Tn1b0c8bVuqnf7Lf5A_6HS3v3muXhxEIuxiXWRmZSHK7NTapLEYzCaJb0bUML5MqLs5fIEl14-YTaFL6cEheYABMvTydZFDKU1tdag1vGoW-8ekQK0uAqJiDkGnnvF7pylrXzXcGco6yCXegloxxLFGOnFk70HGY8VXbeo4K1_SIqMjBCL-pR30XdIWrVXESO29B4ZRjmpG4cJE40cqD3SfDsZ-YPRzhzisLWdZtLEWRkXFDd_ZYpCyCEkKrn9QPfc-42r9FVR6LBKb-V0VzCjvsvtavTx5mBUvpKRROzqXQSvDh4rsAcQiEVOuBU7ErVIqD-WmxQUDhQiAl8Wi5SpgyRrkU8HbMdsurrfPUK6yvNaJc6Wqwebhz3vznRj_0ytxGnxF1PvCxxz05UY-Mx-e_YDf-etuL-pQyFwEOVFc2B5A1xp0lopFzImrkFdHZwfDJy0>`_
 
 **Passi 1.1-1.4 (Flusso Avviato dal Wallet):** L'Utente, utilizzando l'Istanza del Wallet, seleziona il Credential Issuer tra quelli elencati nella lista delle entità affidabili.
 
-**Passi 2.1-2.3 (Flusso Avviato dall'Issuer):** L'Utente, mentre naviga sul sito web del Credential Issuer, trova un link per ottenere un Attestato Elettronico.
+**Passi 2.1-2.3 (Flusso Avviato da una Terza Parte):** L'Utente, mentre naviga sul sito web del Credential Issuer o di una Terza Parte che supporta il meccanismo di Credential Offer (per esempio una Fonte Autentica), trova un link per ottenere un Attestato Elettronico.
 
 **Passi 2.4-2.6 (Cross-Device):** La Credential Offer viene presentata come un codice QR. L'Utente lo scansiona con la fotocamera del dispositivo o con lo scanner integrato dell'Istanza del Wallet, attivando l'Istanza del Wallet per recuperare i parametri definiti nella :ref:`Tabella dei parametri della Credential Offer <table_credential_offer_claim>` (:ref:`WP_047-048 <wallet-credential-issuance-testcases>`).
 
@@ -672,7 +672,7 @@ L'oggetto Credential Offer decodificato:
 
 **Esempio 2: Credential Offer per riferimento da Credential Issuer**
 
-Il codice QR contiene:
+Il codice QR o il pulsante href contiene:
 
 .. code-block:: text
 

--- a/docs/it/credential-issuer-metadata.rst
+++ b/docs/it/credential-issuer-metadata.rst
@@ -35,8 +35,6 @@ I Metadata *oauth_authorization_server* DEVONO contenere i seguenti parametri.
       - `https://trust-registry.eid-wallet.example.it/loa/high`
   * - **scopes_supported**
     - Array JSON contenente un elenco dei valori *scope* supportati. Vedi :rfc:`8414#section-2`.
-  * - **response_modes_supported**
-    - Array JSON contenente un elenco dei valori "*response_mode*" supportati, come specificato in `OAuth 2.0 Multiple Response Type Encoding Practices <https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html>`_. Il valore supportato DEVE essere *query*.
   * - **response_types_supported**
     - Array JSON contenente un elenco dei valori "*response_type*" supportati, come specificato in :rfc:`8414`. Il valore supportato DEVE essere *code*.
   * - **authorization_signing_alg_values_supported**

--- a/docs/it/plantuml/credential-user-request-flow.puml
+++ b/docs/it/plantuml/credential-user-request-flow.puml
@@ -31,7 +31,7 @@ u-->w: ok
 
 deactivate w
 
-else if Issuer Initiated Flow
+else if third party Initiated Flow
 
 autonumber 2.1
 

--- a/docs/it/plantuml/credential-user-request-flow.puml
+++ b/docs/it/plantuml/credential-user-request-flow.puml
@@ -12,7 +12,7 @@ box "User's external device" #Orange
 participant "Browser" as bre
 end box
 
-participant "Credential Issuer" as i
+participant "Third Party's website" as i
 
 alt if Wallet Initiated Flow
 
@@ -35,7 +35,7 @@ else if Issuer Initiated Flow
 
 autonumber 2.1
 
-u -> i: Open PID/(Q)/EAA Provider website
+u -> i: Open Third Party website\n(Credential Issuer, Authentic Source, Registry, etc.)
 i -> u: obtain your Digital Credential
 u --> i: yes
 
@@ -43,10 +43,10 @@ alt if Cross Device Flow
 
 i -> bre: html page with QRCode containing Credential Offer
 bre -> u: Show the QRCode page
-u --> w: Open the Wallet Instance app\nlocal user authentication
+u --> w: Scan QR Code \n(using camera or Wallet Instance app)\nlocal user authentication
 activate w
-w -> w: Scan QR Code
-
+' w -> w: Scan QR Code
+deactivate w
 
 
 else if Same Device Flow

--- a/docs/it/test-plans-wallet-provider.rst
+++ b/docs/it/test-plans-wallet-provider.rst
@@ -369,11 +369,11 @@ Questa sezione elenca i casi di test dalle Sezioni:
    * - WP_047
      - Issuance, Interoperabilità
      - Flusso Third-Party-Initiated: scansione e decodifica QR Credential Offer
-     - In un flusso cross-device Third-Party-Initiated, Istanza del Wallet scansiona con successo il codice QR, e decodifica l'URL ``credential_offer``.
+     - In un flusso cross-device Third-Party-Initiated, l'Istanza del Wallet scansiona con successo il codice QR, e ottiene il parametro ``credential_offer`` o ``credential_offer_uri``.
    * - WP_048
      - Issuance, Interoperabilità
      - Flusso Third-Party-Initiated: parsing Credential Offer
-     - In un flusso Third-Party-Initiated, Istanza del Wallet estrae e valida tutti i parametri richiesti presenti (``iss``, ``credential_offer``, ecc.) nell'URL decodificato ``credential_offer``.
+     - In un flusso Third-Party-Initiated, l'Istanza del Wallet estrae e valida tutti i parametri richiesti presenti nell'oggetto Credential Offer.
    * - WP_049
      - Issuance, Interoperabilità
      - Flusso Issuer-Initiated: controllo identificativo dell'Authorization Server

--- a/docs/it/test-plans-wallet-provider.rst
+++ b/docs/it/test-plans-wallet-provider.rst
@@ -368,12 +368,12 @@ Questa sezione elenca i casi di test dalle Sezioni:
      - Istanza del Wallet costruisce e verifica la Trust Chain completa dal Credential Issuer attraverso Intermediari fino al Trust Anchor radice, assicurandosi che ogni firma sia valida.
    * - WP_047
      - Issuance, Interoperabilità
-     - Flusso Issuer-Initiated: scansione e decodifica QR Credential Offer
-     - In un flusso cross-device Issuer-Initiated, Istanza del Wallet scansiona con successo il codice QR, e decodifica l'URL ``credential_offer``.
+     - Flusso Third-Party-Initiated: scansione e decodifica QR Credential Offer
+     - In un flusso cross-device Third-Party-Initiated, Istanza del Wallet scansiona con successo il codice QR, e decodifica l'URL ``credential_offer``.
    * - WP_048
      - Issuance, Interoperabilità
-     - Flusso Issuer-Initiated: parsing Credential Offer
-     - In un flusso Issuer-Initiated, Istanza del Wallet estrae e valida tutti i parametri richiesti presenti (``iss``, ``credential_offer``, ecc.) nell'URL decodificato ``credential_offer``.
+     - Flusso Third-Party-Initiated: parsing Credential Offer
+     - In un flusso Third-Party-Initiated, Istanza del Wallet estrae e valida tutti i parametri richiesti presenti (``iss``, ``credential_offer``, ecc.) nell'URL decodificato ``credential_offer``.
    * - WP_049
      - Issuance, Interoperabilità
      - Flusso Issuer-Initiated: controllo identificativo dell'Authorization Server

--- a/examples/ec-eaa.json
+++ b/examples/ec-eaa.json
@@ -48,9 +48,6 @@
                 "EuropeanDisabilityCard",
                 "mDL"
             ],
-            "response_modes_supported": [
-                "query"
-            ],
             "response_types_supported": [
                 "code"
             ],

--- a/examples/request-object-payload.json
+++ b/examples/request-object-payload.json
@@ -4,7 +4,6 @@
     "iat": 1715842560,
     "exp": 1715842860,
     "response_type": "code",
-    "response_mode": "query",
     "client_id": "47b982369791d08003a7283f059cb0d1",
     "iss": "47b982369791d08003a7283f059cb0d1",
     "state": "fyZiOL9Lf2CeKuNT2JzxiLRDink0uPcd",


### PR DESCRIPTION
This PR:

- resolves #900 
- resolves #885 
- resolves #914  

Credential Offer enhancements (#900 and #885):

- Moved Credential Offer specification from endpoint section to dedicated flow section
- Added Third Party support (Authentic Sources, Registries, Catalogues)
- Added Universal Link support alongside custom URL schemes (openid-credential-offer://, haip://)
- Made grants and scope REQUIRED for IT-Wallet as specified in HAIP
- Added by-reference (credential_offer_uri) and by-value flow support
- Clarified issuer_state as OPTIONAL

Response mode cleanup (#914): 

- Removed response_mode parameter from Request Object (only query supported per OID4VCI) 
- Update relevant sections accordingly


All changes include Italian translation alignment and non-normative examples.