### PR TITLE
Add key rotation and certificate updates procedures

### DIFF
--- a/docs/en/x5c-evaluation.rst
+++ b/docs/en/x5c-evaluation.rst
@@ -182,8 +182,6 @@ Subordinates MAY use one or more of the following mechanisms to detect changes:
 - **Fetch Endpoint**: Retrieve Subordinate Statement via ``GET {superior}/fetch?sub={subordinate_entity_id}`` to obtain current certificates.
 - **Events Endpoint**: Monitor ``GET {superior}/federation_subordinate_events_endpoint?sub={subordinate_entity_id}`` for ``jwks_update`` events. The Federation Subordinate Events endpoint returns historical track of registration events as defined in :ref:`trust-infrastructure:Federation API endpoints`.
 
-**Implementation**
-
 Subordinates SHOULD implement automated scheduling for:
 
 - Daily fetch operations to retrieve current Subordinate Statement.

--- a/docs/en/x5c-evaluation.rst
+++ b/docs/en/x5c-evaluation.rst
@@ -158,7 +158,7 @@ Federation entities MUST coordinate X.509 Certificate management with federation
 Key Rotation Procedures
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Federation entities MUST implement key rotation mechanisms to maintain security posture and respond to security events. This section defines operational procedures for detecting and responding to superior key rotations and for subordinate key renewal.
+Federation entities MUST implement key rotation mechanisms to maintain security posture and respond to security events. This section defines the operational procedures for detecting and responding to superior key rotations and for subordinate key renewal.
 
 Periodic Trust Chain Verification
 """"""""""""""""""""""""""""""""""

--- a/docs/en/x5c-evaluation.rst
+++ b/docs/en/x5c-evaluation.rst
@@ -112,7 +112,7 @@ X.509 Certificate Validation Integration
 Federation entities SHOULD integrate X.509 Certificate validation procedures into their standard federation operations:
 
 	1. **Entity Configuration Updates**: Verify X.509 Certificate chains when processing authority hints and X.509 Certificate updates.
-	2. **Trust Chain Construction**: Validate all X.509 Certificates during trust chain building procedures.
+	2. **Trust Chain Construction**: Validate all X.509 Certificates during Trust Chain building procedures.
 	3. **X.509 PKI Operations**: Perform X.509 Certificate revocation checks using CRL endpoints.
 	4. **Protocol Certificate Management**: Validate self-issued protocol specific X.509 Certificate for internal services.
 	5. **Periodic Validation**: Implement regular X.509 Certificate and CRL validation schedules.

--- a/docs/en/x5c-evaluation.rst
+++ b/docs/en/x5c-evaluation.rst
@@ -170,7 +170,7 @@ Subordinate entities MUST perform periodic verification of their trust chain to 
 Federation Subordinates MUST:
 
 1. Fetch their own Subordinate Statement from immediate superior every 24 hours using the fetch endpoint defined in :ref:`trust-infrastructure:Federation API endpoints`.
-2. Verify validity and detect updates related tto the X.509 certificate of the Superior in the ``x5c`` field.
+2. Verify validity and detect updates related to the X.509 certificate of the Superior in the ``x5c`` field.
 3. Check for revocation or suspension status.
 4. Update local Entity Configuration when superior certificates change.
 

--- a/docs/en/x5c-evaluation.rst
+++ b/docs/en/x5c-evaluation.rst
@@ -163,7 +163,7 @@ Federation entities MUST implement key rotation mechanisms to maintain security 
 Superior Key Rotation
 """""""""""""""""""""""
 
-Subordinate entities MUST perform periodic verification of their trust chain to detect superior key rotations and ensure continued federation membership.
+Subordinate entities MUST perform periodic verification of their Trust Chain to detect superior key rotations and ensure continued federation membership.
 
 **Verification Requirements**
 

--- a/docs/en/x5c-evaluation.rst
+++ b/docs/en/x5c-evaluation.rst
@@ -169,7 +169,7 @@ Subordinate entities MUST perform periodic verification of their Trust Chain to 
 
 Federation Subordinates MUST:
 
-1. Fetch their own Subordinate Statement from immediate superior every 24 hours using the fetch endpoint defined in :ref:`trust-infrastructure:Federation API endpoints`.
+1. Periodically fetch their own Subordinate Statement from immediate superior using the fetch endpoint defined in :ref:`trust-infrastructure:Federation API endpoints`. This SHOULD be made within a time interval not superior that 24 hours.
 2. Verify validity and detect updates related to the X.509 certificate of the Superior in the ``x5c`` field.
 3. Check for revocation or suspension status.
 4. Update local Entity Configuration when superior certificates change.

--- a/docs/en/x5c-evaluation.rst
+++ b/docs/en/x5c-evaluation.rst
@@ -155,6 +155,79 @@ Federation entities MUST coordinate X.509 Certificate management with federation
 - **Federation Exit**: Ensure proper X.509 Certificate revocation during voluntary or supervisory body-initiated federation exit.
 
 
+Key Rotation Procedures
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Federation entities MUST implement key rotation mechanisms to maintain security posture and respond to security events. This section defines operational procedures for detecting and responding to superior key rotations and for subordinate key renewal.
+
+Periodic Trust Chain Verification
+""""""""""""""""""""""""""""""""""
+
+Subordinate entities MUST perform periodic verification of their trust chain to detect superior key rotations and ensure continued federation membership.
+
+**Verification Requirements**
+
+Federation subordinates MUST:
+
+1. Fetch their own Subordinate Statement from immediate superior every 24 hours using the fetch endpoint defined in :ref:`trust-infrastructure:Federation API endpoints`.
+2. Verify X.509 Certificate validity and detect certificate updates in the ``x5c`` field.
+3. Check for revocation or suspension status.
+4. Update local Entity Configuration when superior certificates change.
+
+**Detection Mechanisms**
+
+Subordinates MAY use one or more of the following mechanisms to detect changes:
+
+- **CRL/OCSP Verification**: Monitor Certificate Revocation Lists or Online Certificate Status Protocol responses to detect revocation of superior certificates as defined in :ref:`trust-infrastructure:X.509 Certificate Revocation`. Certificate revocation indicates superior key rotation is in progress.
+- **Fetch Endpoint**: Retrieve Subordinate Statement via ``GET {superior}/fetch?sub={subordinate_entity_id}`` to obtain current certificates.
+- **Events Endpoint**: Monitor ``GET {superior}/federation_subordinate_events_endpoint?sub={subordinate_entity_id}`` for ``jwks_update`` events. The Federation Subordinate Events endpoint returns historical track of registration events as defined in :ref:`trust-infrastructure:Federation API endpoints`.
+
+**Implementation**
+
+Subordinates SHOULD implement automated scheduling for:
+
+- Daily fetch operations to retrieve current Subordinate Statement.
+- X.509 Certificate chain validation after each fetch.
+- Automatic Entity Configuration updates when certificate changes detected.
+- Event monitoring for proactive change detection.
+
+Superior Key Rotation
+""""""""""""""""""""""
+
+When a superior entity (Trust Anchor or Intermediate) rotates its Federation Entity Key, all subordinate X.509 certificates MUST be reissued.
+
+**Rotation Procedure**
+
+1. **Key Revocation**: Superior publishes Certificate Revocation List (CRL) or Historical Keys (HK) entry revoking the old key as defined in :ref:`trust-infrastructure:X.509 Certificate Revocation`.
+2. **Entity Configuration Update**: Superior publishes new Entity Configuration signed with new Federation Entity Key.
+3. **X.509 Certificate Reissuance**: Superior reissues X.509 certificates to all subordinates using new key.
+4. **Certificate Publication**: Superior makes new certificates available on fetch endpoint.
+5. **Subordinate Detection**: Subordinates detect change during periodic fetch (within 24 hours).
+6. **Certificate Update**: Subordinates update ``x5c`` field in their Entity Configuration with new certificate.
+
+**Certificate Priority**
+
+When multiple X.509 certificates exist for the same subordinate public key, the certificate in the Subordinate Statement MUST take priority over the certificate in the subordinate's Entity Configuration.
+
+Subordinate Key Rotation
+"""""""""""""""""""""""""
+
+Subordinates rotate their Federation Entity Keys by submitting Certificate Signing Requests to their immediate superior following the same procedure as initial onboarding.
+
+**Rotation Procedure**
+
+1. **New Key Generation**: Subordinate generates new Federation Entity Key pair.
+2. **CSR Generation**: Subordinate generates PKCS #10 Certificate Signing Request for new key as defined in :ref:`entity-onboarding:Entity Onboarding`.
+3. **CSR Submission**: Subordinate submits CSR to superior entity using the same onboarding endpoint.
+4. **Certificate Issuance**: Superior validates CSR and issues new X.509 certificate.
+5. **Certificate Publication**: Superior makes new certificate available on fetch endpoint.
+6. **Certificate Retrieval**: Subordinate fetches updated Subordinate Statement containing new certificate.
+7. **Entity Configuration Update**: Subordinate adds new JWK with new certificate to Entity Configuration ``jwks`` array.
+
+.. note::
+   During key rotation, subordinates SHOULD maintain both old and new keys temporarily to ensure service continuity. The old key SHOULD be removed only after confirming successful propagation of the new key throughout the federation.
+
+
 Entity Lifecycle Management
 ----------------------------
 

--- a/docs/en/x5c-evaluation.rst
+++ b/docs/en/x5c-evaluation.rst
@@ -170,7 +170,7 @@ Subordinate entities MUST perform periodic verification of their trust chain to 
 Federation Subordinates MUST:
 
 1. Fetch their own Subordinate Statement from immediate superior every 24 hours using the fetch endpoint defined in :ref:`trust-infrastructure:Federation API endpoints`.
-2. Verify X.509 Certificate validity and detect certificate updates in the ``x5c`` field.
+2. Verify X.509 Certificate validity and detect the X.509 certificate updates in the ``x5c`` field.
 3. Check for revocation or suspension status.
 4. Update local Entity Configuration when superior certificates change.
 

--- a/docs/en/x5c-evaluation.rst
+++ b/docs/en/x5c-evaluation.rst
@@ -167,7 +167,7 @@ Subordinate entities MUST perform periodic verification of their trust chain to 
 
 **Verification Requirements**
 
-Federation subordinates MUST:
+Federation Subordinates MUST:
 
 1. Fetch their own Subordinate Statement from immediate superior every 24 hours using the fetch endpoint defined in :ref:`trust-infrastructure:Federation API endpoints`.
 2. Verify X.509 Certificate validity and detect certificate updates in the ``x5c`` field.

--- a/docs/en/x5c-evaluation.rst
+++ b/docs/en/x5c-evaluation.rst
@@ -169,10 +169,9 @@ Subordinate entities MUST perform periodic verification of their Trust Chain to 
 
 Federation Subordinates MUST:
 
-1. Periodically fetch their own Subordinate Statement from immediate superior using the fetch endpoint defined in :ref:`trust-infrastructure:Federation API endpoints`. This SHOULD be made within a time interval not superior that 24 hours.
-2. Verify validity and detect updates related to the X.509 certificate of the Superior in the ``x5c`` field.
-3. Check for revocation or suspension status.
-4. Update local Entity Configuration when superior certificates change.
+1. Periodically fetch their own Subordinate Statement from immediate superior using the fetch endpoint defined in :ref:`trust-infrastructure:Federation API endpoints`. This SHOULD be made within 24 hours.
+2. After fetching, verify the validity of the Superior's X.509 certificate in the ``x5c`` field, including checking for revocation or suspension status.
+3. Update local Entity Configuration when superior certificates change.
 
 **Detection Mechanisms**
 
@@ -205,7 +204,7 @@ When a superior entity (Trust Anchor or Intermediate) rotates its Federation Ent
 When multiple X.509 certificates exist for the same subordinate public key, the certificate in the Subordinate Statement MUST take priority over the certificate in the subordinate's Entity Configuration.
 
 .. note::
-  A superior entity cannot independently initiate a Subordinate Key rotation process. The Subordinate Key Rotation mechanism is always initiated by the Subordinate entity, see Section ::ref:`x5c-evaluation:Subordinate Key Rotation`.
+  A superior entity cannot independently initiate a Subordinate Key rotation process. The Subordinate Key Rotation mechanism is always initiated by the Subordinate entity, see Section :ref:`x5c-evaluation:Subordinate Key Rotation`.
 
 Subordinate Key Rotation
 """""""""""""""""""""""""

--- a/docs/en/x5c-evaluation.rst
+++ b/docs/en/x5c-evaluation.rst
@@ -160,8 +160,8 @@ Key Rotation Procedures
 
 Federation entities MUST implement key rotation mechanisms to maintain security posture and respond to security events. This section defines the operational procedures for detecting and responding to superior key rotations and for subordinate key renewal.
 
-Periodic Trust Chain Verification
-""""""""""""""""""""""""""""""""""
+Superior Key Rotation
+"""""""""""""""""""""""
 
 Subordinate entities MUST perform periodic verification of their trust chain to detect superior key rotations and ensure continued federation membership.
 
@@ -170,7 +170,7 @@ Subordinate entities MUST perform periodic verification of their trust chain to 
 Federation Subordinates MUST:
 
 1. Fetch their own Subordinate Statement from immediate superior every 24 hours using the fetch endpoint defined in :ref:`trust-infrastructure:Federation API endpoints`.
-2. Verify X.509 Certificate validity and detect the X.509 certificate updates in the ``x5c`` field.
+2. Verify validity and detect updates related tto the X.509 certificate of the Superior in the ``x5c`` field.
 3. Check for revocation or suspension status.
 4. Update local Entity Configuration when superior certificates change.
 
@@ -189,9 +189,6 @@ Subordinates SHOULD implement automated scheduling for:
 - Automatic Entity Configuration updates when certificate changes detected.
 - Event monitoring for proactive change detection.
 
-Superior Key Rotation
-""""""""""""""""""""""
-
 When a superior entity (Trust Anchor or Intermediate) rotates its Federation Entity Key, all subordinate X.509 certificates MUST be reissued.
 
 **Rotation Procedure**
@@ -206,6 +203,9 @@ When a superior entity (Trust Anchor or Intermediate) rotates its Federation Ent
 **Certificate Priority**
 
 When multiple X.509 certificates exist for the same subordinate public key, the certificate in the Subordinate Statement MUST take priority over the certificate in the subordinate's Entity Configuration.
+
+.. note::
+  A superior entity cannot independently initiate a Subordinate Key rotation process. The Subordinate Key Rotation mechanism is always initiated by the Subordinate entity, see Section ::ref:`x5c-evaluation:Subordinate Key Rotation`.
 
 Subordinate Key Rotation
 """""""""""""""""""""""""

--- a/docs/it/x5c-evaluation.rst
+++ b/docs/it/x5c-evaluation.rst
@@ -169,10 +169,9 @@ Le entità subordinate DEVONO eseguire la verifica periodica della propria trust
 
 I Subordinati della federazione DEVONO:
 
-1. Recuperare il proprio Subordinate Statement dal superiore immediato ogni 24 ore utilizzando il fetch endpoint definito in :ref:`trust-infrastructure:Endpoint delle API della Federazione`.
-2. Verificare la validità e rilevare gli aggiornamenti dei certificati X.509 del superiore nel campo ``x5c``.
-3. Verificare lo stato di revoca o sospensione.
-4. Aggiornare il proprio Entity Configuration quando cambiano i certificati superiori.
+1. Recuperare il proprio Subordinate Statement dal superiore immediato ogni 24 ore utilizzando il fetch endpoint definito in :ref:`trust-infrastructure:Endpoint delle API della Federazione`. Ciò DEVE essere fatto entro un intervallo di tempo non superiore a 24 ore.
+2. Verificare lo stato di revoca o sospensione.
+3. Aggiornare il proprio Entity Configuration quando cambiano i certificati superiori.
 
 **Meccanismi di Rilevamento**
 

--- a/docs/it/x5c-evaluation.rst
+++ b/docs/it/x5c-evaluation.rst
@@ -160,59 +160,57 @@ Procedure di Rotazione delle Chiavi
 
 Le entità federate DEVONO implementare meccanismi di rotazione delle chiavi per mantenere la postura di sicurezza e rispondere agli eventi di sicurezza. Questa sezione definisce le procedure operative per rilevare e rispondere alle rotazioni delle chiavi superiori e per il rinnovo delle chiavi subordinate.
 
-Verifica Periodica della Trust Chain
+Rotazione delle Chiavi Superiori
 """""""""""""""""""""""""""""""""""""
 
 Le entità subordinate DEVONO eseguire la verifica periodica della propria trust chain per rilevare le rotazioni delle chiavi superiori e garantire la continuità dell'appartenenza alla federazione.
 
 **Requisiti di Verifica**
 
-I subordinati della federazione DEVONO:
+I Subordinati della federazione DEVONO:
 
 1. Recuperare il proprio Subordinate Statement dal superiore immediato ogni 24 ore utilizzando il fetch endpoint definito in :ref:`trust-infrastructure:Endpoint delle API della Federazione`.
-2. Verificare la validità del Certificato X.509 e rilevare gli aggiornamenti dei certificati nel campo ``x5c``.
+2. Verificare la validità e rilevare gli aggiornamenti dei certificati X.509 del superiore nel campo ``x5c``.
 3. Verificare lo stato di revoca o sospensione.
 4. Aggiornare il proprio Entity Configuration quando cambiano i certificati superiori.
 
 **Meccanismi di Rilevamento**
 
-I subordinati POSSONO utilizzare uno o più dei seguenti meccanismi per rilevare le modifiche:
+I Subordinati POSSONO utilizzare uno o più dei seguenti meccanismi per rilevare le modifiche:
 
 - **Verifica CRL/OCSP**: Monitorare le Certificate Revocation List o le risposte del protocollo Online Certificate Status Protocol per rilevare la revoca dei certificati superiori come definito in :ref:`trust-infrastructure:Revoca dei Certificati X.509`. La revoca del certificato indica che è in corso la rotazione della chiave superiore.
 - **Fetch Endpoint**: Recuperare il Subordinate Statement tramite ``GET {superiore}/fetch?sub={entity_id_subordinato}`` per ottenere i certificati correnti.
 - **Events Endpoint**: Monitorare ``GET {superiore}/federation_subordinate_events_endpoint?sub={entity_id_subordinato}`` per gli eventi ``jwks_update``. Il Federation Subordinate Events endpoint restituisce la traccia storica degli eventi di registrazione come definito in :ref:`trust-infrastructure:Endpoint delle API della Federazione`.
 
-**Implementazione**
-
-I subordinati DOVREBBERO implementare la pianificazione automatizzata per:
+I Subordinati DOVREBBERO implementare la pianificazione automatizzata per:
 
 - Operazioni di fetch giornaliere per recuperare il Subordinate Statement corrente.
 - Validazione della catena di certificati X.509 dopo ogni fetch.
 - Aggiornamenti automatici dell'Entity Configuration quando vengono rilevate modifiche ai certificati.
 - Monitoraggio degli eventi per il rilevamento proattivo delle modifiche.
 
-Rotazione delle Chiavi Superiori
-"""""""""""""""""""""""""""""""""
-
-Quando un'entità superiore (Trust Anchor o Intermediate) ruota la propria Chiave dell'Entità Federata, tutti i certificati X.509 subordinati DEVONO essere riemessi.
+Quando un'entità superiore (Trust Anchor o Intermediate) ruota la propria Chiave dell'Entità Federata, tutti i certificati X.509 Subordinati DEVONO essere riemessi.
 
 **Procedura di Rotazione**
 
 1. **Revoca della Chiave**: Il superiore pubblica la Certificate Revocation List (CRL) o la voce Historical Keys (HK) revocando la vecchia chiave come definito in :ref:`trust-infrastructure:Revoca dei Certificati X.509`.
 2. **Aggiornamento Entity Configuration**: Il superiore pubblica la nuova Entity Configuration firmata con la nuova Chiave dell'Entità Federata.
-3. **Riemissione Certificati X.509**: Il superiore riemette i certificati X.509 a tutti i subordinati utilizzando la nuova chiave.
+3. **Riemissione Certificati X.509**: Il superiore riemette i certificati X.509 a tutti i Subordinati utilizzando la nuova chiave.
 4. **Pubblicazione Certificati**: Il superiore rende disponibili i nuovi certificati sul fetch endpoint.
-5. **Rilevamento Subordinato**: I subordinati rilevano la modifica durante il fetch periodico (entro 24 ore).
-6. **Aggiornamento Certificati**: I subordinati aggiornano il campo ``x5c`` nella propria Entity Configuration con il nuovo certificato.
+5. **Rilevamento Subordinato**: I Subordinati rilevano la modifica durante il fetch periodico (entro 24 ore).
+6. **Aggiornamento Certificati**: I Subordinati aggiornano il campo ``x5c`` nella propria Entity Configuration con il nuovo certificato.
 
 **Priorità dei Certificati**
 
 Quando esistono più certificati X.509 per la stessa chiave pubblica subordinata, il certificato nel Subordinate Statement DEVE avere priorità sul certificato nella Entity Configuration del subordinato.
 
+.. note::
+  Un'entità superiore non puà avviare autonomamente un processo di rotazione delle Chiavi Subordinate. Il meccanismo di rotazione delle Chiavi Subordinate è sempre avviato dall'entità Subordinata, vedi Sezione ::ref:`x5c-evaluation:Rotazione delle Chiavi Subordinate`.
+
 Rotazione delle Chiavi Subordinate
 """""""""""""""""""""""""""""""""""
 
-I subordinati ruotano le proprie Chiavi dell'Entità Federata inviando Certificate Signing Request al proprio superiore immediato seguendo la stessa procedura dell'onboarding iniziale.
+I Subordinati ruotano le proprie Chiavi dell'Entità Federata inviando Certificate Signing Request al proprio superiore immediato seguendo la stessa procedura dell'onboarding iniziale.
 
 **Procedura di Rotazione**
 
@@ -225,7 +223,7 @@ I subordinati ruotano le proprie Chiavi dell'Entità Federata inviando Certifica
 7. **Aggiornamento Entity Configuration**: Il subordinato aggiunge la nuova JWK con il nuovo certificato all'array ``jwks`` della Entity Configuration.
 
 .. note::
-   Durante la rotazione delle chiavi, i subordinati DOVREBBERO mantenere sia le chiavi vecchie che quelle nuove per garantire la continuità del servizio. La vecchia chiave DOVREBBE essere rimossa solo dopo aver confermato la corretta propagazione della nuova chiave in tutta la federazione.
+   Durante la rotazione delle chiavi, i Subordinati DOVREBBERO mantenere sia le chiavi vecchie che quelle nuove per garantire la continuità del servizio. La vecchia chiave DOVREBBE essere rimossa solo dopo aver confermato la corretta propagazione della nuova chiave in tutta la federazione.
 
 
 Gestione del Ciclo di Vita dell'Entità

--- a/docs/it/x5c-evaluation.rst
+++ b/docs/it/x5c-evaluation.rst
@@ -155,6 +155,79 @@ Le entità federate DEVONO coordinare la gestione dei Certificati X.509 con le p
 - **Uscita dalla Federazione**: Garantire la revoca corretta dei Certificati X.509 durante l'uscita volontaria o avviata dall'organo di supervisione dalla federazione.
 
 
+Procedure di Rotazione delle Chiavi
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Le entità federate DEVONO implementare meccanismi di rotazione delle chiavi per mantenere la postura di sicurezza e rispondere agli eventi di sicurezza. Questa sezione definisce le procedure operative per rilevare e rispondere alle rotazioni delle chiavi superiori e per il rinnovo delle chiavi subordinate.
+
+Verifica Periodica della Trust Chain
+"""""""""""""""""""""""""""""""""""""
+
+Le entità subordinate DEVONO eseguire la verifica periodica della propria trust chain per rilevare le rotazioni delle chiavi superiori e garantire la continuità dell'appartenenza alla federazione.
+
+**Requisiti di Verifica**
+
+I subordinati della federazione DEVONO:
+
+1. Recuperare il proprio Subordinate Statement dal superiore immediato ogni 24 ore utilizzando il fetch endpoint definito in :ref:`trust-infrastructure:Endpoint delle API della Federazione`.
+2. Verificare la validità del Certificato X.509 e rilevare gli aggiornamenti dei certificati nel campo ``x5c``.
+3. Verificare lo stato di revoca o sospensione.
+4. Aggiornare il proprio Entity Configuration quando cambiano i certificati superiori.
+
+**Meccanismi di Rilevamento**
+
+I subordinati POSSONO utilizzare uno o più dei seguenti meccanismi per rilevare le modifiche:
+
+- **Verifica CRL/OCSP**: Monitorare le Certificate Revocation List o le risposte del protocollo Online Certificate Status Protocol per rilevare la revoca dei certificati superiori come definito in :ref:`trust-infrastructure:Revoca dei Certificati X.509`. La revoca del certificato indica che è in corso la rotazione della chiave superiore.
+- **Fetch Endpoint**: Recuperare il Subordinate Statement tramite ``GET {superiore}/fetch?sub={entity_id_subordinato}`` per ottenere i certificati correnti.
+- **Events Endpoint**: Monitorare ``GET {superiore}/federation_subordinate_events_endpoint?sub={entity_id_subordinato}`` per gli eventi ``jwks_update``. Il Federation Subordinate Events endpoint restituisce la traccia storica degli eventi di registrazione come definito in :ref:`trust-infrastructure:Endpoint delle API della Federazione`.
+
+**Implementazione**
+
+I subordinati DOVREBBERO implementare la pianificazione automatizzata per:
+
+- Operazioni di fetch giornaliere per recuperare il Subordinate Statement corrente.
+- Validazione della catena di certificati X.509 dopo ogni fetch.
+- Aggiornamenti automatici dell'Entity Configuration quando vengono rilevate modifiche ai certificati.
+- Monitoraggio degli eventi per il rilevamento proattivo delle modifiche.
+
+Rotazione delle Chiavi Superiori
+"""""""""""""""""""""""""""""""""
+
+Quando un'entità superiore (Trust Anchor o Intermediate) ruota la propria Chiave dell'Entità Federata, tutti i certificati X.509 subordinati DEVONO essere riemessi.
+
+**Procedura di Rotazione**
+
+1. **Revoca della Chiave**: Il superiore pubblica la Certificate Revocation List (CRL) o la voce Historical Keys (HK) revocando la vecchia chiave come definito in :ref:`trust-infrastructure:Revoca dei Certificati X.509`.
+2. **Aggiornamento Entity Configuration**: Il superiore pubblica la nuova Entity Configuration firmata con la nuova Chiave dell'Entità Federata.
+3. **Riemissione Certificati X.509**: Il superiore riemette i certificati X.509 a tutti i subordinati utilizzando la nuova chiave.
+4. **Pubblicazione Certificati**: Il superiore rende disponibili i nuovi certificati sul fetch endpoint.
+5. **Rilevamento Subordinato**: I subordinati rilevano la modifica durante il fetch periodico (entro 24 ore).
+6. **Aggiornamento Certificati**: I subordinati aggiornano il campo ``x5c`` nella propria Entity Configuration con il nuovo certificato.
+
+**Priorità dei Certificati**
+
+Quando esistono più certificati X.509 per la stessa chiave pubblica subordinata, il certificato nel Subordinate Statement DEVE avere priorità sul certificato nella Entity Configuration del subordinato.
+
+Rotazione delle Chiavi Subordinate
+"""""""""""""""""""""""""""""""""""
+
+I subordinati ruotano le proprie Chiavi dell'Entità Federata inviando Certificate Signing Request al proprio superiore immediato seguendo la stessa procedura dell'onboarding iniziale.
+
+**Procedura di Rotazione**
+
+1. **Generazione Nuova Chiave**: Il subordinato genera una nuova coppia di Chiavi dell'Entità Federata.
+2. **Generazione CSR**: Il subordinato genera un Certificate Signing Request PKCS #10 per la nuova chiave come definito in :ref:`entity-onboarding:Onboarding delle Entità`.
+3. **Invio CSR**: Il subordinato invia il CSR all'entità superiore utilizzando lo stesso endpoint di onboarding.
+4. **Emissione Certificato**: Il superiore valida il CSR ed emette un nuovo certificato X.509.
+5. **Pubblicazione Certificato**: Il superiore rende disponibile il nuovo certificato sul fetch endpoint.
+6. **Recupero Certificato**: Il subordinato recupera il Subordinate Statement aggiornato contenente il nuovo certificato.
+7. **Aggiornamento Entity Configuration**: Il subordinato aggiunge la nuova JWK con il nuovo certificato all'array ``jwks`` della Entity Configuration.
+
+.. note::
+   Durante la rotazione delle chiavi, i subordinati DOVREBBERO mantenere sia le chiavi vecchie che quelle nuove per garantire la continuità del servizio. La vecchia chiave DOVREBBE essere rimossa solo dopo aver confermato la corretta propagazione della nuova chiave in tutta la federazione.
+
+
 Gestione del Ciclo di Vita dell'Entità
 --------------------------------------
 

--- a/docs/it/x5c-evaluation.rst
+++ b/docs/it/x5c-evaluation.rst
@@ -169,7 +169,7 @@ Le entità subordinate DEVONO eseguire la verifica periodica della propria Trust
 
 I Subordinati della federazione DEVONO:
 
-1. Recuperare il proprio Subordinate Statement dal superiore immediato ogni 24 ore utilizzando il fetch endpoint definito in :ref:`trust-infrastructure:Endpoint delle API della Federazione`. Ciò DEVE essere fatto entro un intervallo di tempo non superiore a 24 ore.
+1. Recuperare il proprio Subordinate Statement dal superiore immediato ogni 24 ore utilizzando il fetch endpoint definito in :ref:`trust-infrastructure:Endpoint delle API della Federazione`. Ciò DOVREBBE essere fatto entro un intervallo di tempo non superiore a 24 ore.
 2. Verificare lo stato di revoca o sospensione.
 3. Aggiornare il proprio Entity Configuration quando cambiano i certificati superiori.
 
@@ -196,7 +196,7 @@ Quando un'entità superiore (Trust Anchor o Intermediate) ruota la propria Chiav
 2. **Aggiornamento Entity Configuration**: Il superiore pubblica la nuova Entity Configuration firmata con la nuova Chiave dell'Entità Federata.
 3. **Riemissione Certificati X.509**: Il superiore riemette i certificati X.509 a tutti i Subordinati utilizzando la nuova chiave.
 4. **Pubblicazione Certificati**: Il superiore rende disponibili i nuovi certificati sul fetch endpoint.
-5. **Rilevamento Subordinato**: I Subordinati rilevano la modifica durante il fetch periodico (entro 24 ore).
+5. **Rilevamento Subordinato**: I Subordinati rilevano la modifica al successivo fetch programmato (al massimo entro 24 ore dalla pubblicazione della modifica).
 6. **Aggiornamento Certificati**: I Subordinati aggiornano il campo ``x5c`` nella propria Entity Configuration con il nuovo certificato.
 
 **Priorità dei Certificati**
@@ -204,7 +204,7 @@ Quando un'entità superiore (Trust Anchor o Intermediate) ruota la propria Chiav
 Quando esistono più certificati X.509 per la stessa chiave pubblica subordinata, il certificato nel Subordinate Statement DEVE avere priorità sul certificato nella Entity Configuration del subordinato.
 
 .. note::
-  Un'entità superiore non può avviare autonomamente un processo di rotazione delle Chiavi Subordinate. Il meccanismo di rotazione delle Chiavi Subordinate è sempre avviato dall'entità Subordinata, vedi Sezione ::ref:`x5c-evaluation:Rotazione delle Chiavi Subordinate`.
+  Un'entità superiore non può avviare autonomamente un processo di rotazione delle Chiavi Subordinate. Il meccanismo di rotazione delle Chiavi Subordinate è sempre avviato dall'entità Subordinata, vedi Sezione :ref:`x5c-evaluation:Rotazione delle Chiavi Subordinate`.
 
 Rotazione delle Chiavi Subordinate
 """""""""""""""""""""""""""""""""""

--- a/docs/it/x5c-evaluation.rst
+++ b/docs/it/x5c-evaluation.rst
@@ -163,7 +163,7 @@ Le entità federate DEVONO implementare meccanismi di rotazione delle chiavi per
 Rotazione delle Chiavi Superiori
 """""""""""""""""""""""""""""""""""""
 
-Le entità subordinate DEVONO eseguire la verifica periodica della propria trust chain per rilevare le rotazioni delle chiavi superiori e garantire la continuità dell'appartenenza alla federazione.
+Le entità subordinate DEVONO eseguire la verifica periodica della propria Trust Chain per rilevare le rotazioni delle chiavi superiori e garantire la continuità dell'appartenenza alla federazione.
 
 **Requisiti di Verifica**
 

--- a/docs/it/x5c-evaluation.rst
+++ b/docs/it/x5c-evaluation.rst
@@ -205,7 +205,7 @@ Quando un'entità superiore (Trust Anchor o Intermediate) ruota la propria Chiav
 Quando esistono più certificati X.509 per la stessa chiave pubblica subordinata, il certificato nel Subordinate Statement DEVE avere priorità sul certificato nella Entity Configuration del subordinato.
 
 .. note::
-  Un'entità superiore non puà avviare autonomamente un processo di rotazione delle Chiavi Subordinate. Il meccanismo di rotazione delle Chiavi Subordinate è sempre avviato dall'entità Subordinata, vedi Sezione ::ref:`x5c-evaluation:Rotazione delle Chiavi Subordinate`.
+  Un'entità superiore non può avviare autonomamente un processo di rotazione delle Chiavi Subordinate. Il meccanismo di rotazione delle Chiavi Subordinate è sempre avviato dall'entità Subordinata, vedi Sezione ::ref:`x5c-evaluation:Rotazione delle Chiavi Subordinate`.
 
 Rotazione delle Chiavi Subordinate
 """""""""""""""""""""""""""""""""""


### PR DESCRIPTION
This PR resolves #917 

In particular, the PR adds a new "Key Rotation Procedures" subsection to section "9. X.509 Certificate Management Operations" covering:

- Periodic trust chain verification with CRL/OCSP, fetch, and events detection.
- Superior key rotation procedure (with certificate reissuance).
- Subordinate key rotation via CSR submission.

