### PR TITLE
Add CI_061a test case for PKCE code_verifier validation (IT/EN)

### DIFF
--- a/docs/en/credential-issuance-low-level.rst
+++ b/docs/en/credential-issuance-low-level.rst
@@ -228,6 +228,7 @@ The ``OAuth-Client-Attestation`` is signed using the private key bound to the Wa
    2. It MUST ensure the Authorization ``code`` is valid and has not been previously used (:rfc:`6749`).
    3. It MUST ensure the ``redirect_uri`` matches the value included in the previous Request Object (see Section 3.1.3.1. of [`OIDC`_]).
    4. It MUST validate the DPoP Proof JWT, according to (:rfc:`9449`) Section 4.3.
+   5. It MUST verify the ``code_verifier`` parameter according to the PKCE mechanism, ensuring it matches the ``code_challenge`` associated with the authorization code as defined in Section 4.6 of :rfc:`7636`; otherwise, the request MUST be rejected (:ref:`CI_061a <credential-issuer-test-matrix>`).
 
 .. code-block:: http
 

--- a/docs/en/test-plans-credential-issuer.rst
+++ b/docs/en/test-plans-credential-issuer.rst
@@ -306,7 +306,7 @@ This section provides the set of test cases designed for technical implementers 
     - Credential Issuer verifies the Authorization code is valid and has not been previously used (:rfc:`6749`).
   * - CI_061a
     - Issuance, Security
-    - PKCE code_verifier Verification in Token Request
+    - PKCE ``code_verifier`` Verification in Token Request
     - The Credential Issuer verifies that the ``code_verifier`` parameter is present and matches the ``code_challenge`` associated with the authorization code (:rfc:`7636`); in case of mismatch, the request is rejected.  
   * - CI_062
     - Issuance, Security

--- a/docs/en/test-plans-credential-issuer.rst
+++ b/docs/en/test-plans-credential-issuer.rst
@@ -304,6 +304,10 @@ This section provides the set of test cases designed for technical implementers 
     - Issuance, Security
     - Authorization Code Validity and Usage Check of the Token Request
     - Credential Issuer verifies the Authorization code is valid and has not been previously used (:rfc:`6749`).
+  * - CI_061a
+    - Issuance, Security
+    - PKCE code_verifier Verification in Token Request
+    - The Credential Issuer verifies that the ``code_verifier`` parameter is present and matches the ``code_challenge`` associated with the authorization code (:rfc:`7636`); in case of mismatch, the request is rejected.  
   * - CI_062
     - Issuance, Security
     - Redirect URI Matching Validation of the Token Request

--- a/docs/it/credential-issuance-low-level.rst
+++ b/docs/it/credential-issuance-low-level.rst
@@ -217,6 +217,7 @@ L'``OAuth-Client-Attestation`` è firmato utilizzando la chiave privata associat
    2. DEVE assicurarsi che il ``code`` di autorizzazione sia valido e non sia stato utilizzato in precedenza (:rfc:`6749`).
    3. DEVE assicurarsi che il ``redirect_uri`` corrisponda al valore incluso nel precedente `Request Object` (vedi Sezione 3.1.3.1. di [`OIDC`_]).
    4. DEVE validare il JWT di `DPoP proof`, secondo la Sezione 4.3 di (:rfc:`9449`).
+   5. DEVE verificare il parametro ``code_verifier`` secondo il meccanismo PKCE, assicurandosi che corrisponda al ``code_challenge`` associato al codice di autorizzazione come definito nella Sezione 4.6 di :rfc:`7636`; in caso contrario, la richiesta DEVE essere rifiutata (:ref:`CI_061a <test-plans-credential-issuer:matrice dei test per il credential issuer>`).
 
 .. code-block:: http
 

--- a/docs/it/test-plans-credential-issuer.rst
+++ b/docs/it/test-plans-credential-issuer.rst
@@ -306,7 +306,7 @@ Questa sezione fornisce l'insieme dei test progettati per implementatori tecnici
     - Il Credential Issuer verifica che il codice di autorizzazione sia valido e non sia stato precedentemente utilizzato (:rfc:`6749`).
   * - CI_061a
     - Emissione, Sicurezza
-    - Verifica del code_verifier PKCE nella Richiesta di Token
+    - Verifica del ``code_verifier`` PKCE nella Richiesta di Token
     - Il Credential Issuer verifica che il parametro ``code_verifier`` sia presente e corrisponda al ``code_challenge`` associato al codice di autorizzazione (:rfc:`7636`); in caso di mancata corrispondenza, la richiesta viene rifiutata.
   * - CI_062
     - Emissione, Sicurezza

--- a/docs/it/test-plans-credential-issuer.rst
+++ b/docs/it/test-plans-credential-issuer.rst
@@ -304,6 +304,10 @@ Questa sezione fornisce l'insieme dei test progettati per implementatori tecnici
     - Emissione, Sicurezza
     - Verifica di validità e utilizzo del Codice di Autorizzazione nella Richiesta di Token
     - Il Credential Issuer verifica che il codice di autorizzazione sia valido e non sia stato precedentemente utilizzato (:rfc:`6749`).
+  * - CI_061a
+    - Emissione, Sicurezza
+    - Verifica del code_verifier PKCE nella Richiesta di Token
+    - Il Credential Issuer verifica che il parametro ``code_verifier`` sia presente e corrisponda al ``code_challenge`` associato al codice di autorizzazione (:rfc:`7636`); in caso di mancata corrispondenza, la richiesta viene rifiutata.
   * - CI_062
     - Emissione, Sicurezza
     - Validazione della corrispondenza del Redirect URI nella Richiesta di Token


### PR DESCRIPTION
## Title
Add CI_061a test case for PKCE code_verifier validation (IT/EN)

## Content
This PR introduces a new test case, `CI_061a`, to explicitly verify the `code_verifier` parameter during the Token Request, ensuring compliance with **RFC 7636** (PKCE).

**Changes:**
- **Test Plans (IT/EN):** Added `CI_061a` to `test-plans-credential-issuer.rst`. The test requires the Issuer to reject requests where `code_verifier` is missing or does not match the `code_challenge`.
- **Low-Level Flows (IT/EN):** Updated `credential-issuance-low-level.rst` (Token Request section) to include the mandatory check for `code_verifier` as step 5, referencing the new test case and **RFC 7636 Section 4.6**.

**Motivation:**
Previous test cases (`CI_060`, `CI_061`) covered Authorization Code validity but did not explicitly enforce the PKCE check (`code_verifier` vs `code_challenge`), which is critical for preventing authorization code interception attacks.

## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [ ] Example files 
- [x] Ask for review
