### PR TITLE
PDF: fix malformed index by using Sphinx .ist style file

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -78,7 +78,7 @@ jobs:
           lualatex -interaction=nonstopmode -file-line-error "$SETTINGS_FILE_NAME.tex" 2>&1 | grep -E "Warning|Error" 
           
           echo "Processing index..."
-          makeindex "$SETTINGS_FILE_NAME.idx" || true
+          makeindex -s python.ist "$SETTINGS_FILE_NAME.idx" || true
           
           echo "=== Second LaTeX run ==="
           lualatex -interaction=nonstopmode -file-line-error "$SETTINGS_FILE_NAME.tex" 2>&1 | grep -E "Warning|Error" 
@@ -99,7 +99,7 @@ jobs:
           lualatex -interaction=nonstopmode -file-line-error "$SETTINGS_FILE_NAME.tex" 2>&1 | grep -E "Warning|Error" 
           
           echo "Processing index..."
-          makeindex "$SETTINGS_FILE_NAME.idx" || true
+          makeindex -s python.ist "$SETTINGS_FILE_NAME.idx" || true
           
           echo "=== Second LaTeX run ==="
           lualatex -interaction=nonstopmode -file-line-error "$SETTINGS_FILE_NAME.tex" 2>&1 | grep -E "Warning|Error" 


### PR DESCRIPTION
This PR resolves #918 

The file python.ist generated by sphinx defines how to process the special macro \spxentry. The problem was that, without the .ist file, makeindex cannot understand the Sphinx syntax and generates a malformed index with visible "raw" LaTeX commands. 

We added the flag -s python.ist to the makeindex command to enable it to recognize the macro correctly. 