### PR TITLE
fix: build title name

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # -- PROJECT Variables ----------------------------------------------------
-settings_project_name = "IT-Wallet Technical Documentation"
+settings_project_name = "IT-Wallet Technical Specifications"
 # settings_copyright_copyleft = 'Dipartimento per la Trasformazione Digitale'
 settings_editor_name = 'Dipartimento per la Trasformazione Digitale'
 settings_doc_version = '1.3.3'

--- a/docs/it/conf.py
+++ b/docs/it/conf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # -- PROJECT Variables ----------------------------------------------------
-settings_project_name = "IT-Wallet Technical Documentation"
+settings_project_name = "IT-Wallet Technical Specifications"
 # settings_copyright_copyleft = 'Dipartimento per la Trasformazione Digitale'
 settings_editor_name = 'Dipartimento per la Trasformazione Digitale'
 settings_doc_version = '1.3.3'


### PR DESCRIPTION
According to the national guidelines, these are the Technical Specifications and not the Technical Documentation
