### PR TITLE
fix: RST build fix

### DIFF
--- a/docs/en/functionalities.rst
+++ b/docs/en/functionalities.rst
@@ -228,6 +228,7 @@ The flow is shown below with illustrative wireframes.
     Example of the User Experience during the issuance an Authentic Electronic Attestation from Authentic Source.
 
 .. only:: format_latex
+
   .. figure:: ./images/pdf/Issuance-from-Authentic-Source.pdf
     :alt: Example of User Experience in the issuance an Authentic Electronic Attestation from Authentic Source.
     :width: 100%
@@ -410,6 +411,7 @@ The flow is shown below with illustrative wireframes.
     Example of User Experience in remote, same-device presentation.
 
 .. only:: format_latex
+
   .. figure:: ./images/pdf/Remote-presentation-same-device.pdf
     :alt: Example of User Experience in remote, same-device presentation.
     :width: 100%
@@ -439,6 +441,7 @@ The flow is shown below with illustrative wireframes.
 
 
 .. only:: format_latex
+
   .. figure:: ./images/pdf/Remote-presentation-cross-device.pdf
     :alt: Example of User Experience in remote, cross-device presentation.
     :width: 100%
@@ -686,6 +689,7 @@ Both flows are shown below with illustrative wireframes.
     Example of same-device Authentication User Experience.
 
 .. only:: format_latex
+
   .. figure:: ./images/pdf/Authentication-same-device.pdf
     :alt: Example of same-device Authentication User Experience.
     :width: 100%
@@ -701,6 +705,7 @@ Both flows are shown below with illustrative wireframes.
     Example of cross-device Authentication User Experience.
 
 .. only:: format_latex
+
   .. figure:: ./images/pdf/Authentication-cross-device.pdf
     :alt: Example of cross-device Authentication User Experience.
     :width: 100%
@@ -838,6 +843,7 @@ The flow is shown below with illustrative wireframes.
      Example of User Experience in Updating an Electronic Attestation.
 
 .. only:: format_latex
+
   .. figure:: ./images/pdf/Update-EAA.pdf
     :alt: Example of User Experience in Updating an Electronic Attestation
     :width: 100%
@@ -880,6 +886,7 @@ The flow is shown below with illustrative wireframes.
 
 
 .. only:: format_latex
+
   .. figure:: ./images/pdf/Revocation-EAA-from-wallet.pdf
     :alt: Example of User Experience in Revoking an Electronic Attestation.
     :width: 100%
@@ -950,6 +957,7 @@ The flow is shown below with illustrative wireframes.
 
 
 .. only:: format_latex
+
   .. figure:: ./images/pdf/wallet-deactivation.pdf
     :alt: Example of User Experience in Deactivating a Wallet Instance
     :width: 100%

--- a/docs/it/algorithms.rst
+++ b/docs/it/algorithms.rst
@@ -1,5 +1,6 @@
 .. include:: ../common/common_definitions.rst
 
+.. _algorithms-cryptographic-algorithms:
 
 Algoritmi Crittografici
 =======================

--- a/docs/it/authentic-sources.rst
+++ b/docs/it/authentic-sources.rst
@@ -4,7 +4,7 @@
 Fonti Autentiche
 ================
 
-Le Fonti Autentiche forniscono gli Attributi dell'Utente ai Fornitori di Attestati Elettronici consentendo loro il rilascio degli Attestati Elettronici. Durante il Flusso di Emissione, i Fornitori di Attestati Elettronici richiedono alle Fonti Autentiche gli attributi necessari per fornire l'Attestato Elettronico richiesto dall'Utente. Le Fonti Autentiche POSSONO anche fornire una Credential Offer legata ai loro Fornitori di Attestati Elettronici come definito nella Sezione :ref:`credential-issuance-low-level:Credential Offer Flow`.
+Le Fonti Autentiche forniscono gli Attributi dell'Utente ai Fornitori di Attestati Elettronici consentendo loro il rilascio degli Attestati Elettronici. Durante il Flusso di Emissione, i Fornitori di Attestati Elettronici richiedono alle Fonti Autentiche gli attributi necessari per fornire l'Attestato Elettronico richiesto dall'Utente. Le Fonti Autentiche POSSONO anche fornire una Credential Offer legata ai loro Fornitori di Attestati Elettronici come definito nella Sezione :ref:`credential-issuance-low-level-credential-offer-flow`.
 
 Le Fonti Autentiche Pubbliche DEVONO interagire con i Fornitori di Attestati Elettronici tramite PDND secondo le regole definite nella Sezione :ref:`e-service-pdnd:e-Service PDND` e nella Sezione :ref:`credential-revocation:Aggiornamento dello Stato da parte delle Fonti Autentiche`. Vedere anche la Sezione :ref:`authentic-source-endpoint:Catalogo degli e-Service PDND delle Fonti Autentiche` per ulteriori dettagli.
 

--- a/docs/it/credential-data-model.rst
+++ b/docs/it/credential-data-model.rst
@@ -48,6 +48,8 @@ La seguente tabella definisce gli attributi di metadati comuni che sono applicab
 
 Le sezioni seguenti forniscono gli attributi specifici del formato e una mappatura degli attributi di metadati sopra indicati ai parametri tecnici specifici del formato quando la credenziale è codificata in formato SD-JWT VC o mdoc-CBOR.
 
+.. _credential-data-model-attestato-elettronico-in-formato-sd-jwt-vc:
+
 Formato Attestato Elettronico SD-JWT-VC
 ----------------------------------------
 
@@ -301,6 +303,8 @@ Di seguito è riportato un esempio non normativo.
       ...
     }
 
+
+.. _credential-data-model-attestato-elettronico-in-formato-mdoc-cbor:
 
 Formato Attestato Elettronico mdoc-CBOR
 ------------------------------------------

--- a/docs/it/credential-issuance-l2plus.rst
+++ b/docs/it/credential-issuance-l2plus.rst
@@ -749,7 +749,7 @@ Inoltre, ogni nonce ha uno scopo di sicurezza specifico:
 Metadati del Provider PID
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In aggiunta ai valori ``trust_frameworks_supported`` definiti nella sezione :ref:`credential-issuer-metadata-metadata-for-openid-credential-issuer`, i Metadati del Provider PID per ``openid_credential_issuer`` DEVONO anche supportare il valore ``it_l2+document_proof`` indicante il protocollo di Autenticazione multi-step descritto in questa Specifica.
+In aggiunta ai valori ``trust_frameworks_supported`` definiti nella sezione :ref:`credential-issuer-metadata-metadata-per-openid-credential-issuer`, i Metadati del Provider PID per ``openid_credential_issuer`` DEVONO anche supportare il valore ``it_l2+document_proof`` indicante il protocollo di Autenticazione multi-step descritto in questa Specifica.
 
 Controlli di Sicurezza
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/it/credential-issuance-l2plus.rst
+++ b/docs/it/credential-issuance-l2plus.rst
@@ -749,7 +749,7 @@ Inoltre, ogni nonce ha uno scopo di sicurezza specifico:
 Metadati del Provider PID
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In aggiunta ai valori ``trust_frameworks_supported`` definiti nella sezione :ref:`credential-issuer-metadata:Metadata for openid_credential_issuer`, i Metadati del Provider PID per ``openid_credential_issuer`` DEVONO anche supportare il valore ``it_l2+document_proof`` indicante il protocollo di Autenticazione multi-step descritto in questa Specifica.
+In aggiunta ai valori ``trust_frameworks_supported`` definiti nella sezione :ref:`credential-issuer-metadata-metadata-for-openid-credential-issuer`, i Metadati del Provider PID per ``openid_credential_issuer`` DEVONO anche supportare il valore ``it_l2+document_proof`` indicante il protocollo di Autenticazione multi-step descritto in questa Specifica.
 
 Controlli di Sicurezza
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/it/credential-issuance-low-level.rst
+++ b/docs/it/credential-issuance-low-level.rst
@@ -596,6 +596,7 @@ Per garantire l'integrità e la sicurezza del Re-issuance Flow, si applicano le 
   - Consenso dell'Utente: Per i Re-issuance Flow attivati da modifiche agli attributi, il consenso dell'Utente DEVE essere ottenuto prima di memorizzare il nuovo Attestato Elettronico.
   - Refresh Token vincolato al mittente: I Refresh Token DEVONO essere crittograficamente vincolati all'Istanza del Wallet utilizzando il protocollo DPoP. Ciò mitiga il rischio di uso improprio del token, garantendo che solo l'Istanza del Wallet prevista possa utilizzarlo.
 
+.. _credential-issuance-low-level-credential-offer-flow:
 
 Flusso Credential Offer
 -----------------------

--- a/docs/it/credential-issuer-metadata.rst
+++ b/docs/it/credential-issuer-metadata.rst
@@ -59,9 +59,9 @@ I Metadata *oauth_authorization_server* DEVONO contenere i seguenti parametri.
     - JSON Web Key Set contenente le chiavi crittografiche per '*authorization server*. Vedi `OID-FED`_ Sezione 5.2.1 e `JWK`_.
 
 .. important::
-  Se ``token_endpoint_auth_methods_supported`` include ``attest_jwt_client_auth``, l’Authorization Server DEVE includere entrambi ``client_attestation_signing_alg_values_supported`` e ``client_attestation_pop_signing_alg_values_supported`` nei propri metadati. I client DOVREBBERO recuperare e analizzare i metadati per rilevare supporto e requisiti di algoritmo per l’Attestation-Based Client Authentication e, in caso di incompatibilità, POSSONO ottenere una nuova attestation con un algoritmo supportato.
+  Se ``token_endpoint_auth_methods_supported`` include ``attest_jwt_client_auth``, l'Authorization Server DEVE includere entrambi ``client_attestation_signing_alg_values_supported`` e ``client_attestation_pop_signing_alg_values_supported`` nei propri metadati. I client DOVREBBERO recuperare e analizzare i metadati per rilevare supporto e requisiti di algoritmo per l'Attestation-Based Client Authentication e, in caso di incompatibilità, POSSONO ottenere una nuova attestation con un algoritmo supportato.
 
-.. _credential-issuer-metadata-metadata-for-openid-credential-issuer:
+.. _credential-issuer-metadata-metadata-per-openid-credential-issuer:
 
 Metadata per openid_credential_issuer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/it/credential-issuer-metadata.rst
+++ b/docs/it/credential-issuer-metadata.rst
@@ -61,6 +61,7 @@ I Metadata *oauth_authorization_server* DEVONO contenere i seguenti parametri.
 .. important::
   Se ``token_endpoint_auth_methods_supported`` include ``attest_jwt_client_auth``, l’Authorization Server DEVE includere entrambi ``client_attestation_signing_alg_values_supported`` e ``client_attestation_pop_signing_alg_values_supported`` nei propri metadati. I client DOVREBBERO recuperare e analizzare i metadati per rilevare supporto e requisiti di algoritmo per l’Attestation-Based Client Authentication e, in caso di incompatibilità, POSSONO ottenere una nuova attestation con un algoritmo supportato.
 
+.. _credential-issuer-metadata-metadata-for-openid-credential-issuer:
 
 Metadata per openid_credential_issuer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -105,8 +106,8 @@ I Metadata *openid_credential_issuer* DEVONO contenere i seguenti *claims*.
         - **cryptographic_binding_methods_supported**: Array JSON di stringhe *case sensitive* che identificano la rappresentazione della chiave crittografica di *binding* dell'Attestato Elettronico emesso. Il Fornitore di Attestato Elettronico DEVE supportare il valore "*jwk*" per il formato "dc+sd-jwt" e "*cose_key*" per "mso_mdoc".
         - **credential_signing_alg_values_supported**: Array JSON di stringhe *case sensitive* che identificano gli algoritmi che il Fornitore di Attestato Elettronico DEVE supportare per firmare l'Attestato Elettronico emesso. Vedi Sezione :ref:`algorithms:Algoritmi Crittografici` per maggiori dettagli.
         - **proof_types_supported**: Oggetto JSON che fornisce informazioni dettagliate sulle *key proof* supportate dal Fornitore di Attestato Elettronico. Consiste in un elenco di coppie nome/valore, dove ogni nome identifica in modo univoco il *proof type* supportato. Il Fornitore di Attestato Elettronico DEVE supportare almeno "*jwt*" come definito in `OpenID4VCI`_ Appendice F.1. Il valore associato a ciascuna coppia nome/valore è un oggetto JSON contenente informazioni relative alla *key proof(s)*. Il Fornitore di Attestato Elettronico DEVE supportare almeno il parametro **proof_signing_alg_values_supported** che DEVE essere un Array JSON di stringhe *case sensitive* che identificano gli algoritmi supportati (vedi Sezione :ref:`algorithms:Algoritmi Crittografici` per maggiori dettagli sugli algoritmi supportati). Il Fornitore di Attestato Elettronico PUÒ supportare il parametro **key_attestations_required** come definito nella Sezione 12.2 di `OpenID4VCI`_.
-        - **vct**: RICHIESTO solo se ``format`` è valorizzato con "*dc+sd-jwt*". Come definito in [:ref:`credential-data-model:Attestato Elettronico in formato SD-JWT-VC`].        
-        - **doctype**: RICHIESTO solo se ``format`` è valorizzato con "*mso_mdoc*". Come definito in [:ref:`credential-data-model:Attestato Elettronico in formato mdoc-CBOR`].
+        - **vct**: RICHIESTO solo se ``format`` è valorizzato con "*dc+sd-jwt*". Come definito in :ref:`credential-data-model-attestato-elettronico-in-formato-sd-jwt-vc`.        
+        - **doctype**: RICHIESTO solo se ``format`` è valorizzato con "*mso_mdoc*". Come definito in :ref:`credential-data-model-attestato-elettronico-in-formato-mdoc-cbor`.
         - **credential_metadata**: OBBLIGATORIO. Oggetto contenente informazioni rilevanti per l'utilizzo e la visualizzazione degli Attestati emessi. I parametri che DEVONO essere inclusi sono:
 
           - **display**: Array di oggetti contenente le proprietà legate alla visualizzazione. I seguenti parametri sono inclusi:

--- a/docs/it/credential-revocation.rst
+++ b/docs/it/credential-revocation.rst
@@ -205,7 +205,7 @@ Aggiornamento dello Stato relativo all'Utente
 
 Gli Utenti POSSONO modificare lo stato di validità del loro Attestato Elettronico:
 
-  1. Eliminando l'Attestato Elettronico dalla propria Istanza del Wallet: l'Istanza del Wallet DOVREBBE proporre all'Utente un prompt per notificare opzionalmente al Fornitore di Attestati Elettronici il desiderio da parte dell'Utente di richiedere la revoca della Credenziale. Quando l'Utente utilizza questa funzionalità, la notifica da inviare al Fornitore di Attestati Elettronici DEVE utilizzare il Notification Endpoint messo a disposizione dal Fornitore di Attestati Elettronici, come descritto nella Sezione :ref:`credential-revocation:Status Update by Wallet Instance`.
+  1. Eliminando l'Attestato Elettronico dalla propria Istanza del Wallet: l'Istanza del Wallet DOVREBBE proporre all'Utente un prompt per notificare opzionalmente al Fornitore di Attestati Elettronici il desiderio da parte dell'Utente di richiedere la revoca della Credenziale. Quando l'Utente utilizza questa funzionalità, la notifica da inviare al Fornitore di Attestati Elettronici DEVE utilizzare il Notification Endpoint messo a disposizione dal Fornitore di Attestati Elettronici, come descritto nella Sezione :ref:`credential-revocation-status-update-by-wallet-instance`.
   2. Utilizzando il portale web del Fornitore di Attestati Elettronici:
 
     a. Gli Utenti POSSONO accedere ad un'area sicura con almeno lo stesso Livello di Garanzia utilizzato durante la fase di emissione.
@@ -221,10 +221,12 @@ Inoltre, quando gli Utenti rilevano dati non corretti in un Attestato Elettronic
   Se l'Utente attiva un'altra Istanza del Wallet dello stesso Fornitore di Wallet e utilizzando la stessa Soluzione di Wallet e ottiene un nuovo PID, il PID precedente DEVE essere revocato e la precedente Istanza del Wallet DEVE passare allo stato operativo.
 
 In caso di morte dell'Utente, i Fornitori di Attestati Elettronici DEVONO garantire che gli Attestati Elettronici e le Istanze del Wallet di proprietà dell'Utente siano revocati.
-La morte dell'Utente comporta una modifica dello stato di validità degli attributi identificativi dell'Utente contenuti nel registro pubblico (ANPR). La morte dell'Utente DEVE produrre la revoca del PID. Pertanto, la Fonte Autentica del PID (ANPR) DEVE notificare al PID Provider che gli attributi dell'Utente non sono più validi a causa della morte dell'Utente. La Fonte Autentica e il PID Provider DEVONO utilizzare i meccanismi previsti nella Sezione :ref:`credential-revocation:Status Update by Authentic Sources`.
+La morte dell'Utente comporta una modifica dello stato di validità degli attributi identificativi dell'Utente contenuti nel registro pubblico (ANPR). La morte dell'Utente DEVE produrre la revoca del PID. Pertanto, la Fonte Autentica del PID (ANPR) DEVE notificare al PID Provider che gli attributi dell'Utente non sono più validi a causa della morte dell'Utente. La Fonte Autentica e il PID Provider DEVONO utilizzare i meccanismi previsti nella Sezione :ref:`credential-revocation-status-update-by-authentic-sources`.
 
 .. note::
   Le versioni future della presente specifica tecnica definiranno come le informazioni verso i Fornitori di (Q)EAA vengono propagate, in accordo alla normativa nazionale. Inoltre, saranno definite procedure automatizzate per la revoca degli Attestati dovuta ad attività illecite.
+
+.. _credential-revocation-status-update-by-wallet-instance:
 
 Aggiornamento dello Stato da parte dell'Istanza del Wallet
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -244,6 +246,8 @@ Aggiornamento dello Stato da parte dei Fornitori di Wallet
 Il Fornitore di Wallet che, per qualsiasi motivo, revoca una Wallet Instance DEVE garantire che lo stato aggiornato sia riportato all'interno della Status List della Wallet Unit Attestation.
 In aggiunta a quanto definito in :ref:`credential-revocation:Ciclo di Vita degli Attestati Elettronici`, il Fornitore di Attestati Elettronici DEVE implementare un meccanismo di monitoraggio degli stati correnti di tutte le Wallet Unit Attestation relative alle Wallet Instance a cui sono stati emessi gli Attestati Elettronici.
 In seguito alla revoca della Wallet Unit Attestation, il Credential Issuer procede alla revoca di tutti gli Attestati Elettronici emessi alla Wallet Instance.
+
+.. _credential-revocation-status-update-by-authentic-sources:
 
 Aggiornamento dello Stato da parte delle Fonti Autentiche
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/docs/it/entity-onboarding.rst
+++ b/docs/it/entity-onboarding.rst
@@ -1,6 +1,8 @@
 .. include:: ../common/common_definitions.rst
 .. include:: ../common/symbols.rst
 
+.. _entity-onboarding-gestione-del-ciclo-di-vita-delle-entita:
+
 Onboarding delle Entità
 ========================
 

--- a/docs/it/functionalities.rst
+++ b/docs/it/functionalities.rst
@@ -141,7 +141,7 @@ Ad attivazione conclusa, l'Utente PUÒ ottenere uno o più Attestati Elettronici
 
 A seconda delle specifiche esigenze dell'Utente, della tipologia di Attestato Elettronico di Attributi e delle disponibilità offerte dal Fornitore di Wallet, dal Fornitore di Attestati Elettronici di Attributi e dalla Fonte Autentica, l'ottenimento degli Attestati Elettronici di Attributi può avvenire attraverso due modalità: 
 
-- **dal Catalogo dell'Istanza del Wallet**: l'Utente esplora l'elenco degli Attestati Elettronici di Attributi forniti dalla Soluzione Wallet, seleziona quello di interesse e avvia il processo di richiesta, concludendo con il rilascio dell'Attestato Elettronico di Attributi nell'Istanza del Wallet. Questo percorso è disponibile per i tipi di credenziale idonei per la discovery pubblica come determinato dalle politiche dell'organismo di supervisione durante il processo di onboarding (vedere :ref:`registry:Catalogo delle Credenziali Digitali`).
+- **dal Catalogo dell'Istanza del Wallet**: l'Utente esplora l'elenco degli Attestati Elettronici di Attributi forniti dalla Soluzione Wallet, seleziona quello di interesse e avvia il processo di richiesta, concludendo con il rilascio dell'Attestato Elettronico di Attributi nell'Istanza del Wallet. Questo percorso è disponibile per i tipi di credenziale idonei per la discovery pubblica come determinato dalle politiche dell'organismo di supervisione durante il processo di onboarding (vedere :ref:`registry-catalogo-delle-credenziali-digitali`).
 
 - **da un Touchpoint della Fonte Autentica** (o del Fornitore di Attestati Elettronici di Attributi se coincide con la Fonte Autentica): l'Utente interagisce con il servizio digitale della Fonte Autentica, consentendogli di ottenere un Attestato Elettronico di Attributi specifico nella propria Istanza del Wallet tramite un Engagement Button.
 
@@ -276,7 +276,7 @@ Focus sugli Attestati Elettronici di Attributi
 
 Gli Attestati Elettronici di Attributi (EAA) ottenuti all'interno dell'Istanza del Wallet DEVONO garantire un elevato livello di riconoscibilità e accessibilità [RIF_ACCESSIBILITÀ] delle informazioni contenute. 
 
-La rappresentazione degli EAA dipende dalla UI e dalle scelte di design della Soluzione Wallet e, per specifici aspetti, da quanto definito nel Registro delle Fonti Autentiche e nel Catalogo delle Credenziali Digitali (vedi :ref:`registry:Infrastruttura di Registro`). 
+La rappresentazione degli EAA dipende dalla UI e dalle scelte di design della Soluzione Wallet e, per specifici aspetti, da quanto definito nel Registro delle Fonti Autentiche e nel Catalogo delle Credenziali Digitali (vedi :ref:`registry-infrastruttura-di-registro`). 
 
 Di seguito sono riportati i requisiti che ogni Fonte Autentica DEVE rispettare per personalizzare i propri EAA (vedi :ref:`registry:Registro delle Fonti Autentiche`):  
 
@@ -328,7 +328,7 @@ Di seguito sono riportati i requisiti di Esperienza Utente per assicurare una vi
 - DEVE mostrare l’EAA correttamente su tutti i dispositivi, garantendo un’esperienza coerente su schermi di dimensioni diverse; 
 - PUÒ mostrare gli EAA ottenuti in formato tessera nella Vista in Anteprima, in linea con gli approcci già utilizzati da altri portafogli digitali nel mercato; 
 - DEVE garantire un layout dell'EAA ottimizzato per scalabilità e usabilità, nella Vista in Anteprima, specialmente quando più EAA vengono visualizzati sulla stessa schermata; 
-- DEVE mostrare chiaramente il nome dell’EAA, così come definito dal Catalogo delle Credenziali Digitali attraverso il parametro credential_name (vedi :ref:`registry:Catalogo delle Credenziali Digitali`), sia nella Vista di Anteprima che nelle Vista di Dettaglio; 
+- DEVE mostrare chiaramente il nome dell'EAA, così come definito dal Catalogo delle Credenziali Digitali attraverso il parametro credential_name (vedi :ref:`registry-catalogo-delle-credenziali-digitali`), sia nella Vista di Anteprima che nelle Vista di Dettaglio; 
 - DEVE mostrare lo stato dell’EAA, se diverso da valido, per fornire trasparenza sul suo ciclo di vita, e PUÒ visualizzarlo se valido, sia nella Vista di Anteprima che nella Vista di Dettaglio. Evidenze specifiche sullo stato dell’EAA, se non valido, POSSONO essere fornite nella Vista di Dettaglio (ad esempio, il motivo per cui l’EAA è stato revocato); 
 - PUÒ includere informazioni opzionali per migliorare l’Esperienza Utente e la riconoscibilità dell’EAA, sia nella Vista di Anteprima che nella Vista di Dettaglio, come ad esempio il logo, il colore, l’immagine o la filigrana come definito della Fonte Autentica attraverso il Registro delle Fonti Autentiche (vedi :ref:`registry:Registro delle Fonti Autentiche`); 
 - DEVE includere le stesse informazioni della Vista di Anteprima nella Vista di Dettaglio e dare una rappresentazione esaustiva di tutti gli altri Attributi, seguendo l’ordine definito dalla Fonte Autentica nel Registro delle Fonti Autentiche (vedi :ref:`registry:Registro delle Fonti Autentiche`); 

--- a/docs/it/how-to-read-spec.rst
+++ b/docs/it/how-to-read-spec.rst
@@ -129,8 +129,8 @@ I lettori interessati all'implementazione o alla gestione di una Soluzione di **
 * **Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Comprensione dei formati delle Credenziali Elettroniche e verifica della validità.
 * **Sezione** :ref:`credential-presentation:Presentazione dell'Attestato Elettronico`: Implementazione del flusso di presentazione sia per scenari remoti che di prossimità.
 * **Sezione** :ref:`relying-party-endpoints:Endpoint della Relying Party`: Panoramica completa di tutti gli endpoint della Relying Party e i loro ambiti.
-* **Sezione** :ref:`relying-party-remote-flow-endpoints:Endpoint per Flussi Remoti della Relying Party`: Specifiche API complete della Relying Party per flussi remoti e di prossimità.
-* **Sezione** :ref:`relying-party-provider-backend-endpoint:Endpoint del Backend del Provider di Relying Party`: Specifiche API del Backend del Provider di Relying Party per la gestione del ciclo di vita delle App di Verifica.
+* **Sezione** :ref:`relying-party-remote-flow-endpoints-endpoint-per-flussi-remoti-della-relying-party`: Specifiche API complete della Relying Party per flussi remoti e di prossimità.
+* **Sezione** :ref:`relying-party-provider-backend-endpoint-endpoint-del-backend-del-provider-di-relying-party`: Specifiche API del Backend del Provider di Relying Party per la gestione del ciclo di vita delle App di Verifica.
 * **Sezione** :ref:`algorithms:Algoritmi Crittografici`: Requisiti della suite crittografica.
 
 **Sezioni secondarie:**

--- a/docs/it/onboarding-high-level.rst
+++ b/docs/it/onboarding-high-level.rst
@@ -145,7 +145,7 @@ La gestione del ciclo di vita nell'ecosistema IT-Wallet necessita di coordinamen
     - **Sincronizzazione del registro:** Quando un'entità apporta cambiamenti che influenzano altre entità, tutti i sistemi di registro DEVONO essere aggiornati correttamente assicurando che tutti i cambiamenti siano registrati in modo sicuro con timestamp e ragioni.
     - **Garanzia di continuità aziendale:** Le entità DOVREBBERO bilanciare tra l'apportare aggiornamenti necessari e mantenere i loro obblighi verso utenti e normative. Questo include assicurare che il servizio sia il più disponibile possibile, gestire i dati personali correttamente durante i cambiamenti e rimanere conformi ai requisiti legali anche in situazioni di emergenza.
 
-Le procedure tecniche e i requisiti di conformità specifici per la gestione del ciclo di vita sono dettagliati nella Sezione :ref:`entity-onboarding:Gestione del Ciclo di Vita delle Entità`.
+Le procedure tecniche e i requisiti di conformità specifici per la gestione del ciclo di vita sono dettagliati nella Sezione :ref:`entity-onboarding-gestione-del-ciclo-di-vita-delle-entita`.
 
 Onboarding Journey Maps
 ------------------------

--- a/docs/it/proximity-flow.rst
+++ b/docs/it/proximity-flow.rst
@@ -29,7 +29,7 @@ Le Istanze di Relying Party e Wallet registrate nell'ecosistema IT-Wallet DEVONO
 
 - *Flusso di Recupero del Dispositivo Supervisionato* dove un supervisore umano supervisiona il processo di verifica in persona, in contrasto con il *flusso non supervisionato* dove la verifica potrebbe avvenire attraverso sistemi automatizzati senza supervisione umana (:ref:`WP_095 <wallet-credential-presentation-testcases>`).
 - *Autenticazione dell'Istanza di Relying Party* seguendo i meccanismi definiti nella `ISO18013-5`_ per il *reader authentication* (:ref:`WP_098 <wallet-credential-presentation-testcases>`).
-- *Tipo di Documento* domestico e *Namespace* definiti in questa specifica tecnica in aggiunta a quelli già definiti nell'`ISO18013-5`_ per l'mDL (vedi :ref:`credential-data-model:Attestato Elettronico in formato mdoc-CBOR` per maggiori dettagli) (:ref:`WP_099 <wallet-credential-presentation-testcases>`).
+- *Tipo di Documento* domestico e *Namespace* definiti in questa specifica tecnica in aggiunta a quelli già definiti nell'`ISO18013-5`_ per l'mDL (vedi :ref:`credential-data-model-attestato-elettronico-in-formato-mdoc-cbor` per maggiori dettagli) (:ref:`WP_099 <wallet-credential-presentation-testcases>`).
 
 La tabella seguente mostra le tecnologie di *Device Engagement* supportate  (:ref:`WP_097 <wallet-credential-presentation-testcases>`), specificando quali sono obbligatorie.
 
@@ -443,7 +443,7 @@ Ogni Richiesta mdoc DEVE essere conforme alla seguente struttura e DEVE includer
 
        - **itemsRequest**. Struttura `ItemsRequest` codificata CBOR, formattata come:
 
-         - **docType** *(tstr)*. Il tipo di documento richiesto. Vedere :ref:`credential-data-model:Attestato Elettronico in formato mdoc-CBOR`.
+         - **docType** *(tstr)*. Il tipo di documento richiesto. Vedere :ref:`credential-data-model-attestato-elettronico-in-formato-mdoc-cbor`.
 
          - **nameSpaces** *(map)*. Una mappa di identificatori di namespace a *DataElements* richiesti.
 
@@ -507,7 +507,7 @@ Ogni elemento in **documents** DEVE essere conforme alla seguente struttura e DE
      - *(tstr)*. identificativo del tipo di documento. Ad esempio, per un mDL, il valore DEVE essere ``org.iso.18013.5.1.mDL`` (:ref:`PPR-010 <test-plans-proximity-presentation:Matrice di Test per il Verificatore di Credenziali in Prossimità>`).
 
    * - **issuerSigned**
-     - *(bstr)*. Contiene la struttura `IssuerNameSpaces`, che include elementi dati firmati dal Fornitore di Attestati Elettronici, e la struttura `issuerAuth`, che garantisce la loro autenticità e integrità utilizzando il Mobile Security Object (MSO). Vedere :ref:`credential-data-model:Attestato Elettronico in formato mdoc-CBOR`.
+     - *(bstr)*. Contiene la struttura `IssuerNameSpaces`, che include elementi dati firmati dal Fornitore di Attestati Elettronici, e la struttura `issuerAuth`, che garantisce la loro autenticità e integrità utilizzando il Mobile Security Object (MSO). Vedere :ref:`credential-data-model-attestato-elettronico-in-formato-mdoc-cbor`.
 
    * - **deviceSigned**
      - *(bstr)*. Contiene la struttura `DeviceNameSpaces` (elementi dati firmati dall'Istanza del Wallet), e la struttura `deviceAuth`, che include i dati di autenticazione firmati dall'Istanza del Wallet. Vedere la tabella sottostante per dettagli.
@@ -561,4 +561,4 @@ Quando una sessione viene terminata, l'Istanza del Wallet e l'Istanza di Relying
 - Chiusura del canale di comunicazione utilizzato per il *Device Retrieval*.
 
 .. note::
-  Vedere :ref:`credential-data-model:Attestato Elettronico in formato mdoc-CBOR` per il significato degli acronimi di tipo CBOR.
+  Vedere :ref:`credential-data-model-attestato-elettronico-in-formato-mdoc-cbor` per il significato degli acronimi di tipo CBOR.

--- a/docs/it/registry.rst
+++ b/docs/it/registry.rst
@@ -1,6 +1,8 @@
 .. include:: ../common/common_definitions.rst
 
 
+.. _registry-infrastruttura-di-registro:
+
 Infrastruttura del Registro
 ============================
 
@@ -443,6 +445,8 @@ Le operazioni del Registro di Federazione sono accessibili attraverso gli endpoi
    Gli endpoint di federazione sono disponibili sia attraverso il meccanismo di scoperta del registro (per l'accesso unificato al registro) che attraverso l'Entity Configuration del Trust Anchor a ``.well-known/openid-federation`` (per operazioni specifiche della federazione). Entrambe le fonti forniscono gli stessi URL degli endpoint ma servono diversi pattern di scoperta: scoperta del registro per l'orientamento iniziale nell'ecosistema, Entity Configuration per la conformità standard OpenID Federation 1.0.
    
    Per le specifiche tecniche complete dei protocolli di federazione, configurazioni delle entità, meccanismi di valutazione della fiducia e validazione della catena di fiducia, vedere :ref:`trust-infrastructure:L'Infrastruttura di Trust`.
+
+.. _registry-catalogo-delle-credenziali-digitali:
 
 Catalogo degli Attestati Elettronici
 ------------------------------------

--- a/docs/it/relying-party-provider-backend-endpoint.rst
+++ b/docs/it/relying-party-provider-backend-endpoint.rst
@@ -1,5 +1,7 @@
 .. include:: ../common/common_definitions.rst
 
+.. _relying-party-provider-backend-endpoint-endpoint-del-backend-del-provider-di-relying-party:
+
 .. "included" file, so we start with '-' title level
 
 La Relying Party DEVE esporre una serie di endpoint per gestire il ciclo di vita delle App di Verifica che utilizzano un servizio di backend remoto fornito dal loro Backend del Provider di Relying Party. Questi endpoint supportano i flussi di presentazione in prossimità fornendo generazione di nonce, registrazione delle chiavi hardware, convalida dell'integrità e rilascio del Certificato di Accesso. I dettagli specifici della loro implementazione sono lasciati alla discrezione della Relying Party.

--- a/docs/it/relying-party-remote-flow-endpoints.rst
+++ b/docs/it/relying-party-remote-flow-endpoints.rst
@@ -57,7 +57,7 @@ Endpoint di Cancellazione della Relying Party
 
 L'Endpoint di Cancellazione, che è descritto in :ref:`relying-party-metadata:Metadati della Relying Party`, consente alle Istanze di Wallet di richiedere la cancellazione degli attributi presentati alla Relying Party. La Relying Party DEVE richiedere l'autenticazione dell'Utente prima di procedere con la cancellazione degli attributi.
 
-.. _relying-party-provider-backend-endpoint-richiesta-di-cancellazione:
+.. _relying-party-remote-flow-endpoints-richiesta-di-cancellazione:
 
 Richiesta di Cancellazione
 ..........................
@@ -71,7 +71,7 @@ Di seguito è riportato un esempio non normativo di una Richiesta di Cancellazio
   GET /erasure-endpoint?callback_url=https://wallet-instance/erasure_response HTTP/1.1
   Host: relying-party.example.org
 
-.. _relying-party-provider-backend-endpoint-risposta-di-cancellazione:
+.. _relying-party-remote-flow-endpoints-risposta-di-cancellazione:
 
 Risposta di Cancellazione
 .........................
@@ -122,7 +122,7 @@ Di seguito è riportato un esempio di Error Response dall'Endpoint di Cancellazi
 Alla ricezione di una Error Response, l'Istanza di Wallet che ha effettuato la Richiesta di Cancellazione DEVE informare l'Utente della condizione di errore in modo appropriato.
 
 
-.. _remote-flow-considerazioni-di-sicurezza:
+.. _relying-party-remote-flow-endpoints-considerazioni-di-sicurezza:
 
 Considerazioni di Sicurezza
 """""""""""""""""""""""""""
@@ -135,7 +135,7 @@ Tutti gli endpoint della Relying Party DEVONO implementare appropriate misure di
 - **Rate Limiting**: Gli endpoint DOVREBBERO implementare rate limiting per prevenire abusi
 - **Audit Logging**: Tutte le interazioni degli endpoint DOVREBBERO essere registrate per il monitoraggio della sicurezza
 
-Per i requisiti di sicurezza dettagliati, vedere :ref:`remote-flow-considerazioni-di-sicurezza` e i casi di test pertinenti in :ref:`test-plans-remote-presentation:Matrice di Test per il Verificatore di Credenziali in Remoto`.
+Per i requisiti di sicurezza dettagliati, vedere :ref:`relying-party-remote-flow-endpoints-considerazioni-di-sicurezza` e i casi di test pertinenti in :ref:`test-plans-remote-presentation:Matrice di Test per il Verificatore di Credenziali in Remoto`.
 
 
 Note di Implementazione

--- a/docs/it/relying-party-remote-flow-endpoints.rst
+++ b/docs/it/relying-party-remote-flow-endpoints.rst
@@ -1,5 +1,7 @@
 .. include:: ../common/common_definitions.rst
 
+.. _relying-party-remote-flow-endpoints-endpoint-per-flussi-remoti-della-relying-party:
+
 .. "included" file, so we start with '-' title level
 
 La Relying Party DEVE esporre una serie di endpoint per supportare i flussi di presentazione remoti come definiti in OpenID4VP 1.0. Questi endpoint abilitano la verifica sicura delle credenziali, l'instaurazione della fiducia e l'autenticazione dell'utente per modelli di interazione cross-device e same-device.
@@ -26,7 +28,7 @@ Endpoint Request URI
 
 L'Endpoint Request URI è dove la Relying Party fornisce il Request Object firmato all'Istanza del Wallet. Questo endpoint supporta sia i metodi GET che POST come definito nella specifica OpenID4VP 1.0.
 
-Per i requisiti di implementazione dettagliati, vedere :ref:`remote-flow:Endpoint URI Request` e :ref:`remote-flow:Richiesta all'Endpoint URI Request`.
+Per i requisiti di implementazione dettagliati, vedere :ref:`remote-flow-endpoint-uri-request` e :ref:`remote-flow:Richiesta all'Endpoint URI Request`.
 
 
 Endpoint Response URI
@@ -42,7 +44,7 @@ Endpoint Status (Opzionale)
 
 L'Endpoint Status è un endpoint opzionale che consente all'user-agent di monitorare il progresso del flusso di presentazione. Questo endpoint è particolarmente utile per i flussi Same Device dove l'user-agent deve sapere quando l'Istanza del Wallet ha completato la presentazione.
 
-Per i requisiti di implementazione dettagliati, vedere :ref:`remote-flow:Status Endpoint` e :ref:`remote-flow:Errori Status Endpoint`.
+Per i requisiti di implementazione dettagliati, vedere :ref:`remote-flow:Status Endpoint` e :ref:`remote-flow-errori-status-endpoint`.
 
 
 Endpoint di Gestione Dati Utente
@@ -55,6 +57,8 @@ Endpoint di Cancellazione della Relying Party
 
 L'Endpoint di Cancellazione, che è descritto in :ref:`relying-party-metadata:Metadati della Relying Party`, consente alle Istanze di Wallet di richiedere la cancellazione degli attributi presentati alla Relying Party. La Relying Party DEVE richiedere l'autenticazione dell'Utente prima di procedere con la cancellazione degli attributi.
 
+.. _relying-party-provider-backend-endpoint-richiesta-di-cancellazione:
+
 Richiesta di Cancellazione
 ..........................
 
@@ -66,6 +70,8 @@ Di seguito è riportato un esempio non normativo di una Richiesta di Cancellazio
 
   GET /erasure-endpoint?callback_url=https://wallet-instance/erasure_response HTTP/1.1
   Host: relying-party.example.org
+
+.. _relying-party-provider-backend-endpoint-risposta-di-cancellazione:
 
 Risposta di Cancellazione
 .........................
@@ -116,6 +122,8 @@ Di seguito è riportato un esempio di Error Response dall'Endpoint di Cancellazi
 Alla ricezione di una Error Response, l'Istanza di Wallet che ha effettuato la Richiesta di Cancellazione DEVE informare l'Utente della condizione di errore in modo appropriato.
 
 
+.. _remote-flow-considerazioni-di-sicurezza:
+
 Considerazioni di Sicurezza
 """""""""""""""""""""""""""
 
@@ -127,7 +135,7 @@ Tutti gli endpoint della Relying Party DEVONO implementare appropriate misure di
 - **Rate Limiting**: Gli endpoint DOVREBBERO implementare rate limiting per prevenire abusi
 - **Audit Logging**: Tutte le interazioni degli endpoint DOVREBBERO essere registrate per il monitoraggio della sicurezza
 
-Per i requisiti di sicurezza dettagliati, vedere :ref:`remote-flow:Considerazioni di Sicurezza` e i casi di test pertinenti in :ref:`test-plans-remote-presentation:Matrice di Test per il Verificatore di Credenziali in Remoto`.
+Per i requisiti di sicurezza dettagliati, vedere :ref:`remote-flow-considerazioni-di-sicurezza` e i casi di test pertinenti in :ref:`test-plans-remote-presentation:Matrice di Test per il Verificatore di Credenziali in Remoto`.
 
 
 Note di Implementazione

--- a/docs/it/remote-flow.rst
+++ b/docs/it/remote-flow.rst
@@ -333,6 +333,8 @@ I parametri URL contenuti nella Authorization Request della Relying Party sono d
 Il valore corrispondente all'endpoint ``request_uri`` DOVREBBE essere casuale, secondo quanto prescritto da `RFC 9101, The OAuth 2.0 Authorization Framework: JWT-Secured Authorization Request (JAR) <https://www.rfc-editor.org/rfc/rfc9101.html#section-5.2.1>`_ Sezione 5.2.1.
 
 
+.. _remote-flow-endpoint-uri-request:
+
 Richiesta all'Endpoint URI Request
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -401,6 +403,8 @@ Risposta dell'Endpoint URI Request
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 La Relying Party emette il Request Object firmato utilizzando il tipo di contenuto impostato su ``application/oauth-authz-req+jwt``. Per il contenuto dell'oggetto Request, vedere la Sezione :ref:`remote-flow:Request Object`.
+
+.. _remote-flow-errori-status-endpoint:
 
 Errori dell'Endpoint URI Request
 --------------------------------
@@ -751,6 +755,8 @@ La Relying Party lega la richiesta dello user-agent, con un cookie di sessione c
 * **201 Created**; quando il Request Object firmato è stato emesso dalla Relying Party che attende di essere scaricato dall'Istanza del Wallet all'endpoint ``request_uri``.
 * **202 Accepted**; quando il Request Object firmato è stato ottenuto dall'Istanza del Wallet.
 * **200 OK**; quando l'Istanza del Wallet ha fornito la presentazione all'endpoint ``response_uri`` della Relying Party e l'autenticazione dell'Utente ha avuto successo. La Relying Party aggiorna il cookie di sessione consentendo allo user-agent di accedere alla risorsa protetta. Viene fornito un ``redirect_uri`` che trasporta lo user-agent alla pagina in cui l'Utente deve navigare.
+
+.. _remote-flow-errori-status-endpoint:
 
 Errori dello Status Endpoint
 -----------------------------

--- a/docs/it/remote-flow.rst
+++ b/docs/it/remote-flow.rst
@@ -404,7 +404,7 @@ Risposta dell'Endpoint URI Request
 
 La Relying Party emette il Request Object firmato utilizzando il tipo di contenuto impostato su ``application/oauth-authz-req+jwt``. Per il contenuto dell'oggetto Request, vedere la Sezione :ref:`remote-flow:Request Object`.
 
-.. _remote-flow-errori-status-endpoint:
+.. _remote-flow-errori-endpoint-uri-request:
 
 Errori dell'Endpoint URI Request
 --------------------------------

--- a/docs/it/test-plans-federation-authority.rst
+++ b/docs/it/test-plans-federation-authority.rst
@@ -41,7 +41,7 @@ Tutte le validazioni sono allineate con (`OID-FED`_).
   * - FA_005
     - Security, Interoperability
     - Parametri comuni dell'Entity Configuration
-    - Il payload contiene ``jwks`` e ``metadata`` con l'oggetto ``federation_entity`` che include gli endpoint della Federazione pubblicati come da :ref:`trust-infrastructure:Integrazione tra Infrastruttura di Trust e Registry`.
+    - Il payload contiene ``jwks`` e ``metadata`` con l'oggetto ``federation_entity`` che include gli endpoint della Federazione pubblicati come da :ref:`trust-infrastructure-integrazione-tra-infrastruttura-di-trust-e-registry`.
   * - FA_006
     - Security
     - Validità del materiale crittografico

--- a/docs/it/test-plans-remote-presentation.rst
+++ b/docs/it/test-plans-remote-presentation.rst
@@ -1,7 +1,5 @@
 .. include:: ../common/common_definitions.rst
 
-.. _test-plans-remote-presentation:
-
 Matrice di Test per il Verificatore di Credenziali in Remoto
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/it/test-plans-remote-presentation.rst
+++ b/docs/it/test-plans-remote-presentation.rst
@@ -1,5 +1,7 @@
 .. include:: ../common/common_definitions.rst
 
+.. _test-plans-remote-presentation:
+
 Matrice di Test per il Verificatore di Credenziali in Remoto
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/it/trust-infrastructure.rst
+++ b/docs/it/trust-infrastructure.rst
@@ -78,6 +78,8 @@ Di seguito la tabella con il riepilogo dei ruoli delle Entità di Federazione, m
      - Leaf
      -
 
+.. _trust-infrastructure-integrazione-tra-infrastruttura-di-trust-e-registry:
+
 Integrazione dell'Infrastruttura di Trust e del Registro
 --------------------------------------------------------
 
@@ -178,6 +180,8 @@ Questa sezione include i requisiti necessari per l'implementazione e il funziona
    * - FR19
      - **Binding delle Capacità del Protocollo Sicuro**: il protocollo sicuro deve abilitare lo scambio di dati delle capacità specifiche del protocollo come metadati crittograficamente legati associati a un'identità specifica. Questi metadati dovrebbero definire le capacità tecniche associate all'identità, garantendo prova verificabile e associazione a prova di manomissione per un robusto stabilimento del trust e controllo degli accessi.
 
+
+.. _trust-infrastructure-endpoint-delle-api-della-federazione:
 
 Endpoint API di Federazione
 ---------------------------
@@ -885,6 +889,8 @@ Ogni JWT contenente una Trust Chain negli header JWT può essere verificato nel 
 
 Anche se il Trust Anchor ha cambiato le sue chiavi crittografiche per la firma digitale, l'endpoint delle Chiavi Storiche di Federazione rende sempre disponibili le chiavi non più utilizzate per le verifiche di firma storiche.
 
+.. _trust-infrastructure-pki-x509:
+
 X.509 PKI
 ---------
 
@@ -968,6 +974,8 @@ Di seguito è riportato un esempio non normativo, in testo semplice (formato Ope
 
 Utilizzando il livello sottostante stabilito con OpenID Federation 1.0, tutti i certificati X.509 sono emessi in modo propriamente decentralizzato utilizzando il pattern di delegazione.
 
+
+.. _trust-infrastructure-revoca-dei-certificati-x509:
 
 Revoca di Certificati X.509
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/it/user-attribute-deletion.rst
+++ b/docs/it/user-attribute-deletion.rst
@@ -32,13 +32,13 @@ Questa funzionalità dell'Istanza del Wallet consente agli Utenti di ottenere un
   * la Relying Party a cui è stata fatta la richiesta,
   * gli attributi di cui è stata richiesta la rimozione.
 
-**Passi 7 - 8:** L'Istanza del Wallet reindirizza l'Utente all'Endpoint di Cancellazione. DEVE inoltre garantire che sia presente un meccanismo di callback per consentire all'User-Agent di notificare all'Istanza del Wallet (e quindi all'Utente) dopo la Risposta di Cancellazione (:ref:`WP_118 <user-attribute-deletion-testcases>`). I dettagli sulla Richiesta di Cancellazione si trovano in :ref:`relying-party-provider-backend-endpoint-richiesta-di-cancellazione` (:ref:`WP_117 <user-attribute-deletion-testcases>`).
+**Passi 7 - 8:** L'Istanza del Wallet reindirizza l'Utente all'Endpoint di Cancellazione. DEVE inoltre garantire che sia presente un meccanismo di callback per consentire all'User-Agent di notificare all'Istanza del Wallet (e quindi all'Utente) dopo la Risposta di Cancellazione (:ref:`WP_118 <user-attribute-deletion-testcases>`). I dettagli sulla Richiesta di Cancellazione si trovano in :ref:`relying-party-remote-flow-endpoints-richiesta-di-cancellazione` (:ref:`WP_117 <user-attribute-deletion-testcases>`).
 
 .. note::
   La pagina web della Relying Party autenticherà l'Utente con un Livello di Garanzia appropriato utilizzando qualsiasi metodo come CIE o la presentazione dell'Attestato Elettronico di Dati di Identificazione Personale. Il meccanismo specifico utilizzato per l'autenticazione è lasciato alla Relying Party. Dopo aver autenticato l'Utente, la Relying Party PUÒ richiedere all'Utente di eseguire ulteriori passaggi necessari per l'eliminazione degli attributi, ad esempio, potrebbe richiedere all'Utente di confermare l'operazione di eliminazione.
 
 **Passo 9:** Dopo aver autenticato con successo l'Utente, la Relying Party DEVE eliminare tutti gli attributi legati all'Utente in suo possesso.
 
-**Passo 10:** La Relying Party restituisce la Risposta di Cancellazione sotto forma di Risposta HTTP all'User-Agent e include l'URL di callback se fornito nella Richiesta di Cancellazione. I dettagli sulla Risposta di Cancellazione si trovano in :ref:`relying-party-provider-backend-endpoint-risposta-di-cancellazione`.
+**Passo 10:** La Relying Party restituisce la Risposta di Cancellazione sotto forma di Risposta HTTP all'User-Agent e include l'URL di callback se fornito nella Richiesta di Cancellazione. I dettagli sulla Risposta di Cancellazione si trovano in :ref:`relying-party-remote-flow-endpoints-risposta-di-cancellazione`.
 
 **Passi 11 - 12:** L'User-Agent utilizza il metodo implementato per restituire la Risposta di Cancellazione all'Istanza del Wallet. Infine, l'Utente viene notificato tramite l'Istanza del Wallet riguardo all'esito della Risposta di Cancellazione (:ref:`WP_119 <user-attribute-deletion-testcases>`).

--- a/docs/it/user-attribute-deletion.rst
+++ b/docs/it/user-attribute-deletion.rst
@@ -32,13 +32,13 @@ Questa funzionalità dell'Istanza del Wallet consente agli Utenti di ottenere un
   * la Relying Party a cui è stata fatta la richiesta,
   * gli attributi di cui è stata richiesta la rimozione.
 
-**Passi 7 - 8:** L'Istanza del Wallet reindirizza l'Utente all'Endpoint di Cancellazione. DEVE inoltre garantire che sia presente un meccanismo di callback per consentire all'User-Agent di notificare all'Istanza del Wallet (e quindi all'Utente) dopo la Risposta di Cancellazione (:ref:`WP_118 <user-attribute-deletion-testcases>`). I dettagli sulla Richiesta di Cancellazione si trovano in :ref:`relying-party-provider-backend-endpoint:Richiesta di Cancellazione` (:ref:`WP_117 <user-attribute-deletion-testcases>`).
+**Passi 7 - 8:** L'Istanza del Wallet reindirizza l'Utente all'Endpoint di Cancellazione. DEVE inoltre garantire che sia presente un meccanismo di callback per consentire all'User-Agent di notificare all'Istanza del Wallet (e quindi all'Utente) dopo la Risposta di Cancellazione (:ref:`WP_118 <user-attribute-deletion-testcases>`). I dettagli sulla Richiesta di Cancellazione si trovano in :ref:`relying-party-provider-backend-endpoint-richiesta-di-cancellazione` (:ref:`WP_117 <user-attribute-deletion-testcases>`).
 
 .. note::
   La pagina web della Relying Party autenticherà l'Utente con un Livello di Garanzia appropriato utilizzando qualsiasi metodo come CIE o la presentazione dell'Attestato Elettronico di Dati di Identificazione Personale. Il meccanismo specifico utilizzato per l'autenticazione è lasciato alla Relying Party. Dopo aver autenticato l'Utente, la Relying Party PUÒ richiedere all'Utente di eseguire ulteriori passaggi necessari per l'eliminazione degli attributi, ad esempio, potrebbe richiedere all'Utente di confermare l'operazione di eliminazione.
 
 **Passo 9:** Dopo aver autenticato con successo l'Utente, la Relying Party DEVE eliminare tutti gli attributi legati all'Utente in suo possesso.
 
-**Passo 10:** La Relying Party restituisce la Risposta di Cancellazione sotto forma di Risposta HTTP all'User-Agent e include l'URL di callback se fornito nella Richiesta di Cancellazione. I dettagli sulla Risposta di Cancellazione si trovano in :ref:`relying-party-provider-backend-endpoint:Risposta di Cancellazione`.
+**Passo 10:** La Relying Party restituisce la Risposta di Cancellazione sotto forma di Risposta HTTP all'User-Agent e include l'URL di callback se fornito nella Richiesta di Cancellazione. I dettagli sulla Risposta di Cancellazione si trovano in :ref:`relying-party-provider-backend-endpoint-risposta-di-cancellazione`.
 
 **Passi 11 - 12:** L'User-Agent utilizza il metodo implementato per restituire la Risposta di Cancellazione all'Istanza del Wallet. Infine, l'Utente viene notificato tramite l'Istanza del Wallet riguardo all'esito della Risposta di Cancellazione (:ref:`WP_119 <user-attribute-deletion-testcases>`).

--- a/docs/it/wallet-metadata-retrieval.rst
+++ b/docs/it/wallet-metadata-retrieval.rst
@@ -8,7 +8,7 @@ In primo luogo, con l'Immediate Subordinate Listing endpoint ottengono la lista 
 Se il Trust Anchor non supporta questa funzione, DEVE utilizzare il codice di stato HTTP 400 e il Content Type  ``application/json``, con il codice di errore ``unsupported_parameter``.
 
 Quindi, dato l'``entity_id``, per ciascun Wallet Provider recuperano la corrispondente configurazione utilizzando l'endpoint dei metadati della federazione (GET .well-known/openid-federation) 
-e ottengono i metadati della Wallet Solution (vedere :ref:`wallet-solution-metadata:Metadati della Soluzioen Wallet`). Maggiori dettagli sull'uso degli endpoint del Trust Anchor sono forniti in :ref:`trust-infrastructure:L'Infrastruttura di Trust`.
+e ottengono i metadati della Wallet Solution (vedere :ref:`wallet-solution-metadata-metadati-della-soluzione-wallet`). Maggiori dettagli sull'uso degli endpoint del Trust Anchor sono forniti in :ref:`trust-infrastructure:L'Infrastruttura di Trust`.
 
 All'interno dei metadati, le terze parti che supportano il Credential Offer e le Relying Party recuperano le informazioni necessarie per la Selection Page, ovvero il logo e il nome completo delle Soluzioni Wallet.
 Maggiori dettagli sulla progettazione della Selection Page sono disponibili in :ref:`functionalities:Design dell'Esperienza Utente`.

--- a/docs/it/wallet-provider-endpoint.rst
+++ b/docs/it/wallet-provider-endpoint.rst
@@ -226,7 +226,7 @@ In particolare, il JWT della richiesta di emissione della Wallet App e Wallet Un
       - **Descrizione**
       - **Riferimento**
     * - **alg**
-      - Identificatore dell'algoritmo di firma digitale, come definito nel registro IANA "JSON Web Signature and Encryption Algorithms". DEVE essere uno degli algoritmi supportati elencati in :ref:`algorithms:cryptographic algorithms` e non DEVE essere impostato su ``none`` né su alcun identificatore di algoritmo simmetrico (MAC).
+      - Identificatore dell'algoritmo di firma digitale, come definito nel registro IANA "JSON Web Signature and Encryption Algorithms". DEVE essere uno degli algoritmi supportati elencati in :ref:`algorithms-cryptographic-algorithms` e non DEVE essere impostato su ``none`` né su alcun identificatore di algoritmo simmetrico (MAC).
       - [:rfc:`7516#section-4.1.1`]
     * - **kid**
       - thumbprint della JWK dell'Istanza del Wallet contenuta nella dichiarazione ``cnf``.

--- a/docs/it/wallet-solution-metadata.rst
+++ b/docs/it/wallet-solution-metadata.rst
@@ -1,5 +1,7 @@
 .. include:: ../common/common_definitions.rst
 
+.. _wallet-solution-metadata-metadati-della-soluzione-wallet:
+
 Metadati della Soluzione Wallet
 --------------------------------
 

--- a/docs/it/x5c-evaluation.rst
+++ b/docs/it/x5c-evaluation.rst
@@ -3,7 +3,7 @@ Operazioni di Gestione dei Certificati X.509
 
 Questa sezione definisce le procedure operative per la gestione dei Certificati X.509 all'interno della federazione IT-Wallet, coprendo l'analisi delle catene di Certificati X.509, le procedure di validazione e la verifica di revoca. Queste procedure completano i processi di onboarding della federazione e supportano la gestione continua del ciclo di vita dei Certificati X.509 per tutti i partecipanti.
 
-Per l'infrastruttura PKI X.509 fondamentale e le procedure di emissione dei certificati, vedere :ref:`trust-infrastructure:PKI X.509`.
+Per l'infrastruttura PKI X.509 fondamentale e le procedure di emissione dei certificati, vedere :ref:`trust-infrastructure-pki-x509`.
 
 Architettura PKI della Federazione
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -169,7 +169,7 @@ Le entità subordinate DEVONO eseguire la verifica periodica della propria Trust
 
 I Subordinati della federazione DEVONO:
 
-1. Recuperare il proprio Subordinate Statement dal superiore immediato ogni 24 ore utilizzando il fetch endpoint definito in :ref:`trust-infrastructure:Endpoint delle API della Federazione`. Ciò DOVREBBE essere fatto entro un intervallo di tempo non superiore a 24 ore.
+1. Recuperare il proprio Subordinate Statement dal superiore immediato ogni 24 ore utilizzando il fetch endpoint definito in :ref:`trust-infrastructure-endpoint-delle-api-della-federazione`. Ciò DOVREBBE essere fatto entro un intervallo di tempo non superiore a 24 ore.
 2. Verificare lo stato di revoca o sospensione.
 3. Aggiornare il proprio Entity Configuration quando cambiano i certificati superiori.
 
@@ -177,9 +177,9 @@ I Subordinati della federazione DEVONO:
 
 I Subordinati POSSONO utilizzare uno o più dei seguenti meccanismi per rilevare le modifiche:
 
-- **Verifica CRL/OCSP**: Monitorare le Certificate Revocation List o le risposte del protocollo Online Certificate Status Protocol per rilevare la revoca dei certificati superiori come definito in :ref:`trust-infrastructure:Revoca dei Certificati X.509`. La revoca del certificato indica che è in corso la rotazione della chiave superiore.
+- **Verifica CRL/OCSP**: Monitorare le Certificate Revocation List o le risposte del protocollo Online Certificate Status Protocol per rilevare la revoca dei certificati superiori come definito in :ref:`trust-infrastructure-revoca-dei-certificati-x509`. La revoca del certificato indica che è in corso la rotazione della chiave superiore.
 - **Fetch Endpoint**: Recuperare il Subordinate Statement tramite ``GET {superiore}/fetch?sub={entity_id_subordinato}`` per ottenere i certificati correnti.
-- **Events Endpoint**: Monitorare ``GET {superiore}/federation_subordinate_events_endpoint?sub={entity_id_subordinato}`` per gli eventi ``jwks_update``. Il Federation Subordinate Events endpoint restituisce la traccia storica degli eventi di registrazione come definito in :ref:`trust-infrastructure:Endpoint delle API della Federazione`.
+- **Events Endpoint**: Monitorare ``GET {superiore}/federation_subordinate_events_endpoint?sub={entity_id_subordinato}`` per gli eventi ``jwks_update``. Il Federation Subordinate Events endpoint restituisce la traccia storica degli eventi di registrazione come definito in :ref:`trust-infrastructure-endpoint-delle-api-della-federazione`.
 
 I Subordinati DOVREBBERO implementare la pianificazione automatizzata per:
 
@@ -192,7 +192,7 @@ Quando un'entità superiore (Trust Anchor o Intermediate) ruota la propria Chiav
 
 **Procedura di Rotazione**
 
-1. **Revoca della Chiave**: Il superiore pubblica la Certificate Revocation List (CRL) o la voce Historical Keys (HK) revocando la vecchia chiave come definito in :ref:`trust-infrastructure:Revoca dei Certificati X.509`.
+1. **Revoca della Chiave**: Il superiore pubblica la Certificate Revocation List (CRL) o la voce Historical Keys (HK) revocando la vecchia chiave come definito in :ref:`trust-infrastructure-revoca-dei-certificati-x509`.
 2. **Aggiornamento Entity Configuration**: Il superiore pubblica la nuova Entity Configuration firmata con la nuova Chiave dell'Entità Federata.
 3. **Riemissione Certificati X.509**: Il superiore riemette i certificati X.509 a tutti i Subordinati utilizzando la nuova chiave.
 4. **Pubblicazione Certificati**: Il superiore rende disponibili i nuovi certificati sul fetch endpoint.
@@ -228,7 +228,7 @@ I Subordinati ruotano le proprie Chiavi dell'Entità Federata inviando Certifica
 Gestione del Ciclo di Vita dell'Entità
 --------------------------------------
 
-Questa sezione fornisce le procedure di implementazione tecnica per la gestione del ciclo di vita dell'entità. Per i concetti di alto livello del ciclo di vita e i processi aziendali, vedere :ref:`onboarding-high-level:Gestione del Ciclo di Vita dell'Entità`.
+Questa sezione fornisce le procedure di implementazione tecnica per la gestione del ciclo di vita dell'entità. Per i concetti di alto livello del ciclo di vita e i processi aziendali, vedere :ref:`onboarding-high-level:Gestione del Ciclo di Vita delle Entità`.
 
 Mentre l'aggiornamento dei dati amministrativi DEVE seguire processi di governance che sono fuori dall'ambito di questa specifica tecnica, gli aggiornamenti della configurazione tecnica sono descritti nelle seguenti sezioni.
 


### PR DESCRIPTION
This PR fixes undefined label warnings and .. only:: directive syntax errors in the documentation.

In particular, it adds missing label definitions before section titles in multiple files:
- credential-issuance-low-level.rst: Added label for "Flusso Credential Offer"
- registry.rst: Added labels for "Infrastruttura del Registro" and "Catalogo delle Credenziali Digitali"
- credential-data-model.rst: Added labels for SD-JWT-VC and mdoc-CBOR format sections
- credential-issuer-metadata.rst: Added label for metadata section
- credential-revocation.rst: Added labels for status update sections
- trust-infrastructure.rst: Added labels for PKI X.509, federation endpoints, and certificate revocation sections

It also did something useful in the following areas and or sections:
- Updated references to use the correct label format (hyphen-separated instead of colon-separated):
- Changed from :ref:doc:Section Title`` to :ref:doc-section-title`` format
- Fixed references in functionalities.rst, proximity-flow.rst, user-attribute-deletion.rst, x5c-evaluation.rst, and others
- Added blank lines after .. only:: format_latex directives in docs/en/functionalities.rst
- Resolved "chunk after expression" errors by ensuring proper spacing between directives and block-level content
