### PR TITLE
docs: clarify signature verification for GetAttributeClaims endpoint

### DIFF
--- a/docs/en/authentic-source-endpoint.rst
+++ b/docs/en/authentic-source-endpoint.rst
@@ -44,7 +44,7 @@ Get Attribute Claims
     - the Authentic Source MUST record the datetime value provided within the ``last_updated`` parameter, which indicates the last time the User's attributes were updated in the Authentic Source's database;
     - the Credential Issuer MUST read the ``last_updated`` value received in the response to be able to check if the User's attributes have changed since the last issuance of a Digital Credential.
 
-The successful response (HTTP 200) returns a ``CredentialClaimsResponse`` object formatted as a **Signed JWT**.
+The successful response (HTTP 200) returns a ``CredentialClaimsResponse`` object formatted as a signed JWT.
 
 Signature Verification and Key Management
 '''''''''''''''''''''''''''''''''''''''''

--- a/docs/en/authentic-source-endpoint.rst
+++ b/docs/en/authentic-source-endpoint.rst
@@ -43,3 +43,16 @@ Get Attribute Claims
     - both MUST save the ``jti`` value in the Agid-JWT-Signature payload of the request to manage Signals related to the deffered issuance of a Digital Credential (see :ref:`signal-hub-endpoint:Signals Processing`);
     - the Authentic Source MUST record the datetime value provided within the ``last_updated`` parameter, which indicates the last time the User's attributes were updated in the Authentic Source's database;
     - the Credential Issuer MUST read the ``last_updated`` value received in the response to be able to check if the User's attributes have changed since the last issuance of a Digital Credential.
+
+The successful response (HTTP 200) returns a ``CredentialClaimsResponse`` object formatted as a **Signed JWT**.
+
+Signature Verification and Key Management
+'''''''''''''''''''''''''''''''''''''''''
+
+As the response token is signed, the Credential Issuer (Consumer) MUST verify the signature to ensure the integrity and authenticity of the data received from the Authentic Source.
+
+The signature verification and key retrieval process MUST strictly follow the standard pattern defined for **PDND e-Services**.
+Please refer to the Technical Appendix (Section :ref:`e-service-pdnd:e-Service PDND`) for details on JWT validation and specifications for retrieving the Provider's public key via the Interoperability API.
+
+.. warning::
+  Alternative mechanisms for distributing cryptographic material (e.g., public ``.well-known`` endpoints directly exposed by the Authentic Source or *out-of-band* distribution) are not allowed. Trust management MUST remain centralized within the perimeter of the PDND infrastructure as described in the references cited above.

--- a/docs/it/authentic-source-endpoint.rst
+++ b/docs/it/authentic-source-endpoint.rst
@@ -43,3 +43,16 @@ Get Attribute Claims
     - entrambi DEVONO salvare il valore ``jti`` contenuto nel payload del token Agid-JWT-Signature della richiesta per gestire i Segnali relativi alla disponibilità degli Attributi utili all'emissione in *deferred* di un Attestato Elettronico (vedere :ref:`signal-hub-endpoint:Elaborazione dei Segnali`);
     - la Fonte Autentica DEVE registrare il valore datetime fornito all'interno del parametro ``last_updated``, che indica data e orario dell'ultima volta che gli Attributi dell'Utente sono stati aggiornati nel database della Fonte Autentica;
     - il Credential Issuer DEVE leggere il valore ``last_updated`` ricevuto nella risposta per essere in grado di verificare se gli Attributi dell'Utente sono cambiati dall'ultima emissione di un Attestato Elettronico.
+
+La risposta in caso di successo (HTTP 200) restituisce un oggetto ``CredentialClaimsResponse`` formattato come **Signed JWT**.
+
+Verifica della Firma e Gestione Chiavi
+''''''''''''''''''''''''''''''''''''''
+
+Essendo il token di risposta firmato, il Credential Issuer (Fruitore) DEVE verificare la firma per garantire l'integrità e l'autenticità dei dati ricevuti dalla Fonte Autentica.
+
+Il processo di verifica e recupero delle chiavi DEVE seguire rigorosamente il pattern standard definito per gli **e-Service PDND**.
+Si rimanda all'Appendice tecnica (Sezione :ref:`e-service-pdnd:e-Service PDND`) per i dettagli sulla validazione del JWT e per le specifiche sul recupero della chiave pubblica dell'Erogatore tramite API di Interoperabilità.
+
+.. warning::
+  Non sono ammessi meccanismi alternativi di distribuzione del materiale crittografico (es. endpoint ``.well-known`` pubblici esposti direttamente dalla Fonte Autentica o distribuzione *out-of-band*). La gestione del trust DEVE rimanere centralizzata all'interno del perimetro dell'infrastruttura PDND come descritto nei riferimenti sopra citati.

--- a/docs/it/authentic-source-endpoint.rst
+++ b/docs/it/authentic-source-endpoint.rst
@@ -44,7 +44,7 @@ Get Attribute Claims
     - la Fonte Autentica DEVE registrare il valore datetime fornito all'interno del parametro ``last_updated``, che indica data e orario dell'ultima volta che gli Attributi dell'Utente sono stati aggiornati nel database della Fonte Autentica;
     - il Credential Issuer DEVE leggere il valore ``last_updated`` ricevuto nella risposta per essere in grado di verificare se gli Attributi dell'Utente sono cambiati dall'ultima emissione di un Attestato Elettronico.
 
-La risposta in caso di successo (HTTP 200) restituisce un oggetto ``CredentialClaimsResponse`` formattato come **Signed JWT**.
+La risposta in caso di successo (HTTP 200) restituisce un oggetto ``CredentialClaimsResponse`` formattato come JWT firmato.
 
 Verifica della Firma e Gestione Chiavi
 ''''''''''''''''''''''''''''''''''''''


### PR DESCRIPTION
## Title
Clarification on JWT Signature Verification for GetAttributeClaims

## Content
This PR updates the `authentic-source-endpoint.rst` documentation (both Italian and English versions) to resolve ambiguity regarding the JWT signature verification for the `GetAttributeClaims` endpoint response.

Specifically, it:
- Explicitly states that the Credential Issuer MUST verify the signature of the `CredentialClaimsResponse` JWT.
- Mandates the use of the standard PDND Interoperability model for key retrieval (referencing the Technical Appendix).
- Adds a warning to explicitly forbid alternative key distribution mechanisms (e.g., public `.well-known` endpoints or out-of-band distribution), ensuring trust remains centralized within the PDND infrastructure.

Relates to issue: italia/eid-wallet-it-docs#980

## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [ ] Example files
- [x] Ask for review
