### PR TITLE
fix: add missing slash in AttributeClaims path parameter

### DIFF
--- a/docs/it/oas3/OAS3-PDND-AS.yaml
+++ b/docs/it/oas3/OAS3-PDND-AS.yaml
@@ -6,7 +6,7 @@ servers:
   - url: https://authentic-source.example.it
     description: Authentic Source API
 paths:
-  /v1.3.1/AttributeClaims{dataset_id}:
+  /v1.3.1/AttributeClaims/{dataset_id}:
     post:
       tags:
         - e-Services PDND


### PR DESCRIPTION
## Title
fix: add missing slash in AttributeClaims path parameter

## Content
This PR fixes a syntax error in the OpenAPI specification for the `AttributeClaims` endpoint.

The previous path `/v1.3.1/AttributeClaims{dataset_id}` was missing a forward slash separator before the path parameter, resulting in an invalid or non-standard REST URI structure.

The path has been updated to `/v1.3.1/AttributeClaims/{dataset_id}` to ensure correct parameter parsing and compliance with REST design standards.

## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [ ] Italian version
- [ ] English version
- [x] Example files 
- [x] Ask for review