### PR TITLE
docs: clarify objectId mapping and AUDIT_REST_02 revocation actions

### DIFF
--- a/docs/en/signal-hub-endpoint.rst
+++ b/docs/en/signal-hub-endpoint.rst
@@ -69,7 +69,7 @@ The Signal Collection e-Service endpoint is used by Authentic Sources to deposit
   * - **objectId**
     - REQUIRED. The subject to which the Signal is bound. If the Signal has ``signalType``:
       
-      - ``CREATE``, then it MUST be set to the ``jti`` value the Credental Issuer used in the Agid-JWT-Signature token of the `get attributes` request to the Authentic Source to obtain the attributes related to a specific Digital Credential (see :ref:`authentic-source-endpoint:Get Attribute Claims`);
+      - ``CREATE``, then it MUST be set to the ``jti`` value the Credential Issuer used in the Agid-JWT-Signature token of the `get attributes` request to the Authentic Source to obtain the attributes related to a specific Digital Credential (see :ref:`authentic-source-endpoint:Get Attribute Claims`);
       - ``UPDATE``, then it MUST be set to the Authentic Source's unique database identifier of the Digital Credential's attributes the Signal refers to.
       
   * - **signalType**
@@ -155,7 +155,7 @@ After the Signals have been successfully recovered by the Credential Issuer, the
 
   - For each Signal, the Credential Issuer MUST check the ``SignalType`` value:
     
-    - if the Signal ``SignalType`` is ``UPDATE`` (where ``objectId`` refers to the **Authentic Source's unique database identifier of the Digital Credential's attribute**), the status and/or value of the attribute associated with a Digital Credential need updates;
+    - if the Signal ``SignalType`` is ``UPDATE`` (where ``objectId`` refers to the **Authentic Source's unique database identifier of the Digital Credential's attributes**), the status and/or value of the attribute associated with a Digital Credential need updates;
     - if the Signal ``SignalType`` is ``CREATE`` (where ``objectId`` refers to the **request ``jti``**), the requested attributes of a specific Digital Credential are now available; 
 
     If the ``objectId`` does not correspond to any valid identifier known to the Credential Issuer, the Signal MUST be ignored. Otherwise, if it corresponds to a known and valid identifier, the Credential Issuer MUST use the :ref:`authentic-source-endpoint:Get Attribute Claims` PDND endpoint of the Authentic Source to retrieve the updated information and, if applicable, apply the new status to the corresponding Credential.

--- a/docs/en/signal-hub-endpoint.rst
+++ b/docs/en/signal-hub-endpoint.rst
@@ -68,7 +68,7 @@ The Signal Collection e-Service endpoint is used by Authentic Sources to deposit
     - REQUIRED. Using this field the Authentic Source MAY use to further specify the Signal.
   * - **objectId**
     - REQUIRED. The subject to which the Signal is bound. If the Signal has ``signalType``:
-    
+      
       - ``CREATE``, then it MUST be set to the ``jti`` value the Credental Issuer used in the Agid-JWT-Signature token of the `get attributes` request to the Authentic Source to obtain the attributes related to a specific Digital Credential (see :ref:`authentic-source-endpoint:Get Attribute Claims`);
       - ``UPDATE``, then it MUST be set to the Authentic Source's unique database identifier of the Digital Credential's attributes the Signal refers to.
       
@@ -155,8 +155,8 @@ After the Signals have been successfully recovered by the Credential Issuer, the
 
   - For each Signal, the Credential Issuer MUST check the ``SignalType`` value:
     
-    - if the Signal ``SignalType`` is ``UPDATE``, the status and/or value of the attribute associated with a Digest Credential need updates;
-    - if the Signal ``SignalType`` is ``CREATE``, the requested attributes of a specific Digital Credential are now available; 
+    - if the Signal ``SignalType`` is ``UPDATE`` (where ``objectId`` refers to the **Digital Credential unique identifier**), the status and/or value of the attribute associated with a Digest Credential need updates;
+    - if the Signal ``SignalType`` is ``CREATE`` (where ``objectId`` refers to the **request ``jti``**), the requested attributes of a specific Digital Credential are now available; 
 
     If the ``objectId`` does not correspond to any valid identifier known to the Credential Issuer, the Signal MUST be ignored. Otherwise, if it corresponds to a known and valid identifier, the Credential Issuer MUST use the :ref:`authentic-source-endpoint:Get Attribute Claims` PDND endpoint of the Authentic Source to retrieve the updated information and, if applicable, apply the new status to the corresponding Credential.
     
@@ -164,6 +164,4 @@ After the Signals have been successfully recovered by the Credential Issuer, the
 
 .. warning::
 
-  Given Signal Hub's currently supported security patterns, if the Authentic Source requires the `AUDIT_REST_02` security pattern from the Credential Issuer, the latter MUST revoke the Digital Credential referenced in Signals with ``signalType`` ``UPDATE`` since it cannot contact the Authentic Source to retrieve the updated information without having authenticated the User before.  
-
-
+  Given Signal Hub's currently supported security patterns, if the Authentic Source requires the `AUDIT_REST_02` security pattern from the Credential Issuer, the latter MUST revoke the Digital Credential referenced in Signals with ``signalType`` ``UPDATE`` since it cannot contact the Authentic Source to retrieve the updated information without having authenticated the User before. **In this scenario, revocation is the only allowed action.**

--- a/docs/en/signal-hub-endpoint.rst
+++ b/docs/en/signal-hub-endpoint.rst
@@ -155,7 +155,7 @@ After the Signals have been successfully recovered by the Credential Issuer, the
 
   - For each Signal, the Credential Issuer MUST check the ``SignalType`` value:
     
-    - if the Signal ``SignalType`` is ``UPDATE`` (where ``objectId`` refers to the **Digital Credential unique identifier**), the status and/or value of the attribute associated with a Digest Credential need updates;
+    - if the Signal ``SignalType`` is ``UPDATE`` (where ``objectId`` refers to the **Authentic Source's unique database identifier of the Digital Credential's attribute**), the status and/or value of the attribute associated with a Digital Credential need updates;
     - if the Signal ``SignalType`` is ``CREATE`` (where ``objectId`` refers to the **request ``jti``**), the requested attributes of a specific Digital Credential are now available; 
 
     If the ``objectId`` does not correspond to any valid identifier known to the Credential Issuer, the Signal MUST be ignored. Otherwise, if it corresponds to a known and valid identifier, the Credential Issuer MUST use the :ref:`authentic-source-endpoint:Get Attribute Claims` PDND endpoint of the Authentic Source to retrieve the updated information and, if applicable, apply the new status to the corresponding Credential.

--- a/docs/it/signal-hub-endpoint.rst
+++ b/docs/it/signal-hub-endpoint.rst
@@ -68,7 +68,7 @@ L'endpoint dell'e-Service di Raccolta Segnali viene utilizzato dalle Fonti Auten
     - OBBLIGATORIO. Questo è un campo libero che la Fonte Autentica PUÒ utilizzare per specificare ulteriormente il Segnale.
   * - **objectId**
     - OBBLIGATORIO. Il soggetto a cui è legato il Segnale. Se il Segnale ha ``signalType``:
-    
+      
       - ``CREATE``, allora DEVE essere impostato sul valore ``jti`` che il Fornitore di Attestati Elettronici ha utilizzato nel token Agid-JWT-Signature della richiesta `get attributes` alla Fonte Autentica per ottenere gli Attributi relativi a un Attestato Elettronico specifico (vedere :ref:`authentic-source-endpoint:Get Attribute Claims`);
       - ``UPDATE``, allora DEVE essere impostato sull'identificatore univoco del database della Fonte Autentica degli Attributi dell'Attestato Elettronico a cui si riferisce il Segnale.
       
@@ -155,8 +155,8 @@ Dopo che i Segnali sono stati recuperati con successo dal Fornitore di Attestati
 
   - Per ogni Segnale, il Fornitore di Attestati Elettronici DEVE verificare il valore ``SignalType``:
     
-    - se il ``SignalType`` del Segnale è ``UPDATE``, lo stato e/o il valore dell'Attributo associato a un Attestato Elettronico necessitano di aggiornamenti;
-    - se il ``SignalType`` del Segnale è ``CREATE``, gli Attributi richiesti di un Attestato Elettronico specifico sono ora disponibili;
+    - se il ``SignalType`` del Segnale è ``UPDATE`` (l'``objectId`` fa riferimento all'**identificativo univoco dell'Attestato**), lo stato e/o il valore dell'Attributo associato a un Attestato Elettronico necessitano di aggiornamenti;
+    - se il ``SignalType`` del Segnale è ``CREATE`` (l'``objectId`` corrisponde al **``jti`` della richiesta**), gli Attributi richiesti di un Attestato Elettronico specifico sono ora disponibili;
 
     Se l'``objectId`` non corrisponde ad alcun identificativo valido noto al Fornitore di Attestati Elettronici, il Segnale DEVE essere ignorato. Altrimenti, se corrisponde a un identificativo noto e valido, il Fornitore di Attestati Elettronici DEVE utilizzare l'endpoint PDND :ref:`authentic-source-endpoint:Get Attribute Claims` della Fonte Autentica per recuperare le informazioni aggiornate e, se possibile, applicare il nuovo stato/attributo all'Attestato Elettronico corrispondente.
     
@@ -164,4 +164,4 @@ Dopo che i Segnali sono stati recuperati con successo dal Fornitore di Attestati
 
 .. warning::
 
-  Dati i pattern di sicurezza attualmente supportati da Signal Hub, se la Fonte Autentica richiede il pattern di sicurezza `AUDIT_REST_02` dal Fornitore di Attestati Elettronici, quest'ultimo DEVE revocare l'Attestato Elettronico referenziato nei Segnali con ``signalType`` ``UPDATE`` non potendo contattare la Fonte Autentica per recuperare le informazioni aggiornate senza aver prima autenticato l'Utente.
+  Dati i pattern di sicurezza attualmente supportati da Signal Hub, se la Fonte Autentica richiede il pattern di sicurezza `AUDIT_REST_02` dal Fornitore di Attestati Elettronici, quest'ultimo DEVE revocare l'Attestato Elettronico referenziato nei Segnali con ``signalType`` ``UPDATE`` non potendo contattare la Fonte Autentica per recuperare le informazioni aggiornate senza aver prima autenticato l'Utente. **In questo scenario, la revoca è l'unica azione ammessa.**

--- a/docs/it/signal-hub-endpoint.rst
+++ b/docs/it/signal-hub-endpoint.rst
@@ -155,7 +155,7 @@ Dopo che i Segnali sono stati recuperati con successo dal Fornitore di Attestati
 
   - Per ogni Segnale, il Fornitore di Attestati Elettronici DEVE verificare il valore ``SignalType``:
     
-    - se il ``SignalType`` del Segnale è ``UPDATE`` (l'``objectId`` fa riferimento all'**identificativo univoco dell'Attestato**), lo stato e/o il valore dell'Attributo associato a un Attestato Elettronico necessitano di aggiornamenti;
+    - se il ``SignalType`` del Segnale è ``UPDATE`` (l'``objectId`` fa riferimento all'**identificativo univoco presente nella base dati della Fonte Autentica relativo agli Attributi dell'Attestato Elettronico**), lo stato e/o il valore dell'Attributo associato a un Attestato Elettronico necessitano di aggiornamenti;    
     - se il ``SignalType`` del Segnale è ``CREATE`` (l'``objectId`` corrisponde al **``jti`` della richiesta**), gli Attributi richiesti di un Attestato Elettronico specifico sono ora disponibili;
 
     Se l'``objectId`` non corrisponde ad alcun identificativo valido noto al Fornitore di Attestati Elettronici, il Segnale DEVE essere ignorato. Altrimenti, se corrisponde a un identificativo noto e valido, il Fornitore di Attestati Elettronici DEVE utilizzare l'endpoint PDND :ref:`authentic-source-endpoint:Get Attribute Claims` della Fonte Autentica per recuperare le informazioni aggiornate e, se possibile, applicare il nuovo stato/attributo all'Attestato Elettronico corrispondente.


### PR DESCRIPTION
## Title

docs: clarify objectId mapping and AUDIT_REST_02 revocation actions

## Content

This PR refines the Signal Hub documentation in both Italian and English to remove ambiguity regarding signal processing logic and security constraints.

**Changes:**

* **Signals Processing (IT/EN):** Added explicit parenthetical clarifications to the `SignalType` verification steps. It is now clearly stated that:
* `CREATE` signals link `objectId` to the request `jti` (Deferred Issuance).
* `UPDATE` signals link `objectId` to the unique Credential ID.


* **AUDIT_REST_02 Warning (IT/EN):** Updated the final warning to explicitly state the operational consequence of using the `AUDIT_REST_02` pattern in asynchronous flows. Since the Credential Issuer cannot retrieve updated data without a user session, **revocation is the only allowed action** upon receiving an UPDATE signal.

These changes are text-only clarifications within the existing structure.

## Review

* [x] Ensure your files are written following RST specs (*not MD!*)
* [x] Italian version
* [x] English version
* [ ] Example files
* [x] Ask for review