### PR TITLE
docs: use bootstrap italia references

### DIFF
--- a/docs/en/official-resources.rst
+++ b/docs/en/official-resources.rst
@@ -23,6 +23,13 @@ The following official graphic assets are available for download in the `officia
 - **Trust Mark**: Official graphic element for attesting the participation in the IT-Wallet System - `Download Trust Mark <_static/trustmark-ENG.svg>`_ - Read more at section :ref:`brand-identity:Trust Mark`
 - **Authentication Button**: Official button for authentication via IT-Wallet - `Download Authentication Button <_static/Authentication-button-ENG.svg>`_
 
+HTML Components
+^^^^^^^^^^^^^^^
+
+The following official HTML components are available in the `official_resources/ <https://github.com/italia/eid-wallet-it-docs/tree/versione-corrente/official_resources>`_ folder of this repository:
+
+- **Authentication Button Component**: Official HTML/CSS component for authentication via IT-Wallet, based on the `Bootstrap Italia <https://italia.github.io/bootstrap-italia/docs/componenti/buttons/>`_ library - `View the component <https://github.com/italia/eid-wallet-it-docs/tree/versione-corrente/official_resources/authentication-button>`_ - `Live demo <_static/authentication-button/authentication-button.html>`_
+
 Brand Manual
 ^^^^^^^^^^^^
 

--- a/docs/en/official-resources.rst
+++ b/docs/en/official-resources.rst
@@ -23,14 +23,6 @@ The following official graphic assets are available for download in the `officia
 - **Trust Mark**: Official graphic element for attesting the participation in the IT-Wallet System - `Download Trust Mark <_static/trustmark-ENG.svg>`_ - Read more at section :ref:`brand-identity:Trust Mark`
 - **Authentication Button**: Official button for authentication via IT-Wallet - `Download Authentication Button <_static/Authentication-button-ENG.svg>`_
 
-HTML Components
-^^^^^^^^^^^^^^^
-
-The following official HTML components are available in the `official_resources/ <https://github.com/italia/eid-wallet-it-docs/tree/versione-corrente/official_resources>`_ folder of this repository:
-
-- **Authentication Button Component**: Official HTML/CSS component for authentication via IT-Wallet, based on the `dev-kit-italia <https://github.com/italia/dev-kit-italia/tree/main/packages/button>`_ framework - `View the component <https://github.com/italia/eid-wallet-it-docs/tree/versione-corrente/official_resources/authentication-button>`_ - `Live demo <_static/authentication-button/authentication-button.html>`_
-
-
 Brand Manual
 ^^^^^^^^^^^^
 

--- a/docs/it/official-resources.rst
+++ b/docs/it/official-resources.rst
@@ -22,6 +22,13 @@ Di seguito sono elencate le risorse grafiche ufficiali, disponibili per il downl
 - **Trust Mark**: Elemento grafico ufficiale per l'attestazione dell'appartenenza al Sistema IT-Wallet - `Scarica Trust Mark <_static/trustmark-ITA.svg>`_ - Consulta la sezione :ref:`brand-identity:Trust Mark`;
 - **Authentication Button**: Pulsante ufficiale per l'autenticazione tramite IT-Wallet - `Scarica Authentication Button <_static/Authentication-button-ITA.svg>`_
 
+Componenti HTML
+^^^^^^^^^^^^^^^^
+
+I seguenti componenti HTML ufficiali sono disponibili nella cartella `official_resources/ <https://github.com/italia/eid-wallet-it-docs/tree/versione-corrente/official_resources>`_ di questo repository:
+
+- **Authentication Button Component**: Componente HTML/CSS ufficiale per l'autenticazione tramite IT-Wallet, basato sulla libreria `Bootstrap Italia <https://italia.github.io/bootstrap-italia/docs/componenti/buttons/>`_ - `Vedi il componente <https://github.com/italia/eid-wallet-it-docs/tree/versione-corrente/official_resources/authentication-button>`_ - `Demo live <_static/authentication-button/authentication-button.html>`_
+
 Brand Manual
 ^^^^^^^^^^^^
 

--- a/docs/it/official-resources.rst
+++ b/docs/it/official-resources.rst
@@ -22,14 +22,6 @@ Di seguito sono elencate le risorse grafiche ufficiali, disponibili per il downl
 - **Trust Mark**: Elemento grafico ufficiale per l'attestazione dell'appartenenza al Sistema IT-Wallet - `Scarica Trust Mark <_static/trustmark-ITA.svg>`_ - Consulta la sezione :ref:`brand-identity:Trust Mark`;
 - **Authentication Button**: Pulsante ufficiale per l'autenticazione tramite IT-Wallet - `Scarica Authentication Button <_static/Authentication-button-ITA.svg>`_
 
-Componenti HTML
-^^^^^^^^^^^^^^^^
-
-I seguenti componenti HTML ufficiali sono disponibili nella cartella `official_resources/ <https://github.com/italia/eid-wallet-it-docs/tree/versione-corrente/official_resources>`_ di questo repository:
-
-- **Authentication Button Component**: Componente HTML/CSS ufficiale per l'autenticazione tramite IT-Wallet, basato sul framework `dev-kit-italia <https://github.com/italia/dev-kit-italia/tree/main/packages/button>`_ - `Vedi il componente <https://github.com/italia/eid-wallet-it-docs/tree/versione-corrente/official_resources/authentication-button>`_ - `Demo live <_static/authentication-button/authentication-button.html>`_
-
-
 Brand Manual
 ^^^^^^^^^^^^
 

--- a/official_resources/authentication-button/README.md
+++ b/official_resources/authentication-button/README.md
@@ -1,6 +1,6 @@
 # Authentication Button - IT-Wallet
 
-Pulsante ufficiale per l'autenticazione tramite IT-Wallet, basato sul framework [dev-kit-italia](https://github.com/italia/dev-kit-italia/tree/main/packages/button) e conforme all'identità visiva del Sistema IT-Wallet.
+Pulsante ufficiale per l'autenticazione tramite IT-Wallet, basato sulla libreria [Bootstrap Italia](https://italia.github.io/bootstrap-italia/docs/componenti/buttons/) e conforme all'identità visiva del Sistema IT-Wallet.
 
 ## Descrizione
 
@@ -22,7 +22,7 @@ Per le linee guida di spaziatura e design, consultare la pagina dei bottoni del 
 
 ## Caratteristiche
 
-- **Conforme alle linee guida PA**: Basato su Bootstrap Italia e dev-kit-italia
+- **Conforme alle linee guida PA**: Basato su Bootstrap Italia
 - **Accessibile**: Rispetta gli standard WCAG per l'accessibilità
 - **Responsive**: Adattabile a diverse dimensioni dello schermo
 - **Varianti di dimensione**: Disponibile in tre dimensioni (large, medium, small)
@@ -135,9 +135,9 @@ authentication-button/
     └── titillium-web-700.ttf     # Font weight 700 (bold)
 ```
 
-## Framework di Riferimento
+## Libreria di Riferimento
 
-Questo componente è basato sul framework [dev-kit-italia](https://github.com/italia/dev-kit-italia/tree/main/packages/button), che fornisce componenti conformi alle linee guida di design per i servizi web della Pubblica Amministrazione italiana.
+Questo componente è basato sulla libreria [Bootstrap Italia](https://italia.github.io/bootstrap-italia/docs/componenti/buttons/), che fornisce componenti conformi alle linee guida di design per i servizi web della Pubblica Amministrazione italiana.
 
 ## Identità Visiva
 

--- a/official_resources/authentication-button/authentication-button.css
+++ b/official_resources/authentication-button/authentication-button.css
@@ -1,7 +1,7 @@
 /**
  * Authentication Button - IT-Wallet
  * Official component for authentication via IT-Wallet
- * Based on dev-kit-italia and Bootstrap Italia
+ * Based on Bootstrap Italia
  * 
  * Brand Manual Specifications:
  * - Icon: IT-Wallet symbol (left side only)

--- a/official_resources/authentication-button/authentication-button.html
+++ b/official_resources/authentication-button/authentication-button.html
@@ -91,8 +91,8 @@
         
         <div class="info-box">
             <strong>Note:</strong> This component is based on the 
-            <a href="https://github.com/italia/dev-kit-italia/tree/main/packages/button">dev-kit-italia</a> 
-            framework and uses the official visual identity of the IT-Wallet System.
+            <a href="https://italia.github.io/bootstrap-italia/docs/componenti/buttons/">Bootstrap Italia</a> 
+            library and uses the official visual identity of the IT-Wallet System.
         </div>
     </div>
 


### PR DESCRIPTION
This PR removes all the references to `dev-kit-italia` since it's not been used in any example shown in this documentation.

I think that my suggestion about using `dev-kit-italia` has been misunderstood. At the moment `dev-kit-italia`'s not been officially released yet despite you can already install some packages from npm and use them in production (`it-button` and `it-icon` are simple and stable imho), but this is not an operation that will be easy and transparent for the final users. The main risk is that they will be forced to install `dev-kit-italia` packages and set up everything. 

A better way to use `dev-kit-italia` would be creating a "It wallet" web component delivered through both npm and prebuilt bundle that uses `it-button` and `it-icon` components transparently, but I don't know whether it's the goal of this project.

## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [ ] Example files 
- [x] Ask for review
