### PR TITLE
ci: path filters on oas-checker

### DIFF
--- a/.github/workflows/oas-spectral.yml
+++ b/.github/workflows/oas-spectral.yml
@@ -3,8 +3,16 @@ name: oas-spectral
 on:
   push:
     branches: [ "*" ]
+    paths:
+      - 'docs/it/oas3/**'
+      - 'docs/en/oas3/**'
+      - '.github/workflows/oas-spectral.yml'
   pull_request:
     branches: [ "*" ]
+    paths:
+      - 'docs/it/oas3/**'
+      - 'docs/en/oas3/**'
+      - '.github/workflows/oas-spectral.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
This pull request updates the configuration for the `oas-spectral` GitHub Actions workflow to trigger only when relevant files are changed. This helps reduce unnecessary workflow runs and improves CI efficiency.

Workflow trigger improvements:

* [`.github/workflows/oas-spectral.yml`](diffhunk://#diff-976d71e58054ef2b83c58fedb48863f44ba26a49042525e32c251372f00bd060R6-R15): Updated the workflow to run only when files in `docs/it/oas3/**`, `docs/en/oas3/**`, or the workflow file itself are changed, for both `push` and `pull_request` events.