### PR TITLE
ci: always build anf publish pdf on release

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -16,13 +16,19 @@ env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/eidas-it-wallet-docs-builder
 
 jobs:
+  # On release we don't need to rebuild the image; use existing. Paths-filter can fail when ref is a tag (no push base), so we bypass it on release.
   check_image_deps:
     runs-on: ubuntu-latest
     outputs:
-      build-image: ${{ steps.filter.outputs.build-image }}
+      build-image: ${{ steps.set_default.outputs.build-image || steps.filter.outputs.build-image }}
     steps:
       - uses: actions/checkout@v4
+      - name: No image rebuild on release (use existing image)
+        if: github.event_name == 'release'
+        id: set_default
+        run: echo "build-image=false" >> $GITHUB_OUTPUT
       - uses: dorny/paths-filter@v3
+        if: github.event_name != 'release'
         id: filter
         with:
           filters: |
@@ -89,13 +95,14 @@ jobs:
     steps:
       - id: set_tag
         run: |
+          # On release or when build was skipped/failed, use latest; only use SHA when we just built.
           if [ "${{ needs.build-image.result }}" = "success" ]; then
             echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
           else
             echo "tag=latest" >> $GITHUB_OUTPUT
           fi
 
-  # Always runs when get_image_tag provides a tag; on release get_image_tag is forced to run so PDFs are always produced.
+  # Produces PDFs and uploads as release assets on release; on manual run uploads as artifact. Always runs when get_image_tag provides a tag.
   build-pdf:
     runs-on: ubuntu-latest
     needs: [get_image_tag]


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/build-pdf.yml` to improve handling of release events and image building logic. The main focus is to ensure that on release events, the workflow skips unnecessary image rebuilds and reliably produces PDFs, even when the paths-filter step is bypassed.

Workflow improvements for release events:

* Modified the `check_image_deps` job to bypass the `paths-filter` step and prevent image rebuilding during release events, ensuring the workflow uses the existing Docker image instead.
* Updated the logic in the `set_tag` step to use the `latest` tag for releases or when the image build is skipped/failed, and only use the commit SHA when the image is freshly built.
* Clarified job comments to indicate that PDF production and artifact uploading always occur on release, regardless of image build status.