### PR TITLE
ci: fix build and publish pdf on release

### DIFF
--- a/.github/workflows/build-html.yml
+++ b/.github/workflows/build-html.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'versione-corrente'
+    tags:
+      - '*'
     paths:
       - 'docs/**'
       - 'official_resources/**'
@@ -29,7 +31,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write   # read + write; needed to push to gh-pages branch
   packages: write
 
 env:
@@ -45,10 +47,15 @@ jobs:
   check_image_deps:
     runs-on: ubuntu-latest
     outputs:
-      build-image: ${{ steps.filter.outputs.build-image }}
+      build-image: ${{ steps.set_default.outputs.build-image || steps.filter.outputs.build-image }}
     steps:
       - uses: actions/checkout@v4
+      - name: No image rebuild on release or tag push (use existing image)
+        if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_type == 'tag')
+        id: set_default
+        run: echo "build-image=false" >> $GITHUB_OUTPUT
       - uses: dorny/paths-filter@v3
+        if: github.event_name != 'release' && !(github.event_name == 'push' && github.ref_type == 'tag')
         id: filter
         with:
           filters: |
@@ -112,7 +119,7 @@ jobs:
   get_image_tag:
     runs-on: ubuntu-latest
     needs: [build-image]
-    if: always() && (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
+    if: always() && (github.event_name == 'release' || (github.event_name == 'push' && github.ref_type == 'tag') || needs.build-image.result == 'success' || needs.build-image.result == 'skipped' || needs.build-image.result == 'failure')
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
     steps:
@@ -130,7 +137,7 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository_owner }}/eidas-it-wallet-docs-builder:${{ needs.get_image_tag.outputs.tag }}
     # Run job ONLY if:
-    # 1. It's a push to a branch (e.g. versione-corrente)
+    # 1. It's a push to a branch (e.g. versione-corrente) or a tag
     # 2. It's a PR from the same repository (not from a fork)
     # 3. It's a release or a manual workflow_dispatch
     if: |
@@ -158,7 +165,10 @@ jobs:
           elif [[ "${{ github.event_name }}" == "release" ]]; then
             TAG="${{ github.event.release.tag_name }}"
             echo "path=releases/${TAG}" >> $GITHUB_OUTPUT
-          else 
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+            TAG="${{ github.ref_name }}"
+            echo "path=releases/${TAG}" >> $GITHUB_OUTPUT
+          else
             # Default case - push to default branch
             echo "path=$DEFAULT_BRANCH" >> $GITHUB_OUTPUT
           fi
@@ -171,6 +181,11 @@ jobs:
             sed -i 's/\(settings_project_name = ".*\)"/\1 - Release '"${TAG}"'"/' docs/it/conf.py
             sed -i 's/\(settings_project_name = ".*\)"/\1 - Release '"${TAG}"'"/' docs/en/conf.py
             echo "Applied release tag '${TAG}' to document titles"
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+            TAG="${{ github.ref_name }}"
+            sed -i 's/\(settings_project_name = ".*\)"/\1 - Release '"${TAG}"'"/' docs/it/conf.py
+            sed -i 's/\(settings_project_name = ".*\)"/\1 - Release '"${TAG}"'"/' docs/en/conf.py
+            echo "Applied tag '${TAG}' to document titles"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             PR_NUM="${{ github.event.pull_request.number }}"
             sed -i 's/\(settings_project_name = ".*\)"/\1 - PR #'"${PR_NUM}"'"/' docs/it/conf.py

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -4,12 +4,16 @@ on:
   release:
     types:
       - published
+  # Run on tag push so PDF is built and published even when release is created from tag later
+  push:
+    tags:
+      - '*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write   # read + write; needed to upload release assets / create release on tag push
   packages: write
 
 env:
@@ -23,12 +27,12 @@ jobs:
       build-image: ${{ steps.set_default.outputs.build-image || steps.filter.outputs.build-image }}
     steps:
       - uses: actions/checkout@v4
-      - name: No image rebuild on release (use existing image)
-        if: github.event_name == 'release'
+      - name: No image rebuild on release or tag push (use existing image)
+        if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_type == 'tag')
         id: set_default
         run: echo "build-image=false" >> $GITHUB_OUTPUT
       - uses: dorny/paths-filter@v3
-        if: github.event_name != 'release'
+        if: github.event_name != 'release' && !(github.event_name == 'push' && github.ref_type == 'tag')
         id: filter
         with:
           filters: |
@@ -89,7 +93,7 @@ jobs:
   get_image_tag:
     runs-on: ubuntu-latest
     needs: [build-image]
-    if: always() && (github.event_name == 'release' || needs.build-image.result == 'success' || needs.build-image.result == 'skipped' || needs.build-image.result == 'failure')
+    if: always() && (github.event_name == 'release' || (github.event_name == 'push' && github.ref_type == 'tag') || needs.build-image.result == 'success' || needs.build-image.result == 'skipped' || needs.build-image.result == 'failure')
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
     steps:
@@ -122,6 +126,11 @@ jobs:
             sed -i 's/\(settings_project_name = ".*\)"/\1 - Release '"${TAG}"'"/' docs/it/conf.py
             sed -i 's/\(settings_project_name = ".*\)"/\1 - Release '"${TAG}"'"/' docs/en/conf.py
             echo "Applied release tag '${TAG}' to document titles"
+          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref_type }}" == "tag" ]]; then
+            TAG="${{ github.ref_name }}"
+            sed -i 's/\(settings_project_name = ".*\)"/\1 - Release '"${TAG}"'"/' docs/it/conf.py
+            sed -i 's/\(settings_project_name = ".*\)"/\1 - Release '"${TAG}"'"/' docs/en/conf.py
+            echo "Applied tag '${TAG}' to document titles"
           else
             # This is for workflow_dispatch, we use editor's copy designation
             echo "Using default title for manual build"
@@ -191,9 +200,10 @@ jobs:
           path: pdf_output/*.pdf
 
       - name: Upload Release Asset
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v1
+        if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_type == 'tag')
+        uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
           files: pdf_output/*.pdf
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for building and publishing HTML and PDF documentation. The main goal is to ensure that builds and releases are triggered and handled correctly when a tag is pushed, not just when a release is published. This improves automation and ensures that documentation is consistently generated and released for both tags and releases.

Trigger and permissions updates:

* Workflows now trigger on tag pushes in addition to branch pushes and releases, ensuring documentation is built and published whenever a tag is pushed. (`.github/workflows/build-html.yml`, `.github/workflows/build-pdf.yml`) [[1]](diffhunk://#diff-86d1c330af5d3a30089305b9fddda6fa161cc69b17195ad49f4f3f2aeb17478aR7-R8) [[2]](diffhunk://#diff-2a0da5bf1761ab6928664a10d5e27abecb31975620f11280dc92e1642f431b2bR7-R16)
* Permissions for the `contents` scope are updated from `read` to `write` to allow pushing to `gh-pages` and uploading release assets. (`.github/workflows/build-html.yml`, `.github/workflows/build-pdf.yml`) [[1]](diffhunk://#diff-86d1c330af5d3a30089305b9fddda6fa161cc69b17195ad49f4f3f2aeb17478aL32-R34) [[2]](diffhunk://#diff-2a0da5bf1761ab6928664a10d5e27abecb31975620f11280dc92e1642f431b2bR7-R16)

Build logic improvements:

* The image build step is skipped on tag pushes and releases, using the existing image instead. The workflow logic is updated to handle this condition. (`.github/workflows/build-html.yml`, `.github/workflows/build-pdf.yml`) [[1]](diffhunk://#diff-86d1c330af5d3a30089305b9fddda6fa161cc69b17195ad49f4f3f2aeb17478aL48-R58) [[2]](diffhunk://#diff-2a0da5bf1761ab6928664a10d5e27abecb31975620f11280dc92e1642f431b2bL26-R35)
* The `get_image_tag` job now runs for tag pushes as well, ensuring the correct image tag is used for subsequent jobs. (`.github/workflows/build-html.yml`, `.github/workflows/build-pdf.yml`) [[1]](diffhunk://#diff-86d1c330af5d3a30089305b9fddda6fa161cc69b17195ad49f4f3f2aeb17478aL115-R122) [[2]](diffhunk://#diff-2a0da5bf1761ab6928664a10d5e27abecb31975620f11280dc92e1642f431b2bL92-R96)

Release and asset handling:

* Document titles are updated to include the tag name when building for a tag push, matching the behavior for releases. (`.github/workflows/build-html.yml`, `.github/workflows/build-pdf.yml`) [[1]](diffhunk://#diff-86d1c330af5d3a30089305b9fddda6fa161cc69b17195ad49f4f3f2aeb17478aR168-R170) [[2]](diffhunk://#diff-86d1c330af5d3a30089305b9fddda6fa161cc69b17195ad49f4f3f2aeb17478aR184-R188) [[3]](diffhunk://#diff-2a0da5bf1761ab6928664a10d5e27abecb31975620f11280dc92e1642f431b2bR129-R133)
* PDF assets are uploaded as release assets for tag pushes, not just for releases, and the action version is updated to v2. (`.github/workflows/build-pdf.yml`)