### PR TITLE
ci: fix build and publish pdf on release again

### DIFF
--- a/.github/workflows/build-html.yml
+++ b/.github/workflows/build-html.yml
@@ -84,22 +84,38 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-  # Build only when image deps changed OR when no image exists in GHCR yet
+  # On release/tag: never build a new image — reuse existing image (latest). Job runs only so dependents run.
+  # Otherwise: build when deps changed or image missing, and event allows build.
   build-image:
     runs-on: ubuntu-latest
     needs: [check_image_deps, check_image_exists]
+    outputs:
+      built: ${{ steps.built.outputs.built }}
     if: |
-      ((needs.check_image_deps.outputs.build-image == 'true') ||
-       (needs.check_image_exists.outputs.exists != 'true')) &&
-      (github.event_name == 'push' ||
-       github.event_name == 'release' ||
-       github.event_name == 'workflow_dispatch' ||
-       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository))
+      (github.event_name == 'release' || (github.event_name == 'push' && github.ref_type == 'tag')) ||
+      (((needs.check_image_deps.outputs.build-image == 'true') ||
+        (needs.check_image_exists.outputs.exists != 'true')) &&
+       (github.event_name == 'push' ||
+        github.event_name == 'release' ||
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)))
     steps:
+      - name: Set built flag (reuse existing image on release/tag; build only when deps or image missing)
+        id: built
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]] || ( [[ "${{ github.event_name }}" == "push" ]] && [[ "${{ github.ref_type }}" == "tag" ]] ); then
+            echo "built=false" >> $GITHUB_OUTPUT
+            echo "Reusing existing image for release/tag — no image build"
+          else
+            echo "built=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout repository
+        if: steps.built.outputs.built == 'true'
         uses: actions/checkout@v4
 
       - name: Log in to GitHub Container Registry
+        if: steps.built.outputs.built == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -107,6 +123,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Sphinx/LaTeX image
+        if: steps.built.outputs.built == 'true'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -119,13 +136,12 @@ jobs:
   get_image_tag:
     runs-on: ubuntu-latest
     needs: [build-image]
-    if: always() && (github.event_name == 'release' || (github.event_name == 'push' && github.ref_type == 'tag') || needs.build-image.result == 'success' || needs.build-image.result == 'skipped' || needs.build-image.result == 'failure')
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
     steps:
       - id: set_tag
         run: |
-          if [ "${{ needs.build-image.result }}" = "success" ]; then
+          if [ "${{ needs.build-image.result }}" = "success" ] && [ "${{ needs.build-image.outputs.built }}" = "true" ]; then
             echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
           else
             echo "tag=latest" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -61,18 +61,34 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-  # Build image only when: (1) deps changed, or (2) image does not exist in GHCR. If build succeeds, HTML/PDF use it.
+  # On release/tag: we never build a new image — reuse existing image (latest). Job runs only so dependents (get_image_tag, build-pdf) are not skipped.
+  # Otherwise: build when deps changed or image missing in GHCR.
   build-image:
     runs-on: ubuntu-latest
     needs: [check_image_deps, check_image_exists]
+    outputs:
+      built: ${{ steps.built.outputs.built }}
     if: |
+      (github.event_name == 'release' || (github.event_name == 'push' && github.ref_type == 'tag')) ||
       (needs.check_image_deps.outputs.build-image == 'true') ||
       (needs.check_image_exists.outputs.exists != 'true')
     steps:
+      - name: Set built flag (reuse existing image on release/tag; build only when deps or image missing)
+        id: built
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]] || ( [[ "${{ github.event_name }}" == "push" ]] && [[ "${{ github.ref_type }}" == "tag" ]] ); then
+            echo "built=false" >> $GITHUB_OUTPUT
+            echo "Reusing existing image for release/tag — no image build"
+          else
+            echo "built=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout repository
+        if: steps.built.outputs.built == 'true'
         uses: actions/checkout@v4
 
       - name: Log in to GitHub Container Registry
+        if: steps.built.outputs.built == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -80,6 +96,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Sphinx/LaTeX image
+        if: steps.built.outputs.built == 'true'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -89,18 +106,16 @@ jobs:
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ github.sha }}
 
-  # Always run on release so build-pdf always produces PDFs. Otherwise run when build-image finished (success/skipped/failure).
   get_image_tag:
     runs-on: ubuntu-latest
     needs: [build-image]
-    if: always() && (github.event_name == 'release' || (github.event_name == 'push' && github.ref_type == 'tag') || needs.build-image.result == 'success' || needs.build-image.result == 'skipped' || needs.build-image.result == 'failure')
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
     steps:
       - id: set_tag
         run: |
-          # On release or when build was skipped/failed, use latest; only use SHA when we just built.
-          if [ "${{ needs.build-image.result }}" = "success" ]; then
+          # Use SHA only when we actually built the image; otherwise use latest (release/tag push or build skipped/failed).
+          if [ "${{ needs.build-image.result }}" = "success" ] && [ "${{ needs.build-image.outputs.built }}" = "true" ]; then
             echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
           else
             echo "tag=latest" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for both HTML and PDF builds to improve container image handling. The main changes ensure that on releases or tag pushes, the workflows reuse the existing container image instead of rebuilding it, and downstream jobs correctly use the "latest" tag unless a new image was built. This prevents unnecessary image builds and ensures consistent behavior across release/tag events and other workflow triggers.

Container image build logic improvements:

* Updated the `build-image` job in both `.github/workflows/build-html.yml` and `.github/workflows/build-pdf.yml` to skip rebuilding the image on release or tag events, and introduced a `built` output flag to indicate whether a new image was built. [[1]](diffhunk://#diff-86d1c330af5d3a30089305b9fddda6fa161cc69b17195ad49f4f3f2aeb17478aL87-R126) [[2]](diffhunk://#diff-2a0da5bf1761ab6928664a10d5e27abecb31975620f11280dc92e1642f431b2bL64-R99)
* Added conditional steps for checking out the repository, logging in to the container registry, and building/pushing the image, so these only run if a new image build is required. [[1]](diffhunk://#diff-86d1c330af5d3a30089305b9fddda6fa161cc69b17195ad49f4f3f2aeb17478aL87-R126) [[2]](diffhunk://#diff-2a0da5bf1761ab6928664a10d5e27abecb31975620f11280dc92e1642f431b2bL64-R99)

Image tag selection logic:

* Modified the `get_image_tag` job in both workflows to set the image tag to `latest` unless a new image was actually built (determined by the `built` output flag), ensuring downstream jobs use the correct image version. [[1]](diffhunk://#diff-86d1c330af5d3a30089305b9fddda6fa161cc69b17195ad49f4f3f2aeb17478aL122-R144) [[2]](diffhunk://#diff-2a0da5bf1761ab6928664a10d5e27abecb31975620f11280dc92e1642f431b2bL92-R118)