### PR TITLE
editorial: img alignments

### DIFF
--- a/docs/en/brand-identity.rst
+++ b/docs/en/brand-identity.rst
@@ -68,7 +68,7 @@ The Logo is the official graphical element that ensures immediate recognition of
 
   .. figure:: ../../official_resources/symbol-IT-Wallet.svg
     :alt: “IT-Wallet” Logo symbol on a light background  
-    :width: 100%
+    :width: 25%
     :align: center
 
     “IT-Wallet” Logo symbol on a light background  
@@ -77,7 +77,7 @@ The Logo is the official graphical element that ensures immediate recognition of
 
   .. figure:: ./images/pdf/symbol-IT-Wallet.pdf
     :alt: “IT-Wallet” Logo symbol on a light background  
-    :width: 100%
+    :width: 25%
     :align: center
 
     “IT-Wallet” Logo symbol on a light background   

--- a/docs/en/brand-identity.rst
+++ b/docs/en/brand-identity.rst
@@ -50,6 +50,7 @@ The Logo is the official graphical element that ensures immediate recognition of
   .. figure:: ../../official_resources/logoIT-Wallet.svg
     :alt: “IT-Wallet" Logo on a light background  
     :width: 100%
+    :align: center
 
     “IT-Wallet" Logo on a light background  
 
@@ -58,6 +59,7 @@ The Logo is the official graphical element that ensures immediate recognition of
   .. figure:: ./images/pdf/logoIT-Wallet.pdf
     :alt: “IT-Wallet" Logo on a light background  
     :width: 100%
+    :align: center
 
     “IT-Wallet" Logo on a light background 
 
@@ -67,6 +69,7 @@ The Logo is the official graphical element that ensures immediate recognition of
   .. figure:: ../../official_resources/symbol-IT-Wallet.svg
     :alt: “IT-Wallet” Logo symbol on a light background  
     :width: 100%
+    :align: center
 
     “IT-Wallet” Logo symbol on a light background  
 
@@ -75,6 +78,7 @@ The Logo is the official graphical element that ensures immediate recognition of
   .. figure:: ./images/pdf/symbol-IT-Wallet.pdf
     :alt: “IT-Wallet” Logo symbol on a light background  
     :width: 100%
+    :align: center
 
     “IT-Wallet” Logo symbol on a light background   
 
@@ -115,6 +119,7 @@ The Trust Mark is the official graphic element that guarantees the belonging of 
   .. figure:: ../../official_resources/trustmark-ENG.svg
     :alt: Trust Mark on a light background  
     :width: 100%
+    :align: center
 
     Trust Mark on a light background  
 
@@ -123,6 +128,7 @@ The Trust Mark is the official graphic element that guarantees the belonging of 
   .. figure:: ./images/pdf/trustmark-ENG.pdf
     :alt: Trust Mark on a light background  
     :width: 100%
+    :align: center
 
     Trust Mark on a light background 
 

--- a/docs/en/functionalities.rst
+++ b/docs/en/functionalities.rst
@@ -17,6 +17,7 @@ The IT-Wallet System provides Users with a simpler, faster, and more secure way 
   .. figure:: ./images/svg/UX-phases-usage.svg
     :alt: User Experience phases of Wallet usage
     :width: 100%
+    :align: center
 
     User Experience phases of Wallet usage
 
@@ -25,6 +26,7 @@ The IT-Wallet System provides Users with a simpler, faster, and more secure way 
   .. figure:: ./images/pdf/UX-phases-usage.pdf
     :alt: User Experience phases of Wallet usage
     :width: 100%
+    :align: center
 
     User Experience phases of Wallet usage
 
@@ -69,6 +71,7 @@ The flow is shown below with illustrative wireframes.
   .. figure:: ./images/svg/IT-Wallet-Activation.svg
     :alt: Example of User Experience in Activating a Wallet Instance 
     :width: 100%
+    :align: center
 
     Example of User Experience in Activating a Wallet Instance
 
@@ -118,6 +121,7 @@ To ensure a consistent identification and representation of the PID across diffe
   .. figure:: ../../official_resources/IT-Wallet-ID.svg
     :alt: IT-Wallet ID official graphic asset on a light background 
     :width: 100%
+    :align: center
 
     IT-Wallet ID official graphic asset on a light background 
 
@@ -197,6 +201,7 @@ The flow is shown below with illustrative wireframes.
   .. figure:: ./images/svg/Issuance-from-catalog.svg
     :alt: Example of User Experience in the issuance an Electronic Attestation of Attributes from Catalog
     :width: 100%
+    :align: center
 
     Example of User Experience in the issuance an Electronic Attestation of Attributes from Catalog 
 
@@ -252,6 +257,7 @@ The flow is shown below with illustrative wireframes.
   .. figure:: ./images/svg/Issuance-from-Authentic-Source.svg
     :alt: Example of User Experience in the issuance of an Electronic Attestation of Attributes from the Authentic Source
     :width: 100%
+    :align: center
 
     Example of the User Experience during the issuance of an Electronic Attestation of Attributes from the Authentic Source.
 
@@ -381,6 +387,7 @@ Below an example of Electronic Attestation of Attribute layout, in a Preview Vie
   .. figure:: ./images/svg/Focus-EAA.svg
     :alt: Example of Electronic Attestation of Attribute layout, Preview View, and Detail View 
     :width: 100%
+    :align: center
 
     Example of Electronic Attestation of Attribute layout, Preview View, and Detail View.
 
@@ -442,6 +449,7 @@ The flow is shown below with illustrative wireframes.
   .. figure:: ./images/svg/proximity-presentation.svg
     :alt: Example of User Experience in proximity presentation
     :width: 100%
+    :align: center
 
     Example of User Experience in proximity presentation.
 
@@ -485,6 +493,7 @@ The flow is shown below with illustrative wireframes.
   .. figure:: ./images/svg/Remote-presentation-same-device.svg
     :alt: Example of User Experience in remote, same-device presentation
     :width: 100%
+    :align: center
 
     Example of User Experience in remote, same-device presentation.
 
@@ -525,6 +534,7 @@ The flow is shown below with illustrative wireframes.
   .. figure:: ./images/svg/Remote-presentation-cross-device.svg
     :alt: Example of User Experience in remote, cross-device presentation
     :width: 100%
+    :align: center
 
     Example of User Experience in remote, cross-device presentation.
 
@@ -606,6 +616,7 @@ To enable Authentication via the IT-Wallet System, the Relying Party MAY replace
   .. figure:: ./images/svg/discovery-page.svg
      :alt: Layout Model of Discovery Page in grid
      :width: 100%
+     :align: center
 
      Layout Model of Discovery Page in grid  
 
@@ -644,6 +655,7 @@ The Relying Party MUST implement the Selection Page made available in the :ref:`
   .. figure:: ./images/svg/selection-page.svg
      :alt: Selection Page
      :width: 100%
+     :align: center
 
      Selection Page 
 
@@ -684,6 +696,7 @@ Relying Parties MUST implement the QR Code Page (cross-device) provided in the :
   .. figure:: ./images/svg/QR-page.svg
      :alt: QR Code Page
      :width: 100%
+     :align: center
 
      QR Code Page 
  
@@ -723,6 +736,7 @@ Relying Parties MUST implement the Waiting Page (cross-device) provided in the :
   .. figure:: ./images/svg/waiting-page.svg
      :alt: Waiting Page
      :width: 100%
+     :align: center
 
      Waiting Page 
  
@@ -750,6 +764,7 @@ Relying Parties MUST implement the Thank You Page provided in the :ref:`official
   .. figure:: ./images/svg/thank-you-page.svg
      :alt: Thank You Page
      :width: 100%
+     :align: center
 
      Thank You Page 
  
@@ -778,6 +793,7 @@ Relying Parties MUST implement the Error Page provided in the :ref:`official-res
   .. figure:: ./images/svg/error-page.svg
      :alt: Error Page
      :width: 100%
+     :align: center
 
      Error Page 
  
@@ -802,6 +818,7 @@ Both flows are shown below with illustrative wireframes.
   .. figure:: ./images/svg/Authentication-same-device.svg
     :alt: Example of same-device Authentication User Experience
     :width: 100%
+    :align: center
 
     Example of same-device Authentication User Experience.
 
@@ -828,6 +845,7 @@ Both flows are shown below with illustrative wireframes.
   .. figure:: ./images/svg/Authentication-cross-device.svg
     :alt: Example of cross-device Authentication User Experience
     :width: 100%
+    :align: center
 
     Example of cross-device Authentication User Experience.
 
@@ -901,6 +919,7 @@ Below are some non-mandatory examples of Authentication Button layout:
   .. figure:: ./images/svg/authentication-button-layout.svg
      :alt: Variants of Authentication Button layout
      :width: 100% 
+     :align: center
 
      Variants of Authentication Button layout
 
@@ -919,6 +938,7 @@ The integration of the Authentication Button within the Discovery Page may vary 
   .. figure:: ./images/svg/discovery-page-layouts.svg
      :alt: Examples of Discovery Page layouts: grid, tab, and list
      :width: 100%
+     :align: center
 
      Examples of Discovery Page layouts: grid, tab, and list
 
@@ -949,6 +969,7 @@ For further information on the Authentication button refer to the Brand Manual, 
   .. figure:: ../../official_resources/Authentication-button-ENG.svg
      :alt: Authentication button in its dimension variants
      :width: 100%
+     :align: center
 
      Example of Authentication button in its dimension variants
 
@@ -966,6 +987,7 @@ For further information on the Authentication button refer to the Brand Manual, 
   .. figure:: ../../official_resources/Authentication-Button-ENG-Fixed-Justified.svg
      :alt: Authentication button fixed justified 
      :width: 100%
+     :align: center
 
      Authentication button fixed justified
 
@@ -983,6 +1005,7 @@ For further information on the Authentication button refer to the Brand Manual, 
   .. figure:: ../../official_resources/Authentication-Button-ENG-Fixed-Centered.svg
      :alt: Authentication button fixed centered
      :width: 100%
+     :align: center
 
      Authentication button fixed centered
 
@@ -1076,6 +1099,9 @@ The flow is shown below with illustrative wireframes.
   .. figure:: ./images/svg/Revocation-EAA-from-wallet.svg
      :alt: Example of User Experience in Revoking an Electronic Attestation
      :width: 100%
+     :align: center
+
+     Example of User Experience in Revoking an Electronic Attestation
 
      Example of User Experience in Revoking an Electronic Attestation.
 

--- a/docs/it/brand-identity.rst
+++ b/docs/it/brand-identity.rst
@@ -51,6 +51,7 @@ Il Logo è l'elemento grafico ufficiale che permette l'immediata riconoscibilit�
   .. figure:: ../../official_resources/logoIT-Wallet.svg
     :alt: Logo del Brand “IT-Wallet” su sfondo chiaro  
     :width: 100%
+    :align: center
 
     Logo del Brand “IT-Wallet” su sfondo chiaro  
 
@@ -59,6 +60,7 @@ Il Logo è l'elemento grafico ufficiale che permette l'immediata riconoscibilit�
   .. figure:: ./images/pdf/logoIT-Wallet.pdf
     :alt: Logo del Brand “IT-Wallet” su sfondo chiaro  
     :width: 100%
+    :align: center
 
     Logo del Brand “IT-Wallet” su sfondo chiaro 
 
@@ -68,6 +70,7 @@ Il Logo è l'elemento grafico ufficiale che permette l'immediata riconoscibilit�
   .. figure:: ../../official_resources/symbol-IT-Wallet.svg
     :alt: Pittogramma del Brand “IT-Wallet” su sfondo chiaro  
     :width: 100%
+    :align: center
 
     Pittogramma del Brand “IT-Wallet” su sfondo chiaro  
 
@@ -76,6 +79,7 @@ Il Logo è l'elemento grafico ufficiale che permette l'immediata riconoscibilit�
   .. figure:: ./images/pdf/symbol-IT-Wallet.pdf
     :alt: Pittogramma del Brand “IT-Wallet” su sfondo chiaro  
     :width: 100%
+    :align: center
 
     Pittogramma del Brand “IT-Wallet” su sfondo chiaro   
 
@@ -113,6 +117,7 @@ Il Trust Mark è l'elemento grafico ufficiale che dà prova all’Utente dell'ap
   .. figure:: ../../official_resources/trustmark-ITA.svg
     :alt: Trust Mark su sfondo chiaro  
     :width: 100%
+    :align: center
 
     Trust Mark su sfondo chiaro  
 
@@ -121,6 +126,7 @@ Il Trust Mark è l'elemento grafico ufficiale che dà prova all’Utente dell'ap
   .. figure:: ./images/pdf/trustmark-ITA.pdf
     :alt: Trust Mark su sfondo chiaro  
     :width: 100%
+    :align: center
 
     Trust Mark su sfondo chiaro 
 

--- a/docs/it/functionalities.rst
+++ b/docs/it/functionalities.rst
@@ -19,6 +19,7 @@ Il Sistema IT-Wallet offre all'utente un'esperienza più semplice, veloce e sicu
   .. figure:: ./images/svg/UX-phases-usage.svg
     :alt: Fasi dell'Esperienza Utente di utilizzo di un'Istanza del Wallet 
     :width: 100%
+    :align: center
 
     Fasi dell'Esperienza Utente di utilizzo di un'Istanza del Wallet 
 
@@ -71,6 +72,7 @@ Il flusso è rappresentato di seguito con wireframe esemplificativi.
   .. figure:: ./images/svg/Attivazione-IT-Wallet.svg
     :alt: Esempio di Esperienza Utente nell'Attivazione di un'Istanza del Wallet 
     :width: 100%
+    :align: center
 
     Esempio di Esperienza Utente nell'Attivazione di un'Istanza del Wallet.
 
@@ -121,6 +123,7 @@ Per assicurare un’identificazione e una rappresentazione del PID coerente tra 
   .. figure:: ../../official_resources/IT-Wallet-ID.svg
     :alt: Elemento grafico “IT-Wallet ID” su sfondo chiaro 
     :width: 100%
+    :align: center
 
     Elemento grafico “IT-Wallet ID” su sfondo chiaro 
 
@@ -201,6 +204,7 @@ Il flusso è rappresentato di seguito con wireframe esemplificativi.
   .. figure:: ./images/svg/Ottenimento-da-catalogo.svg
     :alt: Esempio di Esperienza Utente nell'Ottenimento di un Attestato Elettronico di Attributi da Catalogo
     :width: 100%
+    :align: center
 
     Esempio di Esperienza Utente nell'Ottenimento di un Attestato Elettronico di Attributi da Catalogo.
 
@@ -259,6 +263,7 @@ Il flusso è rappresentato di seguito con wireframe esemplificativi.
   .. figure:: ./images/svg/Ottenimento-da-fonte-autentica.svg
     :alt: Esempio di Esperienza Utente nell'Ottenimento di un Attestato Elettronico da Touchpoint della Fonte Autentica
     :width: 100%
+    :align: center
 
     Esempio di Esperienza Utente nell'Ottenimento di un Attestato Elettronico da Touchpoint della Fonte Autentica
 
@@ -383,6 +388,7 @@ Di seguito un esempio di layout di Attestato Elettronico di Attributi, all'inter
   .. figure:: ./images/svg/A4-Focus-EAA.svg
     :alt: Esempio di layout di Attestato Elettronico di Attributi, Vista in Anteprima e Vista di Dettaglio
     :width: 100%
+    :align: center
 
     Esempio di layout di Attestato Elettronico di Attributi, Vista in Anteprima e Vista di Dettaglio
 
@@ -444,6 +450,7 @@ Il flusso è rappresentato di seguito con wireframe esemplificativi.
   .. figure:: ./images/svg/Presentazione-prossimita.svg
     :alt: Esempio di Esperienza Utente nella presentazione in prossimità
     :width: 100%
+    :align: center
 
     Esempio di Esperienza Utente nella presentazione in prossimità
 
@@ -488,6 +495,7 @@ Il flusso è rappresentato di seguito con wireframe esemplificativi.
   .. figure:: ./images/svg/Presentazione-remoto-same-device.svg
     :alt: Esempio di Esperienza Utente nella presentazione da remoto, same-device
     :width: 100%
+    :align: center
 
     Esempio di Esperienza Utente nella presentazione da remoto, same-device
 
@@ -527,6 +535,7 @@ Il flusso è rappresentato di seguito con wireframe esemplificativi.
   .. figure:: ./images/svg/Presentazione-remoto-cross-device.svg
     :alt: Esempio di Esperienza Utente nella presentazione da remoto, cross-device
     :width: 100%
+    :align: center
 
     Esempio di Esperienza Utente nella presentazione da remoto, cross-device
 
@@ -603,6 +612,7 @@ Per garantire l'Autenticazione tramite il Sistema IT-Wallet, il Verificatore di 
   .. figure:: ./images/svg/discovery-page.svg
      :alt: Modello di layout di Discovery Page a griglia
      :width: 100%
+     :align: center
 
      Modello di layout di Discovery Page a griglia  
 
@@ -641,6 +651,7 @@ Il Verificatore di Attestati Elettronici DEVE implementare la Selection Page res
   .. figure:: ./images/svg/selection-page.svg
      :alt: Selection Page
      :width: 100%
+     :align: center
 
      Selection Page 
 
@@ -681,6 +692,7 @@ Il Verificatore di Attestati Elettronici DEVE implementare la QR Code Page (flus
   .. figure:: ./images/svg/QR-page.svg
      :alt: QR Code Page
      :width: 100%
+     :align: center
 
      QR Code Page 
  
@@ -720,6 +732,7 @@ Il Verificatore di Attestati Elettronici DEVE implementare la Waiting Page (cros
   .. figure:: ./images/svg/waiting-page.svg
      :alt: Waiting Page
      :width: 100%
+     :align: center
 
      Waiting Page 
  
@@ -747,6 +760,7 @@ Il Verificatore di Attestati Elettronici DEVE implementare la Thank You Page res
   .. figure:: ./images/svg/thank-you-page.svg
      :alt: Thank You Page
      :width: 100%
+     :align: center
 
      Thank You Page 
  
@@ -775,6 +789,7 @@ Il Verificatore di Attestati Elettronici DEVE implementare la Error Page resa di
   .. figure:: ./images/svg/error-page.svg
      :alt: Error Page
      :width: 100%
+     :align: center
 
      Error Page 
  
@@ -800,6 +815,7 @@ Entrambi i flussi sono rappresentati di seguito con wireframe esemplificativi.
   .. figure:: ./images/svg/Autenticazione-same-device.svg
     :alt: Esempio di Esperienza Utente di Autenticazione same-device
     :width: 100%
+    :align: center
 
     Esempio di Esperienza Utente di Autenticazione same-device.
 
@@ -824,6 +840,7 @@ Entrambi i flussi sono rappresentati di seguito con wireframe esemplificativi.
   .. figure:: ./images/svg/Autenticazione-cross-device.svg
     :alt: Esempio di Esperienza Utente di Autenticazione cross-device
     :width: 100%
+    :align: center
 
     Esempio di Esperienza Utente di Autenticazione cross-device
 
@@ -892,6 +909,7 @@ Di seguito alcuni esempi non normativi di layout dell'Authentication Button:
   .. figure:: ./images/svg/layout-pulsante-autenticazione.svg
      :alt: Varianti di Authentication Button
      :width: 100% 
+     :align: center
 
  Varianti di Authentication Button
 
@@ -910,6 +928,7 @@ Le modalità di integrazione dell'Authentication Button nella Discovery Page pos
   .. figure:: ./images/svg/discovery-page-layouts.svg
     :alt: Esempi di layout di Discovery Page a griglia, a tab e in lista
      :width: 100%
+     :align: center
 
     Esempi di layout di Discovery Page a griglia, a tab e in lista
 
@@ -940,6 +959,7 @@ Per approfondimenti sull'Authentication button consultare il Brand Manual, indic
   .. figure:: ../../official_resources/Authentication-button-ITA.svg
      :alt: Authentication button nelle varianti di dimensione (S, M, L)
      :width: 100%
+     :align: center
 
      Authentication button nelle varianti di dimensione (S, M, L)
 
@@ -958,6 +978,7 @@ Per approfondimenti sull'Authentication button consultare il Brand Manual, indic
   .. figure:: ../../official_resources/Authentication-Button-ITA-Fixed-Justified.svg
      :alt: Authentication button giustificato, a larghezza fissa
      :width: 100%
+     :align: center
 
      Authentication button giustificato, a larghezza fissa
 
@@ -975,6 +996,7 @@ Per approfondimenti sull'Authentication button consultare il Brand Manual, indic
   .. figure:: ../../official_resources/Authentication-Button-ITA-Fixed-Centered.svg
      :alt: Authentication button centrato, a larghezza fissa
      :width: 100%
+     :align: center
 
      Authentication button centrato, a larghezza fissa
 


### PR DESCRIPTION
This PR resolves https://github.com/italia/eid-wallet-it-docs/issues/971

it adds `:align: center` to all figure blocks in `docs/en/brand-identity.rst` and `docs/it/brand-identity.rst` for logo, symbol, and trust mark images, improving visual consistency in brand identity sections.

These changes make all visual elements are properly centered.

it also resize the logo symbol in section brand identity
