### PR TITLE
align credential lifecycle states and OpenAPI enum mapping

### DIFF
--- a/docs/en/authentic-source-endpoint.rst
+++ b/docs/en/authentic-source-endpoint.rst
@@ -58,21 +58,24 @@ To ensure consistency between the "Electronic Attestation Lifecycle" documented 
      - **Description and Logic**
    * - **Issued** / **Valid**
      - ``VALID``
-     - The dataset is administratively active.
+     - The dataset is administratively active and within its validity period.
    * - **Expired**
      - ``VALID``
-     - The dataset is past its expiry. It returns ``VALID``, delegating the check to the Issuer.
+     - The technical credential (mDL/SD-JWT) has expired, but the underlying dataset remains administratively valid. This allows for credential re-issuance.
    * - **Suspended**
      - ``SUSPENDED``
      - The attestation is temporarily invalid.
    * - **Revoked**
      - ``INVALID``
-     - The attestation has been actively revoked or terminated.
+     - The attestation has been actively revoked or terminated at the source.
 
 **Operational Guidance:**
 
-* **Metadata Verification**: The Credential Issuer MUST verify usability through the ``issuance_date`` and ``expiry_date`` claims.
-* **Irreversibility**: After a transition to ``INVALID``, the Credential cannot return to a ``VALID`` state.
+* **Technical vs Administrative Validity**: Credentials distinguish between a **technical validity** set by the Issuer (claims ``iat`` and ``exp``) and an **administrative validity** determined by the Authentic Source (claims ``issuance_date`` and ``expiry_date``).
+* **Expiry Hierarchy**: The technical expiry (``exp``) MUST NOT be later than the administrative expiry (``expiry_date``). For example, a driver's license may be administratively valid for 10 years, while the issued mDL credential may have a technical expiry of 1 year.
+* **Re-issuance**: If a credential reaches its technical expiry (``exp``) but the dataset is still administratively valid, the OpenAPI status remains ``VALID``, allowing the credential to be re-issued multiple times within the administrative timeframe.
+* **Metadata Verification**: The Credential Issuer MUST verify the effective usability by checking both the technical claims and the administrative dates.
+* **Irreversibility**: After a transition to ``INVALID``, the Credential cannot return to a ``VALID`` state. A new issuance is required for a new dataset.
 * **Signal Processing**: Signals MUST be processed sequentially. If a signal invalidates a Credential, subsequent correction signals for the same object are ignored.
 
 Example of Authentic Source response

--- a/docs/en/authentic-source-endpoint.rst
+++ b/docs/en/authentic-source-endpoint.rst
@@ -44,6 +44,37 @@ Get Attribute Claims
     - the Authentic Source MUST record the datetime value provided within the ``last_updated`` parameter, which indicates the last time the User's attributes were updated in the Authentic Source's database;
     - the Credential Issuer MUST read the ``last_updated`` value received in the response to be able to check if the User's attributes have changed since the last issuance of a Digital Credential.
 
+Credential Lifecycle States Mapping
+"""""""""""""""""""""""""""""""""""
+
+To ensure consistency between the "Electronic Attestation Lifecycle" documented in :ref:`credential-revocation:Digital Credential Lifecycle` and the OpenAPI status Enum, the following mapping MUST be applied for the ``status`` field in the ``attributeClaims``:
+
+.. list-table::
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - **Lifecycle State (Ch. 11.3)**
+     - **OpenAPI status enum**
+     - **Description and Logic**
+   * - **Issued** / **Valid**
+     - ``VALID``
+     - The dataset is administratively active.
+   * - **Expired**
+     - ``VALID``
+     - The dataset is past its expiry. It returns ``VALID``, delegating the check to the Issuer.
+   * - **Suspended**
+     - ``SUSPENDED``
+     - The attestation is temporarily invalid.
+   * - **Revoked**
+     - ``INVALID``
+     - The attestation has been actively revoked or terminated.
+
+**Operational Guidance:**
+
+* **Metadata Verification**: The Credential Issuer MUST verify usability through the ``issuance_date`` and ``expiry_date`` claims.
+* **Irreversibility**: After a transition to ``INVALID``, the Credential cannot return to a ``VALID`` state.
+* **Signal Processing**: Signals MUST be processed sequentially. If a signal invalidates a Credential, subsequent correction signals for the same object are ignored.
+
 Example of Authentic Source response
 """""""""""""""""""""""""""""""""""""
 

--- a/docs/en/authentic-source-endpoint.rst
+++ b/docs/en/authentic-source-endpoint.rst
@@ -45,38 +45,33 @@ Get Attribute Claims
     - the Credential Issuer MUST read the ``last_updated`` value received in the response to be able to check if the User's attributes have changed since the last issuance of a Digital Credential.
 
 Credential Lifecycle States Mapping
-"""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""""""""
 
-To ensure consistency between the "Electronic Attestation Lifecycle" documented in :ref:`credential-revocation:Digital Credential Lifecycle` and the OpenAPI status Enum, the following mapping MUST be applied for the ``status`` field in the ``attributeClaims``:
+To ensure consistency between the "Electronic Attestation Lifecycle" documented in :ref:`credential-revocation:Digital Credential Lifecycle` and the OpenAPI status Enum, the following mapping and operational logic MUST be applied for the ``status`` field in the ``attributeClaims``.
 
-.. list-table::
-   :widths: 25 25 50
-   :header-rows: 1
-
-   * - **Lifecycle State (Ch. 11.3)**
-     - **OpenAPI status enum**
-     - **Description and Logic**
-   * - **Issued** / **Valid**
-     - ``VALID``
-     - The dataset is administratively active and within its validity period.
-   * - **Expired**
-     - ``VALID``
-     - The technical credential (mDL/SD-JWT) has expired, but the underlying dataset remains administratively valid. This allows for credential re-issuance.
-   * - **Suspended**
-     - ``SUSPENDED``
-     - The attestation is temporarily invalid.
-   * - **Revoked**
-     - ``INVALID``
-     - The attestation has been actively revoked or terminated at the source.
+**Directionality and Responsibility:**
+State changes of a Digital Credential at the Credential Issuer level DO NOT imply a change at the Authentic Source. Conversely, any state change of a dataset at the Authentic Source MUST be processed by the Credential Issuer to update the technical Digital Credential status.
 
 **Operational Guidance:**
 
-* **Technical vs Administrative Validity**: Credentials distinguish between a **technical validity** set by the Issuer (claims ``iat`` and ``exp``) and an **administrative validity** determined by the Authentic Source (claims ``issuance_date`` and ``expiry_date``).
-* **Expiry Hierarchy**: The technical expiry (``exp``) MUST NOT be later than the administrative expiry (``expiry_date``). For example, a driver's license may be administratively valid for 10 years, while the issued mDL credential may have a technical expiry of 1 year.
-* **Re-issuance**: If a credential reaches its technical expiry (``exp``) but the dataset is still administratively valid, the OpenAPI status remains ``VALID``, allowing the credential to be re-issued multiple times within the administrative timeframe.
+* **Technical vs Administrative Validity**: Digital Credentials distinguish between a **technical validity** set by the Credential Issuer (claims ``iat`` and ``exp``) and an **administrative validity** determined by the Authentic Source (claims ``issuance_date`` and ``expiry_date``).
+* **Expiry Hierarchy**: The technical expiry (``exp``) MUST NOT be later than the administrative expiry (``expiry_date``). For example, a driver's license may be administratively valid for 10 years, while the issued Digital Credential may have a technical expiry of 1 year.
+* **Re-issuance**: If a Digital Credential reaches its technical expiry (``exp``) but the dataset is still administratively valid, the OpenAPI status remains ``VALID``, allowing the Digital Credential to be re-issued multiple times within the administrative timeframe.
 * **Metadata Verification**: The Credential Issuer MUST verify the effective usability by checking both the technical claims and the administrative dates.
-* **Irreversibility**: After a transition to ``INVALID``, the Credential cannot return to a ``VALID`` state. A new issuance is required for a new dataset.
-* **Signal Processing**: Signals MUST be processed sequentially. If a signal invalidates a Credential, subsequent correction signals for the same object are ignored.
+* **Irreversibility**: After a transition to ``INVALID``, the Digital Credential cannot return to a ``VALID`` state. A new issuance is required for a new dataset. This applies to both explicit revocation and administrative expiry.
+* **Signal Processing**: Signals MUST be processed sequentially. If a Signal invalidates a Digital Credential, subsequent correction Signals for the same object are ignored.
+
+**Status Mapping and Case Logic:**
+
+The Credential Issuer MUST update the Digital Credential ``status`` based on Signals received from the Authentic Source via Signal Hub (``signalType=UPDATE``):
+
+* **Revocation**: If a dataset is revoked at the Authentic Source (status ``INVALID``), the Credential Issuer MUST revoke the Digital Credentials that use that dataset (status transition from ``VALID/SUSPENDED`` to ``INVALID``).
+* **Suspension**: If a dataset is suspended at the Authentic Source (status ``SUSPENDED``), the Credential Issuer MUST suspend the Digital Credentials (status transition from ``VALID`` to ``SUSPENDED``).
+* **Restoration**: If a suspended dataset returns to ``VALID`` at the Authentic Source, the Credential Issuer MUST restore the Digital Credential validity (status transition from ``SUSPENDED`` to ``VALID``).
+* **Modification**: If a dataset is modified but remains ``VALID`` at the Authentic Source, the Credential Issuer—detecting the change via the ``last_updated`` field—assigns the technical status ``ATTRIBUTE_UPDATE`` to the Digital Credential. This triggers a re-issuance flow when the Wallet Instance checks the status.
+* **Administrative Expiry**:
+    * **Scenario A (Metadata-driven)**: If ``expiry_date`` was shared with the Credential Issuer in metadata, the Authentic Source DOES NOT send Signals upon expiry; the Credential Issuer manages the lifecycle independently ensuring technical ``exp`` <= ``expiry_date``.
+    * **Scenario B (Signal-driven)**: If ``expiry_date`` is NOT present in metadata and the dataset expires, the Authentic Source MUST set its status to ``INVALID`` and send a Signal via Signal Hub; the Credential Issuer then revokes the Digital Credentials (status transition to ``INVALID``).
 
 Example of Authentic Source response
 """""""""""""""""""""""""""""""""""""

--- a/docs/it/authentic-source-endpoint.rst
+++ b/docs/it/authentic-source-endpoint.rst
@@ -44,39 +44,34 @@ Get Attribute Claims
     - la Fonte Autentica DEVE registrare il valore datetime fornito all'interno del parametro ``last_updated``, che indica data e orario dell'ultima volta che gli Attributi dell'Utente sono stati aggiornati nel database della Fonte Autentica;
     - il Credential Issuer DEVE leggere il valore ``last_updated`` ricevuto nella risposta per essere in grado di verificare se gli Attributi dell'Utente sono cambiati dall'ultima emissione di un Attestato Elettronico.
 
-Mapping degli Stati del Ciclo di Vita delle Credenziali
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Mapping degli Stati del Ciclo di Vita degli Attestati Elettronici
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-Per garantire la coerenza tra il "Ciclo di Vita degli Attestati Elettronici" documentato in :ref:`credential-revocation:Ciclo di Vita degli Attestati Elettronici` e l'Enum ``status`` delle OpenAPI, deve essere applicato il seguente mapping per il campo ``status`` presente negli ``attributeClaims``:
+Per garantire la coerenza tra il "Ciclo di Vita degli Attestati Elettronici" documentato in :ref:`credential-revocation:Ciclo di Vita degli Attestati Elettronici` e l'Enum status delle OpenAPI, la seguente mappatura e logica operativa DEVE essere applicata per il campo ``status`` negli ``attributeClaims``.
 
-.. list-table::
-   :widths: 25 25 50
-   :header-rows: 1
-
-   * - **Stato del Ciclo di Vita**
-     - **OpenAPI status enum**
-     - **Descrizione e Logica**
-   * - **Issued** / **Valid**
-     - ``VALID``
-     - Il dataset è amministrativamente attivo e nel suo periodo di validità.
-   * - **Expired**
-     - ``VALID``
-     - La credenziale tecnica (mDL/SD-JWT) è scaduta, ma il dataset sottostante rimane amministrativamente valido. Ciò permette la riemissione della credenziale.
-   * - **Suspended**
-     - ``SUSPENDED``
-     - L'attestazione è temporaneamente non valida.
-   * - **Revoked**
-     - ``INVALID``
-     - L'attestazione è stata revocata o terminata permanentemente alla fonte.
+**Direzionalità e Responsabilità:**
+I cambiamenti di stato di un Attestato Elettronico a livello di Fornitore di Attestati Elettronici NON implicano un cambiamento presso la Fonte Autentica. Al contrario, qualsiasi cambiamento di stato di un dataset presso la Fonte Autentica DEVE essere elaborato dal Fornitore di Attestati Elettronici per aggiornare lo stato tecnico dell'Attestato Elettronico.
 
 **Guida Operativa:**
 
-* **Validità Tecnica vs Amministrativa**: Le credenziali distinguono tra una **scadenza tecnica** stabilita dall'Issuer (claim ``iat`` ed ``exp``) e una **scadenza amministrativa** determinata dalla fonte autentica (claim ``issuance_date`` ed ``expiry_date``).
-* **Gerarchia delle Scadenze**: La scadenza tecnica (``exp``) NON può essere successiva alla scadenza amministrativa (``expiry_date``). Ad esempio, una patente può essere valida amministrativamente per 10 anni, mentre la credenziale tecnica emessa può avere una scadenza di 1 anno.
-* **Riemissione**: Se una credenziale raggiunge la scadenza tecnica (``exp``) ma il dataset è ancora amministrativamente valido, lo stato nelle OpenAPI rimane ``VALID``. Questo consente di riemettere la credenziale più volte all'interno dell'arco temporale di validità amministrativa.
-* **Verifica dei Metadati**: Il Credential Issuer deve verificare l'effettiva usabilità della credenziale controllando sia i claim tecnici di sessione che le date amministrative del dataset.
-* **Irreversibilità**: Una volta che una credenziale transita nello stato ``INVALID``, non può più tornare allo stato ``VALID``. Per un nuovo dataset è necessaria una nuova emissione.
-* **Elaborazione dei Segnali**: I segnali provenienti dal Signal Hub devono essere elaborati sequenzialmente. Se un segnale invalida una credenziale, eventuali segnali di correzione successivi per lo stesso ``object_id`` devono essere ignorati.
+* **Validità Tecnica vs Amministrativa**: Gli Attestati Elettronici distinguono tra una **validità tecnica** stabilita dal Fornitore di Attestati Elettronici (claim ``iat`` ed ``exp``) e una **validità amministrativa** determinata dalla Fonte Autentica (claim ``issuance_date`` ed ``expiry_date``).
+* **Gerarchia delle Scadenze**: La scadenza tecnica (``exp``) NON DEVE essere successiva alla scadenza amministrativa (``expiry_date``). Per esempio, una patente di guida può essere amministrativamente valida per 10 anni, mentre l'Attestato Elettronico emesso può avere una scadenza tecnica di 1 anno.
+* **Riemissione**: Se un Attestato Elettronico raggiunge la sua scadenza tecnica (``exp``) ma il dataset è ancora amministrativamente valido, lo stato OpenAPI rimane ``VALID``, consentendo all'Attestato Elettronico di essere riemesso più volte entro l'arco temporale amministrativo.
+* **Verifica dei Metadati**: Il Fornitore di Attestati Elettronici DEVE verificare l'effettiva usabilità controllando sia i claim tecnici che le date amministrative.
+* **Irreversibilità**: Dopo una transizione a ``INVALID``, l'Attestato Elettronico non può tornare a uno stato ``VALID``. È richiesta una nuova emissione per un nuovo dataset. Questo si applica sia alla revoca esplicita che alla scadenza amministrativa.
+* **Elaborazione dei Segnali**: I Segnali DEVONO essere elaborati sequenzialmente. Se un Segnale invalida un Attestato Elettronico, i successivi Segnali di correzione per lo stesso oggetto vengono ignorati.
+
+**Mapping degli Stati e Logica dei Casi:**
+
+Il Fornitore di Attestati Elettronici DEVE aggiornare lo ``status`` dell'Attestato Elettronico in base ai Segnali ricevuti dalla Fonte Autentica via Signal Hub (``signalType=UPDATE``):
+
+* **Revoca**: Se un dataset viene revocato presso la Fonte Autentica (stato ``INVALID``), il Fornitore di Attestati Elettronici DEVE revocare gli Attestati Elettronici che utilizzano quel dataset (transizione di stato da ``VALID/SUSPENDED`` a ``INVALID``).
+* **Sospensione**: Se un dataset viene sospeso presso la Fonte Autentica (stato ``SUSPENDED``), il Fornitore di Attestati Elettronici DEVE sospendere gli Attestati Elettronici (transizione di stato da ``VALID`` a ``SUSPENDED``).
+* **Ripristino**: Se un dataset sospeso torna a essere ``VALID`` presso la Fonte Autentica, il Fornitore di Attestati Elettronici DEVE ripristinare la validità dell'Attestato Elettronico (transizione di stato da ``SUSPENDED`` a ``VALID``).
+* **Modifica**: Se un dataset viene modificato ma rimane ``VALID`` presso la Fonte Autentica, il Fornitore di Attestati Elettronici — rilevando il cambiamento tramite il campo ``last_updated`` — assegna lo stato tecnico ``ATTRIBUTE_UPDATE`` all'Attestato Elettronico. Questo avvia un flusso di riemissione quando l'Istanza del Wallet controlla lo stato.
+* **Scadenza Amministrativa**:
+    * **Scenario A (Basato sui metadati)**: Se ``expiry_date`` è stata condivisa con il Fornitore di Attestati Elettronici nei metadati, la Fonte Autentica NON invia Segnali alla scadenza; il Fornitore di Attestati Elettronici gestisce il ciclo di vita in modo indipendente garantendo che l'``exp`` tecnico sia <= ``expiry_date``.
+    * **Scenario B (Basato sui segnali)**: Se ``expiry_date`` NON è presente nei metadati e il dataset scade, la Fonte Autentica DEVE impostare il suo stato su ``INVALID`` e inviare un Segnale via Signal Hub; il Fornitore di Attestati Elettronici revoca quindi gli Attestati Elettronici (transizione di stato a ``INVALID``).
 
 Esempio di risposta della Authentic Source
 """"""""""""""""""""""""""""""""""""""""""

--- a/docs/it/authentic-source-endpoint.rst
+++ b/docs/it/authentic-source-endpoint.rst
@@ -58,20 +58,23 @@ Per garantire la coerenza tra il "Ciclo di Vita degli Attestati Elettronici" doc
      - **Descrizione e Logica**
    * - **Issued** / **Valid**
      - ``VALID``
-     - Il dataset è amministrativamente attivo. Lo stato "Issued" è considerato un valore inizialmente valido.
+     - Il dataset è amministrativamente attivo e nel suo periodo di validità.
    * - **Expired**
      - ``VALID``
-     - Il dataset ha superato la data di scadenza (``expiry_date``). Deve restituire ``VALID``, delegando il controllo sull'effettiva usabilità all'Issuer tramite i metadati.
+     - La credenziale tecnica (mDL/SD-JWT) è scaduta, ma il dataset sottostante rimane amministrativamente valido. Ciò permette la riemissione della credenziale.
    * - **Suspended**
      - ``SUSPENDED``
      - L'attestazione è temporaneamente non valida.
    * - **Revoked**
      - ``INVALID``
-     - L'attestazione è stata revocata o terminata permanentemente.
+     - L'attestazione è stata revocata o terminata permanentemente alla fonte.
 
 **Guida Operativa:**
 
-* **Verifica dei Metadati**: Poiché gli stati "Issued" ed "Expired" sono mappati come ``VALID``, il Credential Issuer deve verificare l'effettiva usabilità della credenziale controllando i claim ``issuance_date`` (nbf) ed ``expiry_date`` (exp).
+* **Validità Tecnica vs Amministrativa**: Le credenziali distinguono tra una **scadenza tecnica** stabilita dall'Issuer (claim ``iat`` ed ``exp``) e una **scadenza amministrativa** determinata dalla fonte autentica (claim ``issuance_date`` ed ``expiry_date``).
+* **Gerarchia delle Scadenze**: La scadenza tecnica (``exp``) NON può essere successiva alla scadenza amministrativa (``expiry_date``). Ad esempio, una patente può essere valida amministrativamente per 10 anni, mentre la credenziale tecnica emessa può avere una scadenza di 1 anno.
+* **Riemissione**: Se una credenziale raggiunge la scadenza tecnica (``exp``) ma il dataset è ancora amministrativamente valido, lo stato nelle OpenAPI rimane ``VALID``. Questo consente di riemettere la credenziale più volte all'interno dell'arco temporale di validità amministrativa.
+* **Verifica dei Metadati**: Il Credential Issuer deve verificare l'effettiva usabilità della credenziale controllando sia i claim tecnici di sessione che le date amministrative del dataset.
 * **Irreversibilità**: Una volta che una credenziale transita nello stato ``INVALID``, non può più tornare allo stato ``VALID``. Per un nuovo dataset è necessaria una nuova emissione.
 * **Elaborazione dei Segnali**: I segnali provenienti dal Signal Hub devono essere elaborati sequenzialmente. Se un segnale invalida una credenziale, eventuali segnali di correzione successivi per lo stesso ``object_id`` devono essere ignorati.
 

--- a/docs/it/authentic-source-endpoint.rst
+++ b/docs/it/authentic-source-endpoint.rst
@@ -44,6 +44,37 @@ Get Attribute Claims
     - la Fonte Autentica DEVE registrare il valore datetime fornito all'interno del parametro ``last_updated``, che indica data e orario dell'ultima volta che gli Attributi dell'Utente sono stati aggiornati nel database della Fonte Autentica;
     - il Credential Issuer DEVE leggere il valore ``last_updated`` ricevuto nella risposta per essere in grado di verificare se gli Attributi dell'Utente sono cambiati dall'ultima emissione di un Attestato Elettronico.
 
+Mapping degli Stati del Ciclo di Vita delle Credenziali
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Per garantire la coerenza tra il "Ciclo di Vita degli Attestati Elettronici" documentato in :ref:`credential-revocation:Ciclo di Vita degli Attestati Elettronici` e l'Enum ``status`` delle OpenAPI, deve essere applicato il seguente mapping per il campo ``status`` presente negli ``attributeClaims``:
+
+.. list-table::
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - **Stato del Ciclo di Vita**
+     - **OpenAPI status enum**
+     - **Descrizione e Logica**
+   * - **Issued** / **Valid**
+     - ``VALID``
+     - Il dataset è amministrativamente attivo. Lo stato "Issued" è considerato un valore inizialmente valido.
+   * - **Expired**
+     - ``VALID``
+     - Il dataset ha superato la data di scadenza (``expiry_date``). Deve restituire ``VALID``, delegando il controllo sull'effettiva usabilità all'Issuer tramite i metadati.
+   * - **Suspended**
+     - ``SUSPENDED``
+     - L'attestazione è temporaneamente non valida.
+   * - **Revoked**
+     - ``INVALID``
+     - L'attestazione è stata revocata o terminata permanentemente.
+
+**Guida Operativa:**
+
+* **Verifica dei Metadati**: Poiché gli stati "Issued" ed "Expired" sono mappati come ``VALID``, il Credential Issuer deve verificare l'effettiva usabilità della credenziale controllando i claim ``issuance_date`` (nbf) ed ``expiry_date`` (exp).
+* **Irreversibilità**: Una volta che una credenziale transita nello stato ``INVALID``, non può più tornare allo stato ``VALID``. Per un nuovo dataset è necessaria una nuova emissione.
+* **Elaborazione dei Segnali**: I segnali provenienti dal Signal Hub devono essere elaborati sequenzialmente. Se un segnale invalida una credenziale, eventuali segnali di correzione successivi per lo stesso ``object_id`` devono essere ignorati.
+
 Esempio di risposta della Authentic Source
 """"""""""""""""""""""""""""""""""""""""""
 

--- a/docs/it/authentic-source-endpoint.rst
+++ b/docs/it/authentic-source-endpoint.rst
@@ -45,7 +45,7 @@ Get Attribute Claims
     - il Credential Issuer DEVE leggere il valore ``last_updated`` ricevuto nella risposta per essere in grado di verificare se gli Attributi dell'Utente sono cambiati dall'ultima emissione di un Attestato Elettronico.
 
 Mapping degli Stati del Ciclo di Vita degli Attestati Elettronici
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Per garantire la coerenza tra il "Ciclo di Vita degli Attestati Elettronici" documentato in :ref:`credential-revocation:Ciclo di Vita degli Attestati Elettronici` e l'Enum status delle OpenAPI, la seguente mappatura e logica operativa DEVE essere applicata per il campo ``status`` negli ``attributeClaims``.
 


### PR DESCRIPTION
## Title

`docs: align credential lifecycle states with OpenAPI status enum`

## Content

This Pull Request addresses the inconsistency detected between the normative states defined for the "Electronic Attestation Lifecycle" (Ch. 11.3) and the allowed values for the `status` field in the OpenAPI specifications for Authentic Source web services.

**Key Changes:**

* **Mapping Logic**: Added a dedicated section in `authentic-source-endpoint.rst` to clarify how the five normative states (**Issued**, **Valid**, **Expired**, **Revoked**, **Suspended**) map to the three OpenAPI enum values (**VALID**, **INVALID**, **SUSPENDED**).
* **Expired State Management**: Clarified that if a dataset is technically expired (past the `expiry_date`), the Authentic Source must return a `VALID` status, delegating the final validity and date check to the Credential Issuer via metadata claims.
* **State Irreversibility**: Explicitly defined the `INVALID` status (Revoked) as terminal; once a credential is invalidated, it cannot return to a `VALID` state, and a new issuance process is required.
* **Signal Hub Sequentiality**: Integrated requirements for sequential processing of signals. If an `INVALID` signal is processed, subsequent correction signals for the same object must be ignored to prevent unintended behavior in the User's Wallet.
* **Cross-References**: Updated internal documentation links to point to the Italian version of the "Ciclo di Vita degli Attestati Elettronici" for better technical consistency.

Fixes #982

## Review

* [x] Ensure your files are written following RST specs (*not MD!*)
* [x] Italian version
* [x] English version
* [ ] Example files
* [x] Ask for review