### PR TITLE
chore: OAS descriptions and improvements on dataset statuses

### DIFF
--- a/docs/en/authentic-source-endpoint.rst
+++ b/docs/en/authentic-source-endpoint.rst
@@ -72,16 +72,16 @@ The Authentic Source manages the validity of the User's attributes (datasets); t
     - Typical dataset condition
     - Effect on Digital Credential (Credential Issuer action)
   * - VALID
-    - Within validity period, not revoked/suspended
-    - Credential may remain Valid
+    - Dataset not revoked/suspended (includes Issued and Expired; expiry verified via metadata)
+    - Credential may remain Valid (expiry checked via expiry_date, nbf/exp)
   * - INVALID
-    - Expired (past expiry_date), revoked, or otherwise no longer valid
-    - Credential status updated to Revoked/Expired (Status List: INVALID)
+    - Dataset actively revoked by the Authentic Source
+    - Credential status updated to Revoked (Status List: INVALID)
   * - SUSPENDED
     - Temporarily invalid (e.g. under review)
     - Credential status updated to Suspended (Status List: SUSPENDED)
 
-When the dataset has passed its administrative ``expiry_date``, the Authentic Source MUST set ``status`` to INVALID. For full details on the status update flow, see :ref:`credential-revocation:Status Update by Authentic Sources`.
+Issued and Expired datasets fall within VALID; the Credential Issuer verifies expiry via metadata claims (e.g. ``expiry_date``, ``nbf``/``exp``). For full details on the status update flow, see :ref:`credential-revocation:Status Update by Authentic Sources`.
 
 The successful response (HTTP 200) returns a ``CredentialClaimsResponse`` object formatted as a **Payload JSON**.
 

--- a/docs/en/authentic-source-endpoint.rst
+++ b/docs/en/authentic-source-endpoint.rst
@@ -61,7 +61,7 @@ In summary:
 - **interval**: required when the request does not include a ``claims`` parameter; indicates the number of seconds to wait before repeating the request (e.g. 864000 = 10 days).
 
 Dataset Status and Digital Credential Lifecycle
-''''''''''''''''''''''''''''''''''''''''''''''
+''''''''''''''''''''''''''''''''''''''''''''''''''
 
 The Authentic Source manages the validity of the User's attributes (datasets); the Credential Issuer manages the Digital Credential lifecycle. When the Credential Issuer receives an UPDATE Signal or queries the Get Attribute Claims endpoint, it inspects the ``status`` of each dataset and updates the corresponding Digital Credential accordingly:
 

--- a/docs/en/authentic-source-endpoint.rst
+++ b/docs/en/authentic-source-endpoint.rst
@@ -60,6 +60,29 @@ In summary:
 - **metadataClaims**: array of metadata per dataset (``object_id`` required; ``issuance_date`` and ``expiry_date`` optional).
 - **interval**: required when the request does not include a ``claims`` parameter; indicates the number of seconds to wait before repeating the request (e.g. 864000 = 10 days).
 
+Dataset Status and Digital Credential Lifecycle
+''''''''''''''''''''''''''''''''''''''''''''''
+
+The Authentic Source manages the validity of the User's attributes (datasets); the Credential Issuer manages the Digital Credential lifecycle. When the Credential Issuer receives an UPDATE Signal or queries the Get Attribute Claims endpoint, it inspects the ``status`` of each dataset and updates the corresponding Digital Credential accordingly:
+
+.. list-table::
+  :header-rows: 1
+
+  * - Dataset status
+    - Typical dataset condition
+    - Effect on Digital Credential (Credential Issuer action)
+  * - VALID
+    - Within validity period, not revoked/suspended
+    - Credential may remain Valid
+  * - INVALID
+    - Expired (past expiry_date), revoked, or otherwise no longer valid
+    - Credential status updated to Revoked/Expired (Status List: INVALID)
+  * - SUSPENDED
+    - Temporarily invalid (e.g. under review)
+    - Credential status updated to Suspended (Status List: SUSPENDED)
+
+When the dataset has passed its administrative ``expiry_date``, the Authentic Source MUST set ``status`` to INVALID. For full details on the status update flow, see :ref:`credential-revocation:Status Update by Authentic Sources`.
+
 The successful response (HTTP 200) returns a ``CredentialClaimsResponse`` object formatted as a **Payload JSON**.
 
 Signature Verification and Key Management

--- a/docs/en/oas3/OAS3-PDND-AS.yaml
+++ b/docs/en/oas3/OAS3-PDND-AS.yaml
@@ -370,8 +370,8 @@ components:
                 example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
               status:
                 description: |
-                  Status of the Dataset. When the dataset has passed its administrative expiry_date
-                  (see metadataClaims), the status MUST be INVALID.
+                  Status of the Dataset. Issued and Expired datasets fall within VALID; expiry is verified
+                  via metadata claims (e.g. expiry_date, nbf/exp). INVALID indicates active revocation by the AS.
                   For how this status affects the Digital Credential lifecycle managed by the Credential
                   Issuer, see <a target="blank" href="https://italia.github.io/eid-wallet-it-docs/versione-corrente/en/credential-revocation.html#status-update-by-authentic-sources">Status Update by Authentic Sources</a>.
                 type: string
@@ -380,8 +380,8 @@ components:
                   - INVALID
                   - SUSPENDED
                 x-enum-description:
-                  - VALID - Dataset is currently valid (within validity period, not revoked/suspended).
-                  - INVALID - Dataset is no longer valid (e.g. expired, revoked). Use when expiry_date has passed.
+                  - VALID - Dataset is valid (includes Issued and Expired; expiry checked via metadata).
+                  - INVALID - Dataset has been actively revoked by the Authentic Source.
                   - SUSPENDED - Dataset is temporarily invalid (typically reversible).
                 example: "VALID"
               last_updated:

--- a/docs/en/oas3/OAS3-PDND-AS.yaml
+++ b/docs/en/oas3/OAS3-PDND-AS.yaml
@@ -369,17 +369,21 @@ components:
                 type: string
                 example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
               status:
-                description: Status of the Dataset.
+                description: |
+                  Status of the Dataset. When the dataset has passed its administrative expiry_date
+                  (see metadataClaims), the status MUST be INVALID.
+                  For how this status affects the Digital Credential lifecycle managed by the Credential
+                  Issuer, see <a target="blank" href="https://italia.github.io/eid-wallet-it-docs/versione-corrente/en/credential-revocation.html#status-update-by-authentic-sources">Status Update by Authentic Sources</a>.
                 type: string
                 enum:
                   - VALID
                   - INVALID
                   - SUSPENDED
                 x-enum-description:
-                  - valid - The credential is issued or expired
-                  - INVALID - The Dataset is revoked
-                  - suspended - The credential is temporarily not available, for example due to a temporary hold or a pending verification process
-                example: valid
+                  - VALID - Dataset is currently valid (within validity period, not revoked/suspended).
+                  - INVALID - Dataset is no longer valid (e.g. expired, revoked). Use when expiry_date has passed.
+                  - SUSPENDED - Dataset is temporarily invalid (typically reversible).
+                example: "VALID"
               last_updated:
                 description: Last time the status or attributes of the Dataset have been updated. Its format is `YYYY-MM-DDTHH:MM:SSZ`.
                 type: string

--- a/docs/it/authentic-source-endpoint.rst
+++ b/docs/it/authentic-source-endpoint.rst
@@ -72,16 +72,16 @@ La Fonte Autentica gestisce la validità degli Attributi dell'Utente (dataset); 
     - Condizione tipica del dataset
     - Effetto sull'Attestato Elettronico (azione del Fornitore di Attestati Elettronici)
   * - VALID
-    - Entro il periodo di validità, non revocato/sospeso
-    - L'Attestato Elettronico può rimanere Valido
+    - Dataset non revocato/sospeso (include Issued e Expired; scadenza verificata via metadata)
+    - L'Attestato Elettronico può rimanere Valido (scadenza verificata via expiry_date, nbf/exp)
   * - INVALID
-    - Scaduto (oltre expiry_date), revocato o altrimenti non più valido
-    - Stato dell'Attestato Elettronico aggiornato a Revoked/Expired (Status List: INVALID)
+    - Dataset attivamente revocato dalla Fonte Autentica
+    - Stato dell'Attestato Elettronico aggiornato a Revoked (Status List: INVALID)
   * - SUSPENDED
     - Temporaneamente non valido (es. in verifica)
     - Stato dell'Attestato Elettronico aggiornato a Suspended (Status List: SUSPENDED)
 
-Quando il dataset ha superato la data di scadenza amministrativa ``expiry_date``, la Fonte Autentica DEVE impostare ``status`` a INVALID. Per i dettagli completi sul flusso di aggiornamento dello stato, vedere :ref:`credential-revocation:Aggiornamento dello Stato da parte delle Fonti Autentiche`.
+I dataset Issued e Expired ricadono in VALID; il Fornitore di Attestati Elettronici verifica la scadenza tramite metadata claims (es. ``expiry_date``, ``nbf``/``exp``). Per i dettagli completi sul flusso di aggiornamento dello stato, vedere :ref:`credential-revocation:Aggiornamento dello Stato da parte delle Fonti Autentiche`.
 
 La risposta in caso di successo (HTTP 200) restituisce un oggetto ``CredentialClaimsResponse`` formattato come **Payload JSON**.
 

--- a/docs/it/authentic-source-endpoint.rst
+++ b/docs/it/authentic-source-endpoint.rst
@@ -61,7 +61,7 @@ In sintesi:
 - **interval**: obbligatorio se non è presente il parametro ``claims`` nella richiesta; indica i secondi da attendere prima di ripetere la richiesta (es. 864000 = 10 giorni).
 
 Stato del Dataset e Ciclo di Vita dell'Attestato Elettronico
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 La Fonte Autentica gestisce la validità degli Attributi dell'Utente (dataset); il Fornitore di Attestati Elettronici gestisce il ciclo di vita dell'Attestato Elettronico. Quando il Fornitore di Attestati Elettronici riceve un Segnale UPDATE o interroga l'endpoint Get Attribute Claims, ispeziona lo ``status`` di ogni dataset e aggiorna l'Attestato Elettronico corrispondente di conseguenza:
 

--- a/docs/it/authentic-source-endpoint.rst
+++ b/docs/it/authentic-source-endpoint.rst
@@ -60,6 +60,29 @@ In sintesi:
 - **metadataClaims**: array di metadati per dataset (``object_id`` obbligatorio; ``issuance_date`` e ``expiry_date`` opzionali).
 - **interval**: obbligatorio se non è presente il parametro ``claims`` nella richiesta; indica i secondi da attendere prima di ripetere la richiesta (es. 864000 = 10 giorni).
 
+Stato del Dataset e Ciclo di Vita dell'Attestato Elettronico
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+
+La Fonte Autentica gestisce la validità degli Attributi dell'Utente (dataset); il Fornitore di Attestati Elettronici gestisce il ciclo di vita dell'Attestato Elettronico. Quando il Fornitore di Attestati Elettronici riceve un Segnale UPDATE o interroga l'endpoint Get Attribute Claims, ispeziona lo ``status`` di ogni dataset e aggiorna l'Attestato Elettronico corrispondente di conseguenza:
+
+.. list-table::
+  :header-rows: 1
+
+  * - Stato del dataset
+    - Condizione tipica del dataset
+    - Effetto sull'Attestato Elettronico (azione del Fornitore di Attestati Elettronici)
+  * - VALID
+    - Entro il periodo di validità, non revocato/sospeso
+    - L'Attestato Elettronico può rimanere Valido
+  * - INVALID
+    - Scaduto (oltre expiry_date), revocato o altrimenti non più valido
+    - Stato dell'Attestato Elettronico aggiornato a Revoked/Expired (Status List: INVALID)
+  * - SUSPENDED
+    - Temporaneamente non valido (es. in verifica)
+    - Stato dell'Attestato Elettronico aggiornato a Suspended (Status List: SUSPENDED)
+
+Quando il dataset ha superato la data di scadenza amministrativa ``expiry_date``, la Fonte Autentica DEVE impostare ``status`` a INVALID. Per i dettagli completi sul flusso di aggiornamento dello stato, vedere :ref:`credential-revocation:Aggiornamento dello Stato da parte delle Fonti Autentiche`.
+
 La risposta in caso di successo (HTTP 200) restituisce un oggetto ``CredentialClaimsResponse`` formattato come **Payload JSON**.
 
 Verifica della Firma e Gestione Chiavi

--- a/docs/it/oas3/OAS3-PDND-AS.yaml
+++ b/docs/it/oas3/OAS3-PDND-AS.yaml
@@ -361,8 +361,8 @@ components:
                 example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
               status:
                 description: |
-                  Stato del Dataset. Quando il dataset ha superato la data di scadenza amministrativa
-                  (vedi metadataClaims.expiry_date), lo status DEVE essere INVALID.
+                  Stato del Dataset. I dataset Issued e Expired ricadono in VALID; la scadenza è verificata
+                  tramite metadata claims (es. expiry_date, nbf/exp). INVALID indica revoca attiva da parte dell'AS.
                   Per come questo stato influenza il ciclo di vita dell'Attestato Elettronico gestito dal
                   Fornitore di Attestati Elettronici, vedere la sezione <a target="blank" href="https://italia.github.io/eid-wallet-it-docs/versione-corrente/it/credential-revocation.html#aggiornamento-dello-stato-da-parte-delle-fonti-autentiche">Aggiornamento dello Stato da parte delle Fonti Autentiche</a>.
                 type: string
@@ -371,8 +371,8 @@ components:
                   - INVALID
                   - SUSPENDED
                 x-enum-description:
-                  - VALID - Il dataset è attualmente valido (entro il periodo di validità, non revocato/sospeso).
-                  - INVALID - Il dataset non è più valido (es. scaduto, revocato). Da usare quando expiry_date è superata.
+                  - VALID - Il dataset è valido (include Issued e Expired; la scadenza è verificata via metadata).
+                  - INVALID - Il dataset è stato attivamente revocato dalla Fonte Autentica.
                   - SUSPENDED - Il dataset è temporaneamente non valido (tipicamente reversibile).
                 example: "VALID"
               last_updated:

--- a/docs/it/oas3/OAS3-PDND-AS.yaml
+++ b/docs/it/oas3/OAS3-PDND-AS.yaml
@@ -360,9 +360,20 @@ components:
                 type: string
                 example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
               status:
-                description: Status of the Dataset.
+                description: |
+                  Stato del Dataset. Quando il dataset ha superato la data di scadenza amministrativa
+                  (vedi metadataClaims.expiry_date), lo status DEVE essere INVALID.
+                  Per come questo stato influenza il ciclo di vita dell'Attestato Elettronico gestito dal
+                  Fornitore di Attestati Elettronici, vedere la sezione <a target="blank" href="https://italia.github.io/eid-wallet-it-docs/versione-corrente/it/credential-revocation.html#aggiornamento-dello-stato-da-parte-delle-fonti-autentiche">Aggiornamento dello Stato da parte delle Fonti Autentiche</a>.
                 type: string
-                enum: ["VALID", "INVALID", "SUSPENDED"]
+                enum:
+                  - VALID
+                  - INVALID
+                  - SUSPENDED
+                x-enum-description:
+                  - VALID - Il dataset è attualmente valido (entro il periodo di validità, non revocato/sospeso).
+                  - INVALID - Il dataset non è più valido (es. scaduto, revocato). Da usare quando expiry_date è superata.
+                  - SUSPENDED - Il dataset è temporaneamente non valido (tipicamente reversibile).
                 example: "VALID"
               last_updated:
                 description: Last time the status or attributes of the Dataset have been updated. Its format is `YYYY-MM-DDTHH:MM:SSZ`.


### PR DESCRIPTION
This pull request improves the documentation for both English and Italian audiences regarding the handling of dataset status and its impact on the digital credential lifecycle. It clarifies how the `status` field should be managed, especially in relation to the dataset's `expiry_date`, and provides more detailed explanations in both the API documentation and the descriptive sections.

**Documentation and API Schema Improvements:**

*English documentation and schema:*
- Added a new section explaining the relationship between dataset status and the digital credential lifecycle, including a table mapping dataset statuses (`VALID`, `INVALID`, `SUSPENDED`) to their effects on credentials. Also clarified that when a dataset passes its `expiry_date`, its status must be set to `INVALID`.
- Updated the OpenAPI schema (`OAS3-PDND-AS.yaml`) to clarify the meaning of each status, explicitly require `status` to be `INVALID` after `expiry_date`, and added a reference link to the credential lifecycle documentation.

*Italian documentation and schema:*
- Added a parallel section in Italian detailing the dataset status and digital credential lifecycle, including a corresponding table and explicit instructions for setting `status` to `INVALID` after `expiry_date`.
- Updated the Italian OpenAPI schema to match the English improvements, clarifying status descriptions and adding a reference link to the relevant documentation.