### PR TITLE
breaking change: status list reserved values, ATTRIBUTE_UPDATE moved to 0x0F

### DIFF
--- a/docs/en/credential-issuance-low-level.rst
+++ b/docs/en/credential-issuance-low-level.rst
@@ -609,7 +609,7 @@ The following diagram describes the Digital Credential re-issuance flow.
 
 **Step 1**: The flow starts when the User opens the Wallet Instance: this step MAY be triggered either by a notification sent by the Credential Issuer (using e.g., one of the out-of-band communication contacts registered during the Issuance flow).
 
-**Step 2**: The Wallet Instance MUST check the status of any stored Digital Credential, by retrieving either a valid Status List Token (following the flow described in Section :ref:`credential-revocation:Status List Token`) as per (:ref:`WP_069 <wallet-credential-issuance-testcases>`), if a valid one is not available. Then, the Wallet Instance MUST check  (:ref:`WP_070 <wallet-credential-issuance-testcases>`) if any Digital Credential has status set to ``0x03`` - ``UPDATE`` or ``0x0B`` - ``ATTRIBUTE_UPDATE``.
+**Step 2**: The Wallet Instance MUST check the status of any stored Digital Credential, by retrieving either a valid Status List Token (following the flow described in Section :ref:`credential-revocation:Status List Token`) as per (:ref:`WP_069 <wallet-credential-issuance-testcases>`), if a valid one is not available. Then, the Wallet Instance MUST check  (:ref:`WP_070 <wallet-credential-issuance-testcases>`) if any Digital Credential has status set to ``0x03`` - ``UPDATE`` or ``0x0F`` - ``ATTRIBUTE_UPDATE``.
 
 If the conditions above are not met, the flow MUST be interrupted.
 

--- a/docs/en/credential-revocation.rst
+++ b/docs/en/credential-revocation.rst
@@ -283,7 +283,7 @@ Once the data changes, the Authentic Source notifies the Credential Issuers who 
 
 The Credential Issuer periodically queries the Signal Hub :ref:`signal-hub-endpoint:Signal Distribution e-Service` for new Signals. When a new Signal is found, the Credential Issuer retrieves it and processes it as described in :ref:`signal-hub-endpoint:Signals Processing`. Then, the Credential Issuer updates the Credential Status according to the validity mechanism's defined mode. The Credential Issuer MAY notify the User through a registered out-of-band communication channel.
 
-The Wallet instance, following periodic checks of the validity status of the stored Digital Credentials, receives the updated status. When the Credential Status is changed to ``INVALID``, the Credential Issuer MUST inform the User about this change. In case the Credential status is modified to ``UPDATE`` (resp. 0x03) or ``ATTRIBUTE_UPDATE`` (resp. 0x0B), the Wallet Instance SHOULD proceed to the re-issuance of the Digital Credential, as described in :ref:`credential-issuance-low-level:Re-Issuance Flow`.
+The Wallet instance, following periodic checks of the validity status of the stored Digital Credentials, receives the updated status. When the Credential Status is changed to ``INVALID``, the Credential Issuer MUST inform the User about this change. In case the Credential status is modified to ``UPDATE`` (resp. 0x03) or ``ATTRIBUTE_UPDATE`` (resp. 0x0F), the Wallet Instance SHOULD proceed to the re-issuance of the Digital Credential, as described in :ref:`credential-issuance-low-level:Re-Issuance Flow`.
 
 
 Batch Credential Lifecycle Management
@@ -342,7 +342,7 @@ The Issuer of a Digital Credential MUST use the following values for possible St
   - 0x01 - ``INVALID`` - The Digital Credential is revoked.
   - 0x02 - ``SUSPENDED`` - The Digital Credential is temporarily invalid, hanging. This state is usually temporary.
   - 0x03 - ``UPDATE`` - The Digital Credential metadata parameters have changed.
-  - 0x0B - ``ATTRIBUTE_UPDATE`` - The Digital Credential attributes have changed.
+  - 0x0F - ``ATTRIBUTE_UPDATE`` - The Digital Credential attributes have changed.
 
 For example, if five states for a certain Digital Credential are possible, then k=4. If the Credential Issuer creates an array to store the statuses of 6 Digital Credentials, whose validity statuses are 0, 0, 0, 3, 1, 2, respectively; it will:
 

--- a/docs/en/plantuml/credential-lifecycle.puml
+++ b/docs/en/plantuml/credential-lifecycle.puml
@@ -15,7 +15,7 @@ end note
     Required when no valid
     Status List Token exists
     end note
-    if (Credential Status in [0x03, 0x0B]?) then (yes)
+    if (Credential Status in [0x03, 0x0F]?) then (yes)
      else (no) 
              stop
      endif
@@ -36,7 +36,7 @@ end note
         
         :Use DPoP Access Token to retrieve
         new Digital Credential;
-        if (Credential status = 0x0B?) then (yes)
+        if (Credential status = 0x0F?) then (yes)
             :Request User Authorization;            
             if (User Authorizes?) then (yes)
                 :Store new Credential;

--- a/docs/en/plantuml/credential-reissuance-flow.puml
+++ b/docs/en/plantuml/credential-reissuance-flow.puml
@@ -15,7 +15,7 @@ end note
     Required when no valid
     Status List Token exists
     end note
-    if (Credential Status in [0x03, 0x0B]?) then (yes)
+    if (Credential Status in [0x03, 0x0F]?) then (yes)
      else (no) 
              stop
      endif
@@ -36,7 +36,7 @@ end note
         
         :Use DPoP Access Token to retrieve
         new Digital Credential;
-        if (Credential status = 0x0B?) then (yes)
+        if (Credential status = 0x0F?) then (yes)
             :Request User Authorization;            
             if (User Authorizes?) then (yes)
                 :Store new Credential;

--- a/docs/en/test-plans-wallet-provider.rst
+++ b/docs/en/test-plans-wallet-provider.rst
@@ -569,7 +569,7 @@ This section lists the test cases from Sections:
    * - WP_070
      - Issuance, Security
      - Re-issuance flow: detect re-issuance necessity (update status)
-     - Wallet Instance updates a Digital Credential when the Status List shows ``0x03`` (``UPDATE``) or ``0x0B`` (``ATTRIBUTE_UPDATE``) for that Credential.
+     - Wallet Instance updates a Digital Credential when the Status List shows ``0x03`` (``UPDATE``) or ``0x0F`` (``ATTRIBUTE_UPDATE``) for that Credential.
    * - WP_071
      - Issuance, Security
      - Re-issuance flow: verify Access Token validity for re-issuance

--- a/docs/it/credential-revocation.rst
+++ b/docs/it/credential-revocation.rst
@@ -285,7 +285,7 @@ Una volta che i dati cambiano, la Fonte Autentica notifica i Fornitori di Attest
 
 Il Fornitore di Attestati Elettronici interroga periodicamente il Signal Hub :ref:`signal-hub-endpoint:e-Service di Distribuzione Segnali` per nuovi Signal. Quando viene trovato un nuovo Signal, il Fornitore di Attestati Elettronici lo recupera e lo processa come descritto in :ref:`signal-hub-endpoint:Elaborazione dei Segnali`. Quindi, il Fornitore di Attestati Elettronici aggiorna lo Stato dell’Attestato secondo la modalità definita dal meccanismo di validità. Il Fornitore di Attestati Elettronici PUÒ notificare l’Utente tramite un canale di comunicazione registrato e out-of-band.
 
-L’Istanza del Wallet, a seguito di controlli periodici dello stato di validità degli Attestati Elettronici memorizzati, riceve lo stato aggiornato. Quando lo Stato dell’Attestato viene modificato in ``INVALID``, il Fornitore di Attestati Elettronici DEVE informare l’Utente di tale cambiamento. Nel caso in cui lo stato dell’Attestato venga modificato in ``UPDATE`` (risp. 0x03) o ``ATTRIBUTE_UPDATE`` (risp. 0x0B), l’Istanza del Wallet DOVREBBE procedere alla riemissione dell’Attestato Elettronico, come descritto in :ref:`credential-issuance-low-level:Re-Issuance Flow`.
+L’Istanza del Wallet, a seguito di controlli periodici dello stato di validità degli Attestati Elettronici memorizzati, riceve lo stato aggiornato. Quando lo Stato dell’Attestato viene modificato in ``INVALID``, il Fornitore di Attestati Elettronici DEVE informare l’Utente di tale cambiamento. Nel caso in cui lo stato dell’Attestato venga modificato in ``UPDATE`` (risp. 0x03) o ``ATTRIBUTE_UPDATE`` (risp. 0x0F), l’Istanza del Wallet DOVREBBE procedere alla riemissione dell’Attestato Elettronico, come descritto in :ref:`credential-issuance-low-level:Re-Issuance Flow`.
 
 Gestione del ciclo di vita delle Credenziali in batch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -344,7 +344,7 @@ Il Fornitore di Attestati Elettronici DEVE utilizzare i seguenti valori per i po
   - 0x01 - ``INVALID`` - L'Attestato Elettronico è revocato.
   - 0x02 - ``SUSPENDED`` - L'Attestato Elettronico è temporaneamente non valido, sospeso. Questo stato è solitamente temporaneo.
   - 0x03 - ``UPDATE`` - I parametri dei metadata dell'Attestato Elettronico sono cambiati.
-  - 0x0B - ``ATTRIBUTE_UPDATE`` - Gli attributi dell'Attestato Elettronico sono cambiati.
+  - 0x0F - ``ATTRIBUTE_UPDATE`` - Gli attributi dell'Attestato Elettronico sono cambiati.
 
 Ad esempio, se sono possibili cinque stati per un certo Attestato Elettronico, allora k=4. Se il Fornitore di Attestati Elettronici crea un array per memorizzare gli stati di 6 Attestati Elettronici, i cui stati di validità sono 0, 0, 0, 3, 1, 2, rispettivamente; farà:
 

--- a/docs/it/plantuml/credential-lifecycle.puml
+++ b/docs/it/plantuml/credential-lifecycle.puml
@@ -15,7 +15,7 @@ end note
     Required when no valid
     Status List Token exists
     end note
-    if (Credential Status in [0x03, 0x0B]?) then (yes)
+    if (Credential Status in [0x03, 0x0F]?) then (yes)
      else (no) 
              stop
      endif
@@ -36,7 +36,7 @@ end note
         
         :Use DPoP Access Token to retrieve
         new Digital Credential;
-        if (Credential status = 0x0B?) then (yes)
+        if (Credential status = 0x0F?) then (yes)
             :Request User Authorization;            
             if (User Authorizes?) then (yes)
                 :Store new Credential;

--- a/docs/it/plantuml/credential-reissuance-flow.puml
+++ b/docs/it/plantuml/credential-reissuance-flow.puml
@@ -15,7 +15,7 @@ end note
     Required when no valid
     Status List Token exists
     end note
-    if (Credential Status in [0x03, 0x0B]?) then (yes)
+    if (Credential Status in [0x03, 0x0F]?) then (yes)
      else (no) 
              stop
      endif
@@ -36,7 +36,7 @@ end note
         
         :Use DPoP Access Token to retrieve
         new Digital Credential;
-        if (Credential status = 0x0B?) then (yes)
+        if (Credential status = 0x0F?) then (yes)
             :Request User Authorization;            
             if (User Authorizes?) then (yes)
                 :Store new Credential;

--- a/docs/it/test-plans-wallet-provider.rst
+++ b/docs/it/test-plans-wallet-provider.rst
@@ -569,7 +569,7 @@ Questa sezione elenca i casi di test dalle Sezioni:
    * - WP_070
      - Issuance, Sicurezza
      - Flusso re-Issuance: rilevare necessità re-Issuance (aggiornare stato)
-     - Istanza del Wallet aggiorna un Attestato Elettronico quando la Status List mostra ``0x03`` (``UPDATE``) o ``0x0B`` (``ATTRIBUTE_UPDATE``) per quell'Attestato Elettronico.
+     - Istanza del Wallet aggiorna un Attestato Elettronico quando la Status List mostra ``0x03`` (``UPDATE``) o ``0x0F`` (``ATTRIBUTE_UPDATE``) per quell'Attestato Elettronico.
    * - WP_071
      - Issuance, Sicurezza
      - Flusso re-Issuance: verificare validità Access Token per re-Issuance


### PR DESCRIPTION
This pull request updates the documentation and related diagrams to change the status code for the `ATTRIBUTE_UPDATE` state of digital credentials from `0x0B` to `0x0F`. This change is applied consistently across both English and Italian documentation, test plans, and PlantUML sequence diagrams to ensure that the correct status code is referenced throughout the project.

**Status code update for ATTRIBUTE_UPDATE:**

* Updated all references in the English documentation to use `0x0F` instead of `0x0B` for the `ATTRIBUTE_UPDATE` status, including the credential revocation flow, status value descriptions, and test plans. [[1]](diffhunk://#diff-0ceaa7654b88ae0721591359ec3401a335d37ee1d1a293373f0159e5336f9948L286-R286) [[2]](diffhunk://#diff-0ceaa7654b88ae0721591359ec3401a335d37ee1d1a293373f0159e5336f9948L345-R345) [[3]](diffhunk://#diff-1c0af979a980594cec65d6f19f5a39492fb5532a870fa9decd4ad6f1811b717dL612-R612) [[4]](diffhunk://#diff-a5cca28d22376c3a4b4cf9712911c69d070e1d8877312976a8ea55b71b6dabbcL572-R572)
* Updated PlantUML diagrams in the English documentation to check for `0x0F` rather than `0x0B` when determining whether to trigger credential re-issuance. [[1]](diffhunk://#diff-195e915aecde76dce219f9385584ac17927135924edaaf728c0ad7182410bee9L18-R18) [[2]](diffhunk://#diff-195e915aecde76dce219f9385584ac17927135924edaaf728c0ad7182410bee9L39-R39) [[3]](diffhunk://#diff-27254471dfad0cf3b598a863b036bc3aa27f5c12a28d638485658e46a285f672L18-R18) [[4]](diffhunk://#diff-27254471dfad0cf3b598a863b036bc3aa27f5c12a28d638485658e46a285f672L39-R39)

**Internationalization consistency:**

* Updated the Italian documentation to reflect the new `0x0F` code for `ATTRIBUTE_UPDATE` in both narrative and status value listings. [[1]](diffhunk://#diff-4e00b851469a3ccab66db1599a160bbf7a28af49d8945dc58ed4da4276b03e89L288-R288) [[2]](diffhunk://#diff-4e00b851469a3ccab66db1599a160bbf7a28af49d8945dc58ed4da4276b03e89L347-R347)
* Updated the Italian PlantUML diagrams to use `0x0F` instead of `0x0B` for consistency with the English versions. [[1]](diffhunk://#diff-a1bf993d5d014486a13cc8c7e6e6ffb4dce82c7d4ec3e4d1f124b33923f61c58L18-R18) [[2]](diffhunk://#diff-a1bf993d5d014486a13cc8c7e6e6ffb4dce82c7d4ec3e4d1f124b33923f61c58L39-R39) [[3]](diffhunk://#diff-27254471dfad0cf3b598a863b036bc3aa27f5c12a28d638485658e46a285f672L18-R18) [[4]](diffhunk://#diff-27254471dfad0cf3b598a863b036bc3aa27f5c12a28d638485658e46a285f672L39-R39)
* Updated the Italian test plan to check for `0x0F` for `ATTRIBUTE_UPDATE` in the relevant test case descriptions.

These changes ensure that the documentation, diagrams, and test plans are aligned with the updated status code for attribute updates in digital credentials.