### PR TITLE
Update AS OAS3

### DIFF
--- a/docs/en/authentic-source-endpoint.rst
+++ b/docs/en/authentic-source-endpoint.rst
@@ -44,7 +44,7 @@ Get Attribute Claims
 
 .. note::
   The Authentic Source and the Credential Issuer MUST implement the necessary logic to keep track of the requests and responses exchanged via this e-Service, in order to be able to correlate them with the related issuance of a Digital Credential. In particular,
-    - both MUST save the ``deferred_object_id`` value in the payload of the response to manage Signals related to the deffered issuance of a Digital Credential (see :ref:`signal-hub-endpoint:Signals Processing`);
+    - both MUST save the ``deferred_object_id`` value in the payload of the response to manage Signals related to the deffered issuance of a Digital Credential (see :ref:`signal-hub-endpoint:Signals Processing`). Once the Credential Issuer obtains the attributes, the value of ``deferred_object_id`` MUST no longer be used, any subsequent notification related to a specific dataset MUST be handled via ``object_id``.
     - the Authentic Source MUST record the datetime value provided within the ``last_updated`` parameter, which indicates the last time the User's attributes were updated in the Authentic Source's database;
     - the Credential Issuer MUST read the ``last_updated`` value received in the response to be able to check if the User's attributes have changed since the last issuance of a Digital Credential.
 

--- a/docs/en/authentic-source-endpoint.rst
+++ b/docs/en/authentic-source-endpoint.rst
@@ -44,7 +44,7 @@ Get Attribute Claims
 
 .. note::
   The Authentic Source and the Credential Issuer MUST implement the necessary logic to keep track of the requests and responses exchanged via this e-Service, in order to be able to correlate them with the related issuance of a Digital Credential. In particular,
-    - both MUST save the ``deferred_object_id`` value in the payload of the response to manage Signals related to the deffered issuance of a Digital Credential (see :ref:`signal-hub-endpoint:Signals Processing`). Once the Credential Issuer obtains the attributes, the value of ``deferred_object_id`` MUST no longer be used, any subsequent notification related to a specific dataset MUST be handled via ``object_id``.
+    - both MUST save the ``object_id`` value in the payload of the response to manage Signals related to the deffered issuance of a Digital Credential (see :ref:`signal-hub-endpoint:Signals Processing`). Any subsequent notification related to a specific dataset MUST be handled via ``object_id``.
     - the Authentic Source MUST record the datetime value provided within the ``last_updated`` parameter, which indicates the last time the User's attributes were updated in the Authentic Source's database;
     - the Credential Issuer MUST read the ``last_updated`` value received in the response to be able to check if the User's attributes have changed since the last issuance of a Digital Credential.
 

--- a/docs/en/authentic-source-endpoint.rst
+++ b/docs/en/authentic-source-endpoint.rst
@@ -44,7 +44,7 @@ Get Attribute Claims
 
 .. note::
   The Authentic Source and the Credential Issuer MUST implement the necessary logic to keep track of the requests and responses exchanged via this e-Service, in order to be able to correlate them with the related issuance of a Digital Credential. In particular,
-    - both MUST save the ``jti`` value in the Agid-JWT-Signature payload of the request to manage Signals related to the deffered issuance of a Digital Credential (see :ref:`signal-hub-endpoint:Signals Processing`);
+    - both MUST save the ``deferred_object_id`` value in the payload of the response to manage Signals related to the deffered issuance of a Digital Credential (see :ref:`signal-hub-endpoint:Signals Processing`);
     - the Authentic Source MUST record the datetime value provided within the ``last_updated`` parameter, which indicates the last time the User's attributes were updated in the Authentic Source's database;
     - the Credential Issuer MUST read the ``last_updated`` value received in the response to be able to check if the User's attributes have changed since the last issuance of a Digital Credential.
 

--- a/docs/en/oas3/OAS3-PDND-AS.yaml
+++ b/docs/en/oas3/OAS3-PDND-AS.yaml
@@ -181,14 +181,14 @@ paths:
                   personal_administrative_number: "12345A123A"
                 attributeClaims:
                   - object_id: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
-                    status: VALID
+                    status: "VALID"
                     last_updated: "2025-01-15T10:30:00Z"
                     institute_name: "Nome Istituto Universitario"
                     programme_type_name: "Laurea Magistrale"
                     degree_course_name: "Computer Science - Informatica"
                     academic_qualification_date: "2025-06-25"
                   - object_id: "7A0720AB-9C97-E122-C53E-11D05FD075GG"
-                    status: VALID
+                    status: "VALID"
                     last_updated: "2025-01-10T08:00:00Z"
                     institute_name: "Nome Istituto Universitario"
                     programme_type_name: "Laurea Triennale"
@@ -411,7 +411,12 @@ components:
                 example: "2025-12-31"
             required: [object_id]
         interval:
-          description: Required if claims parameter is not present. This represents the estimated amount of time (in seconds) required before making the request of the attribute claims again.
+          description: Required if userClaims and AttributeClaim parameters are not present. This represents the estimated amount of time (in seconds) required before making the request of the attribute claims again.
+          type: integer
+          format: int64
+          example: 864000
+        deferred_object_id:
+          description: Required if userClaims and AttributeClaim parameters are not present. An opaque identifier related to the request of User and Attribute claims. 
           type: integer
           format: int64
           example: 864000
@@ -425,7 +430,7 @@ components:
           description: ID ANPR or Tax identification number
         object_id:
           type: string
-          description: Unique identifier of the Credential dataset or `jti` of the Agid-JWT-Signature Credential Issuer deferred flow's request. If this parameter is present only the indicated dataset is returned
+          description: Unique identifier of the Credential dataset or `deferred_object_id` obtained in the previous response. If this parameter is present only the indicated dataset is returned.
     ProblemDetails:
       type: object
       description: RFC7807-compliant problem details object for error responses.

--- a/docs/en/oas3/OAS3-PDND-AS.yaml
+++ b/docs/en/oas3/OAS3-PDND-AS.yaml
@@ -417,9 +417,8 @@ components:
           example: 864000
         deferred_object_id:
           description: Required if userClaims and AttributeClaim parameters are not present. An opaque identifier related to the request of User and Attribute claims. 
-          type: integer
-          format: int64
-          example: 864000
+          type: string
+          example: "CF518451-0E54-4E52-B6C4-F1D952BE0505"
     CredentialClaimsRequest:
       required:
         - unique_id

--- a/docs/en/oas3/OAS3-PDND-AS.yaml
+++ b/docs/en/oas3/OAS3-PDND-AS.yaml
@@ -365,7 +365,7 @@ components:
             type: object
             properties:
               object_id:
-                description: Unique identifier of the Dataset.
+                description: Unique identifier of the Dataset. It MUST NOT contain personal data.
                 type: string
                 example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
               status:
@@ -398,7 +398,7 @@ components:
             type: object
             properties:
               object_id:
-                description: Unique identifier of the Dataset.
+                description: Unique identifier of the Dataset. It MUST NOT contain personal data.
                 type: string
                 example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
               issuance_date:
@@ -416,7 +416,7 @@ components:
           format: int64
           example: 864000
         deferred_object_id:
-          description: Required if userClaims and AttributeClaim parameters are not present. A unique opaque identifier related to the request of User and Attribute claims. 
+          description: Required if userClaims and AttributeClaim parameters are not present. A unique opaque identifier related to the request of User and Attribute claims. It MUST NOT contain personal data.
           type: string
           example: "CF518451-0E54-4E52-B6C4-F1D952BE0505"
     CredentialClaimsRequest:

--- a/docs/en/oas3/OAS3-PDND-AS.yaml
+++ b/docs/en/oas3/OAS3-PDND-AS.yaml
@@ -365,12 +365,37 @@ components:
             type: object
             properties:
               object_id:
+                description: Unique identifier of the Dataset. It MUST NOT contain personal data. Required also if additionalProperties are not present. This parameter MUST be used to notify through Signal Hub data updating or availability.
+                type: string
+                example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
+              issuance_date:
+                description: Administrative validity start date of the Dataset
+                type: string
+                example: "2025-01-01"
+              expiry_date:
+                description: Administrative expiry date of the Dataset.
+                type: string
+                example: "2025-12-31"
+            additionalProperties:
+              type: string
+            required: [object_id]
+        metadataClaims:
+          description: List of Metadata of Attribute.
+          type: array
+          items:
+            type: object
+            properties:
+              object_id:
                 description: Unique identifier of the Dataset. It MUST NOT contain personal data.
                 type: string
                 example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
+              description:
+                description: Human-Readable description of the Dataset.
+                type: string
+                example: "Example: Master's Degree in Computer Science"
               status:
                 description: |
-                  Status of the Dataset. Issued and Expired datasets fall within VALID; expiry is verified
+                  Status of the Dataset. REQUIRED if additionalProperties of attributeClaims are present. Issued and Expired datasets fall within VALID; expiry is verified
                   via metadata claims (e.g. expiry_date, nbf/exp). INVALID indicates active revocation by the AS.
                   For how this status affects the Digital Credential lifecycle managed by the Credential
                   Issuer, see <a target="blank" href="https://italia.github.io/eid-wallet-it-docs/versione-corrente/en/credential-revocation.html#status-update-by-authentic-sources">Status Update by Authentic Sources</a>.
@@ -384,41 +409,21 @@ components:
                   - INVALID - Dataset has been actively revoked by the Authentic Source.
                   - SUSPENDED - Dataset is temporarily invalid (typically reversible).
                 example: "VALID"
+              status_description:
+                description: Human-Readable description of the Status.
+                type: string
+                example: "Example: Master's Degree in Computer Science"
               last_updated:
-                description: Last time the status or attributes of the Dataset have been updated. Its format is `YYYY-MM-DDTHH:MM:SSZ`.
+                description: REQUIRED if additionalProperties of attributeClaims are present. Last time the status or attributes of the Dataset have been updated. Its format is `YYYY-MM-DDTHH:MM:SSZ`.
                 type: string
                 example: "2025-01-15T10:30:00Z"
-            additionalProperties:
-              type: string
-            required: [object_id, status, last_updated]
-        metadataClaims:
-          description: List of Metadata Claims.
-          type: array
-          items:
-            type: object
-            properties:
-              object_id:
-                description: Unique identifier of the Dataset. It MUST NOT contain personal data.
-                type: string
-                example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
-              issuance_date:
-                description: Administrative validity start date of the Dataset
-                type: string
-                example: "2025-01-01"
-              expiry_date:
-                description: Administrative expiry date of the Dataset.
-                type: string
-                example: "2025-12-31"
-            required: [object_id]
-        interval:
-          description: Required if userClaims and AttributeClaim parameters are not present. This represents the estimated amount of time (in seconds) required before making the request of the attribute claims again.
-          type: integer
-          format: int64
-          example: 864000
-        deferred_object_id:
-          description: Required if userClaims and AttributeClaim parameters are not present. A unique opaque identifier related to the request of User and Attribute claims. It MUST NOT contain personal data.
-          type: string
-          example: "CF518451-0E54-4E52-B6C4-F1D952BE0505"
+              interval:
+                description: Required if userClaims and additionalProperties of AttributeClaim parameters are not present. This represents the estimated amount of time (in seconds) required before making the request of the attribute claims again.
+                type: integer
+                format: int64
+                example: 864000
+            required: [object_id, description]
+      required: [userClaims, attributeClaims, metadataClaims]
     CredentialClaimsRequest:
       required:
         - unique_id
@@ -429,7 +434,7 @@ components:
           description: ID ANPR or Tax identification number
         object_id:
           type: string
-          description: Unique identifier of the Credential dataset or `deferred_object_id` obtained in the previous response. If this parameter is present only the indicated dataset is returned.
+          description: Unique identifier of the Credential dataset. If this parameter is present only the indicated dataset is returned.
     ProblemDetails:
       type: object
       description: RFC7807-compliant problem details object for error responses.

--- a/docs/en/oas3/OAS3-PDND-AS.yaml
+++ b/docs/en/oas3/OAS3-PDND-AS.yaml
@@ -423,7 +423,7 @@ components:
                 format: int64
                 example: 864000
             required: [object_id, description]
-      required: [userClaims, attributeClaims, metadataClaims]
+      required: [attributeClaims, metadataClaims]
     CredentialClaimsRequest:
       required:
         - unique_id

--- a/docs/en/oas3/OAS3-PDND-AS.yaml
+++ b/docs/en/oas3/OAS3-PDND-AS.yaml
@@ -416,7 +416,7 @@ components:
           format: int64
           example: 864000
         deferred_object_id:
-          description: Required if userClaims and AttributeClaim parameters are not present. An opaque identifier related to the request of User and Attribute claims. 
+          description: Required if userClaims and AttributeClaim parameters are not present. A unique opaque identifier related to the request of User and Attribute claims. 
           type: string
           example: "CF518451-0E54-4E52-B6C4-F1D952BE0505"
     CredentialClaimsRequest:

--- a/docs/en/signal-hub-endpoint.rst
+++ b/docs/en/signal-hub-endpoint.rst
@@ -67,8 +67,7 @@ The Signal Collection e-Service endpoint is used by Authentic Sources to deposit
   * - **objectType**
     - REQUIRED. Using this field the Authentic Source MAY use to further specify the Signal.
   * - **objectId**
-    - REQUIRED. The subject to which the Signal is bound. It MUST be set to the ``object_id`` that the Authentic Source used in the `get attributes` payload response to the the Credential Issuer and that corresponds to the Authentic Source's unique database identifier of the dataset of Attribute (see :ref:`authentic-source-endpoint:Get Attribute Claims`).
-    The Signal ``signalType`` MUST be valued with one of the following:
+    - REQUIRED. The subject to which the Signal is bound. It MUST be set to the ``object_id`` that the Authentic Source used in the `get attributes` payload response to the the Credential Issuer and that corresponds to the Authentic Source's unique database identifier of the dataset of Attribute (see :ref:`authentic-source-endpoint:Get Attribute Claims`). The Signal ``signalType`` MUST be valued with one of the following:
       
       - ``CREATE``, in order to notify the availability of the attributes related to a specific Digital Credential.
       - ``UPDATE``, in order to notify the updating of the attributes related to a specific Digital Credential.

--- a/docs/en/signal-hub-endpoint.rst
+++ b/docs/en/signal-hub-endpoint.rst
@@ -67,10 +67,11 @@ The Signal Collection e-Service endpoint is used by Authentic Sources to deposit
   * - **objectType**
     - REQUIRED. Using this field the Authentic Source MAY use to further specify the Signal.
   * - **objectId**
-    - REQUIRED. The subject to which the Signal is bound. If the Signal has ``signalType``:
+    - REQUIRED. The subject to which the Signal is bound. It MUST be set to the ``object_id`` that the Authentic Source used in the `get attributes` payload response to the the Credential Issuer and that corresponds to the Authentic Source's unique database identifier of the dataset of Attribute (see :ref:`authentic-source-endpoint:Get Attribute Claims`).
+    The Signal ``signalType`` MUST be valued with one of the following:
       
-      - ``CREATE``, then it MUST be set to the ``deferred_object_id`` that the Authentic Source used in the `get attributes` payload response to the the Credential Issuer in order to obtain the attributes related to a specific Digital Credential (see :ref:`authentic-source-endpoint:Get Attribute Claims`);
-      - ``UPDATE``, then it MUST be set to the Authentic Source's unique database identifier of the Digital Credential's attributes the Signal refers to (that is the ``object_id`` as defined in :ref:`authentic-source-endpoint:Get Attribute Claims`).
+      - ``CREATE``, in order to notify the availability of the attributes related to a specific Digital Credential.
+      - ``UPDATE``, in order to notify the updating of the attributes related to a specific Digital Credential.
       
   * - **signalType**
     - REQUIRED. Signal Type. It MUST be one of the following: 
@@ -82,7 +83,7 @@ The Signal Collection e-Service endpoint is used by Authentic Sources to deposit
     - REQUIRED. e-Service to which the Signal is bound. It MUST correspond to the e-Service Id value the Authentic Source is a Provider of.
 
 .. note::
-  In the deffered issuance flow, i.e., when the Authentic Source notifies the Credential Issuer of the availability of the Digital Credential's attributes via Signal Hub; both entities MUST keep track of the Authentic Source's ``deferred_object_id`` value used in the ``get attributes`` payload response. This is necessary since the ``objectId`` of the Signal MUST be set to that ``deferred_object_id`` value when the Signal has ``signalType`` with value ``CREATE``.
+  In the deffered issuance flow, i.e., when the Authentic Source notifies the Credential Issuer of the availability of the Digital Credential's attributes via Signal Hub; both entities MUST keep track of the Authentic Source's ``object_id`` value used in the ``get attributes`` payload response. This is necessary since the ``objectId`` of the Signal MUST be set to that ``object_id`` value when the Signal has ``signalType`` with value ``CREATE``.
 
 A non normative example of the Signal Collection request can be found at `Signal Hub push`_.
 
@@ -156,7 +157,7 @@ After the Signals have been successfully recovered by the Credential Issuer, the
   - For each Signal, the Credential Issuer MUST check the ``SignalType`` value:
     
     - if the Signal ``SignalType`` is ``UPDATE`` (where ``objectId`` refers to the **Authentic Source's unique database identifier of the Digital Credential's attributes**), the status and/or value of the attribute associated with a Digital Credential need updates;
-    - if the Signal ``SignalType`` is ``CREATE`` (where ``objectId`` refers to the **response ``deferred_object_id``**), the requested attributes of a specific Digital Credential are now available; 
+    - if the Signal ``SignalType`` is ``CREATE`` (where ``objectId`` refers to the **Authentic Source's unique database identifier of the Digital Credential's attributes**), the requested attributes of a specific Digital Credential are now available; 
 
     If the ``objectId`` does not correspond to any valid identifier known to the Credential Issuer, the Signal MUST be ignored. Otherwise, if it corresponds to a known and valid identifier, the Credential Issuer MUST use the :ref:`authentic-source-endpoint:Get Attribute Claims` PDND endpoint of the Authentic Source to retrieve the updated information and, if applicable, apply the new status to the corresponding Credential.
     

--- a/docs/en/signal-hub-endpoint.rst
+++ b/docs/en/signal-hub-endpoint.rst
@@ -69,8 +69,8 @@ The Signal Collection e-Service endpoint is used by Authentic Sources to deposit
   * - **objectId**
     - REQUIRED. The subject to which the Signal is bound. If the Signal has ``signalType``:
       
-      - ``CREATE``, then it MUST be set to the ``jti`` value the Credential Issuer used in the Agid-JWT-Signature token of the `get attributes` request to the Authentic Source to obtain the attributes related to a specific Digital Credential (see :ref:`authentic-source-endpoint:Get Attribute Claims`);
-      - ``UPDATE``, then it MUST be set to the Authentic Source's unique database identifier of the Digital Credential's attributes the Signal refers to.
+      - ``CREATE``, then it MUST be set to the ``deferred_object_id`` that the Authentic Source used in the `get attributes` payload response to the the Credential Issuer in order to obtain the attributes related to a specific Digital Credential (see :ref:`authentic-source-endpoint:Get Attribute Claims`);
+      - ``UPDATE``, then it MUST be set to the Authentic Source's unique database identifier of the Digital Credential's attributes the Signal refers to (that is the ``object_id`` as defined in :ref:`authentic-source-endpoint:Get Attribute Claims`).
       
   * - **signalType**
     - REQUIRED. Signal Type. It MUST be one of the following: 
@@ -82,7 +82,7 @@ The Signal Collection e-Service endpoint is used by Authentic Sources to deposit
     - REQUIRED. e-Service to which the Signal is bound. It MUST correspond to the e-Service Id value the Authentic Source is a Provider of.
 
 .. note::
-  In the deffered issuance flow, i.e., when the Authentic Source notifies the Credential Issuer of the availability of the Digital Credential's attributes via Signal Hub; both entities MUST keep track of the Credential Issuer's ``jti`` value used in the Agid-JWT-Signature of the ``get attributes`` request. This is necessary since the ``objectId`` of the Signal MUST be set to that ``jti`` value when the Signal has ``signalType`` with value ``CREATE``.
+  In the deffered issuance flow, i.e., when the Authentic Source notifies the Credential Issuer of the availability of the Digital Credential's attributes via Signal Hub; both entities MUST keep track of the Authentic Source's ``deferred_object_id`` value used in the ``get attributes`` payload response. This is necessary since the ``objectId`` of the Signal MUST be set to that ``deferred_object_id`` value when the Signal has ``signalType`` with value ``CREATE``.
 
 A non normative example of the Signal Collection request can be found at `Signal Hub push`_.
 
@@ -156,7 +156,7 @@ After the Signals have been successfully recovered by the Credential Issuer, the
   - For each Signal, the Credential Issuer MUST check the ``SignalType`` value:
     
     - if the Signal ``SignalType`` is ``UPDATE`` (where ``objectId`` refers to the **Authentic Source's unique database identifier of the Digital Credential's attributes**), the status and/or value of the attribute associated with a Digital Credential need updates;
-    - if the Signal ``SignalType`` is ``CREATE`` (where ``objectId`` refers to the **request ``jti``**), the requested attributes of a specific Digital Credential are now available; 
+    - if the Signal ``SignalType`` is ``CREATE`` (where ``objectId`` refers to the **response ``deferred_object_id``**), the requested attributes of a specific Digital Credential are now available; 
 
     If the ``objectId`` does not correspond to any valid identifier known to the Credential Issuer, the Signal MUST be ignored. Otherwise, if it corresponds to a known and valid identifier, the Credential Issuer MUST use the :ref:`authentic-source-endpoint:Get Attribute Claims` PDND endpoint of the Authentic Source to retrieve the updated information and, if applicable, apply the new status to the corresponding Credential.
     

--- a/docs/it/authentic-source-endpoint.rst
+++ b/docs/it/authentic-source-endpoint.rst
@@ -44,7 +44,7 @@ Get Attribute Claims
 
 .. note::
   La Fonte Autentica e il Credential Issuer DEVONO implementare la logica necessaria per tenere traccia delle richieste e delle risposte scambiate tramite questo e-Service, al fine di essere in grado di correlarle con la relativa emissione di un Attestato Elettronico. In particolare,
-    - entrambi DEVONO salvare il valore ``deferred_object_id`` contenuto nel payload della risposta per gestire i Segnali relativi alla disponibilità degli Attributi utili all'emissione in *deferred* di un Attestato Elettronico (vedere :ref:`signal-hub-endpoint:Elaborazione dei Segnali`). Una volta che il Credential Issuer ottiene gli attributi, il valore del ``deferred_object_id`` NON DEVE più essere utilizzato; qualsiasi notifica successiva relativa a un set di dati specifico DEVE essere gestita tramite ``object_id``.
+    - entrambi DEVONO salvare il valore ``object_id`` contenuto nel payload della risposta per gestire i Segnali relativi alla disponibilità degli Attributi utili all'emissione in *deferred* di un Attestato Elettronico (vedere :ref:`signal-hub-endpoint:Elaborazione dei Segnali`). Qualsiasi notifica successiva relativa a un set di dati specifico DEVE essere gestita tramite ``object_id``.
     - la Fonte Autentica DEVE registrare il valore datetime fornito all'interno del parametro ``last_updated``, che indica data e orario dell'ultima volta che gli Attributi dell'Utente sono stati aggiornati nel database della Fonte Autentica;
     - il Credential Issuer DEVE leggere il valore ``last_updated`` ricevuto nella risposta per essere in grado di verificare se gli Attributi dell'Utente sono cambiati dall'ultima emissione di un Attestato Elettronico.
 

--- a/docs/it/authentic-source-endpoint.rst
+++ b/docs/it/authentic-source-endpoint.rst
@@ -44,7 +44,7 @@ Get Attribute Claims
 
 .. note::
   La Fonte Autentica e il Credential Issuer DEVONO implementare la logica necessaria per tenere traccia delle richieste e delle risposte scambiate tramite questo e-Service, al fine di essere in grado di correlarle con la relativa emissione di un Attestato Elettronico. In particolare,
-    - entrambi DEVONO salvare il valore ``deferred_object_id`` contenuto nel payload della risposta per gestire i Segnali relativi alla disponibilità degli Attributi utili all'emissione in *deferred* di un Attestato Elettronico (vedere :ref:`signal-hub-endpoint:Elaborazione dei Segnali`);
+    - entrambi DEVONO salvare il valore ``deferred_object_id`` contenuto nel payload della risposta per gestire i Segnali relativi alla disponibilità degli Attributi utili all'emissione in *deferred* di un Attestato Elettronico (vedere :ref:`signal-hub-endpoint:Elaborazione dei Segnali`). Una volta che il Credential Issuer ottiene gli attributi, il valore del ``deferred_object_id`` NON DEVE più essere utilizzato; qualsiasi notifica successiva relativa a un set di dati specifico DEVE essere gestita tramite ``object_id``.
     - la Fonte Autentica DEVE registrare il valore datetime fornito all'interno del parametro ``last_updated``, che indica data e orario dell'ultima volta che gli Attributi dell'Utente sono stati aggiornati nel database della Fonte Autentica;
     - il Credential Issuer DEVE leggere il valore ``last_updated`` ricevuto nella risposta per essere in grado di verificare se gli Attributi dell'Utente sono cambiati dall'ultima emissione di un Attestato Elettronico.
 

--- a/docs/it/authentic-source-endpoint.rst
+++ b/docs/it/authentic-source-endpoint.rst
@@ -44,7 +44,7 @@ Get Attribute Claims
 
 .. note::
   La Fonte Autentica e il Credential Issuer DEVONO implementare la logica necessaria per tenere traccia delle richieste e delle risposte scambiate tramite questo e-Service, al fine di essere in grado di correlarle con la relativa emissione di un Attestato Elettronico. In particolare,
-    - entrambi DEVONO salvare il valore ``jti`` contenuto nel payload del token Agid-JWT-Signature della richiesta per gestire i Segnali relativi alla disponibilità degli Attributi utili all'emissione in *deferred* di un Attestato Elettronico (vedere :ref:`signal-hub-endpoint:Elaborazione dei Segnali`);
+    - entrambi DEVONO salvare il valore ``deferred_object_id`` contenuto nel payload della risposta per gestire i Segnali relativi alla disponibilità degli Attributi utili all'emissione in *deferred* di un Attestato Elettronico (vedere :ref:`signal-hub-endpoint:Elaborazione dei Segnali`);
     - la Fonte Autentica DEVE registrare il valore datetime fornito all'interno del parametro ``last_updated``, che indica data e orario dell'ultima volta che gli Attributi dell'Utente sono stati aggiornati nel database della Fonte Autentica;
     - il Credential Issuer DEVE leggere il valore ``last_updated`` ricevuto nella risposta per essere in grado di verificare se gli Attributi dell'Utente sono cambiati dall'ultima emissione di un Attestato Elettronico.
 

--- a/docs/it/oas3/OAS3-PDND-AS.yaml
+++ b/docs/it/oas3/OAS3-PDND-AS.yaml
@@ -417,9 +417,8 @@ components:
           example: 864000
         deferred_object_id:
           description: Required if userClaims and AttributeClaim parameters are not present. An opaque identifier related to the request of User and Attribute claims. 
-          type: integer
-          format: int64
-          example: 864000
+          type: string
+          example: "CF518451-0E54-4E52-B6C4-F1D952BE0505"
     CredentialClaimsRequest:
       required:
         - unique_id

--- a/docs/it/oas3/OAS3-PDND-AS.yaml
+++ b/docs/it/oas3/OAS3-PDND-AS.yaml
@@ -365,7 +365,7 @@ components:
             type: object
             properties:
               object_id:
-                description: Unique identifier of the Dataset.
+                description: Unique identifier of the Dataset. It MUST NOT contain personal data.
                 type: string
                 example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
               status:
@@ -398,7 +398,7 @@ components:
             type: object
             properties:
               object_id:
-                description: Unique identifier of the Dataset.
+                description: Unique identifier of the Dataset. It MUST NOT contain personal data.
                 type: string
                 example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
               issuance_date:
@@ -416,7 +416,7 @@ components:
           format: int64
           example: 864000
         deferred_object_id:
-          description: Required if userClaims and AttributeClaim parameters are not present. A unique opaque identifier related to the request of User and Attribute claims. 
+          description: Required if userClaims and AttributeClaim parameters are not present. A unique opaque identifier related to the request of User and Attribute claims. It MUST NOT contain personal data.
           type: string
           example: "CF518451-0E54-4E52-B6C4-F1D952BE0505"
     CredentialClaimsRequest:

--- a/docs/it/oas3/OAS3-PDND-AS.yaml
+++ b/docs/it/oas3/OAS3-PDND-AS.yaml
@@ -365,12 +365,37 @@ components:
             type: object
             properties:
               object_id:
+                description: Unique identifier of the Dataset. It MUST NOT contain personal data. Required also if additionalProperties are not present. This parameter MUST be used to notify through Signal Hub data updating or availability.
+                type: string
+                example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
+              issuance_date:
+                description: Administrative validity start date of the Dataset
+                type: string
+                example: "2025-01-01"
+              expiry_date:
+                description: Administrative expiry date of the Dataset.
+                type: string
+                example: "2025-12-31"
+            additionalProperties:
+              type: string
+            required: [object_id]
+        metadataClaims:
+          description: List of Metadata of Attribute.
+          type: array
+          items:
+            type: object
+            properties:
+              object_id:
                 description: Unique identifier of the Dataset. It MUST NOT contain personal data.
                 type: string
                 example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
+              description:
+                description: Human-Readable description of the Dataset.
+                type: string
+                example: "Example: Master's Degree in Computer Science"
               status:
                 description: |
-                  Stato del Dataset. I dataset Issued e Expired ricadono in VALID; la scadenza è verificata
+                  Stato del Dataset. OBBILIGATORIO se additionalProperties di attributeClaims sono presenti. I dataset Issued e Expired ricadono in VALID; la scadenza è verificata
                   tramite metadata claims (es. expiry_date, nbf/exp). INVALID indica revoca attiva da parte dell'AS.
                   Per come questo stato influenza il ciclo di vita dell'Attestato Elettronico gestito dal
                   Fornitore di Attestati Elettronici, vedere la sezione <a target="blank" href="https://italia.github.io/eid-wallet-it-docs/versione-corrente/it/credential-revocation.html#aggiornamento-dello-stato-da-parte-delle-fonti-autentiche">Aggiornamento dello Stato da parte delle Fonti Autentiche</a>.
@@ -384,41 +409,21 @@ components:
                   - INVALID - Il dataset è stato attivamente revocato dalla Fonte Autentica.
                   - SUSPENDED - Il dataset è temporaneamente non valido (tipicamente reversibile).
                 example: "VALID"
+              status_description:
+                description: Human-Readable description of the Status.
+                type: string
+                example: "Example: Master's Degree in Computer Science"
               last_updated:
-                description: Last time the status or attributes of the Dataset have been updated. Its format is `YYYY-MM-DDTHH:MM:SSZ`.
+                description: OBBILIGATORIO se additionalProperties di attributeClaims sono presenti. Last time the status or attributes of the Dataset have been updated. Its format is `YYYY-MM-DDTHH:MM:SSZ`.
                 type: string
                 example: "2025-01-15T10:30:00Z"
-            additionalProperties:
-              type: string
-            required: [object_id, status, last_updated]
-        metadataClaims:
-          description: List of Metadata Claims.
-          type: array
-          items:
-            type: object
-            properties:
-              object_id:
-                description: Unique identifier of the Dataset. It MUST NOT contain personal data.
-                type: string
-                example: "6F9619FF-8B86-D011-B42D-00C04FC964FF"
-              issuance_date:
-                description: Administrative validity start date of the Dataset
-                type: string
-                example: "2025-01-01"
-              expiry_date:
-                description: Administrative expiry date of the Dataset.
-                type: string
-                example: "2025-12-31"
-            required: [object_id]
-        interval:
-          description: Required if userClaims and AttributeClaim parameters are not present. This represents the estimated amount of time (in seconds) required before making the request of the attribute claims again.
-          type: integer
-          format: int64
-          example: 864000
-        deferred_object_id:
-          description: Required if userClaims and AttributeClaim parameters are not present. A unique opaque identifier related to the request of User and Attribute claims. It MUST NOT contain personal data.
-          type: string
-          example: "CF518451-0E54-4E52-B6C4-F1D952BE0505"
+              interval:
+                description: Required if userClaims and additionalProperties of AttributeClaim parameters are not present. This represents the estimated amount of time (in seconds) required before making the request of the attribute claims again.
+                type: integer
+                format: int64
+                example: 864000
+            required: [object_id, description]
+      required: [userClaims, attributeClaims, metadataClaims]
     CredentialClaimsRequest:
       required:
         - unique_id
@@ -429,7 +434,7 @@ components:
           description: ID ANPR or Tax identification number
         object_id:
           type: string
-          description: Unique identifier of the Credential dataset or `deferred_object_id` obtained in the previous response. If this parameter is present only the indicated dataset is returned.
+          description: Unique identifier of the Credential dataset. If this parameter is present only the indicated dataset is returned.
     ProblemDetails:
       type: object
       description: RFC7807-compliant problem details object for error responses.

--- a/docs/it/oas3/OAS3-PDND-AS.yaml
+++ b/docs/it/oas3/OAS3-PDND-AS.yaml
@@ -2,7 +2,14 @@ openapi: 3.0.1
 info:
   title: IT Wallet API - AS web services
   version: 0.2.0
-  description: IT Wallet Authentic Source e-Service exposed via PDND.
+  description: |
+    # IT Wallet Authentic Source e-Service exposed via PDND.
+    ### ModI patterns to be used:
+      - <b>ID_AUTH_CHANNEL_01</b>: Direct Trust TLS (HTTPS)
+      - <b>ID_AUTH_REST_01</b>: Authorization via PDND token
+      - <b>INTEGRITY_REST_02</b>: Requests and responses are signed
+      - <b>AUDIT_REST_02</b>: Additional properties (the pattern is optional if DPoP Token is used)
+      - <b>DPoP Token</b>: Used as an alternative to a Bearer Token (optional)
   termsOfService: "https://authentic-source.example.it/tos/"
   contact:
     name: IT-Wallet <credential_name> <credential_provider>
@@ -25,6 +32,14 @@ paths:
       summary: Get Authentic Source API status.
       description: Health-check endpoint that returns the operational status of the Authentic Source API.
       operationId: authenticSourceStatus
+      parameters:
+        - name: DPoP
+          in: header
+          description: Use only if the DPoP voucher has been requested from PDND.
+          schema:
+            type: string
+            format: JWT
+          required: false
       responses:
         "200":
           description: Service available
@@ -48,12 +63,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetails"
           headers:
-            X-RateLimit-Limit:
-              $ref: "#/components/headers/RateLimitLimitHeader"
-            X-RateLimit-Remaining:
-              $ref: "#/components/headers/RateLimitRemainingHeader"
-            X-RateLimit-Reset:
-              $ref: "#/components/headers/RateLimitResetHeader"
+            # RFC 6585 defines Retry-After. X-RateLimit-Limit, X-RateLimit-Remaining and X-RateLimit-Reset are not required because redundant along with Retry-After.
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
         "503":
           description: Service Unavailable
           content:
@@ -235,12 +247,9 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetails"
           headers:
-            X-RateLimit-Limit:
-              $ref: "#/components/headers/RateLimitLimitHeader"
-            X-RateLimit-Remaining:
-              $ref: "#/components/headers/RateLimitRemainingHeader"
-            X-RateLimit-Reset:
-              $ref: "#/components/headers/RateLimitResetHeader"
+            # RFC 6585 defines Retry-After. X-RateLimit-Limit, X-RateLimit-Remaining and X-RateLimit-Reset are not required because redundant along with Retry-After.
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
         "500":
           description: Internal Server Error.
           content:
@@ -402,7 +411,12 @@ components:
                 example: "2025-12-31"
             required: [object_id]
         interval:
-          description: Required if claims parameter is not present. This represents the estimated amount of time (in seconds) required before making the request of the attribute claims again.
+          description: Required if userClaims and AttributeClaim parameters are not present. This represents the estimated amount of time (in seconds) required before making the request of the attribute claims again.
+          type: integer
+          format: int64
+          example: 864000
+        deferred_object_id:
+          description: Required if userClaims and AttributeClaim parameters are not present. An opaque identifier related to the request of User and Attribute claims. 
           type: integer
           format: int64
           example: 864000
@@ -416,7 +430,7 @@ components:
           description: ID ANPR or Tax identification number
         object_id:
           type: string
-          description: Unique identifier of the Credential dataset or `jti` of the Agid-JWT-Signature Credential Issuer deferred flow's request. If this parameter is present only the indicated dataset is returned
+          description: Unique identifier of the Credential dataset or `deferred_object_id` obtained in the previous response. If this parameter is present only the indicated dataset is returned.
     ProblemDetails:
       type: object
       description: RFC7807-compliant problem details object for error responses.

--- a/docs/it/oas3/OAS3-PDND-AS.yaml
+++ b/docs/it/oas3/OAS3-PDND-AS.yaml
@@ -423,7 +423,7 @@ components:
                 format: int64
                 example: 864000
             required: [object_id, description]
-      required: [userClaims, attributeClaims, metadataClaims]
+      required: [attributeClaims, metadataClaims]
     CredentialClaimsRequest:
       required:
         - unique_id

--- a/docs/it/oas3/OAS3-PDND-AS.yaml
+++ b/docs/it/oas3/OAS3-PDND-AS.yaml
@@ -416,7 +416,7 @@ components:
           format: int64
           example: 864000
         deferred_object_id:
-          description: Required if userClaims and AttributeClaim parameters are not present. An opaque identifier related to the request of User and Attribute claims. 
+          description: Required if userClaims and AttributeClaim parameters are not present. A unique opaque identifier related to the request of User and Attribute claims. 
           type: string
           example: "CF518451-0E54-4E52-B6C4-F1D952BE0505"
     CredentialClaimsRequest:

--- a/docs/it/signal-hub-endpoint.rst
+++ b/docs/it/signal-hub-endpoint.rst
@@ -70,7 +70,7 @@ L'endpoint dell'e-Service di Raccolta Segnali viene utilizzato dalle Fonti Auten
     - OBBLIGATORIO. Il soggetto a cui è legato il Segnale. Se il Segnale ha ``signalType``:
       
       - ``CREATE``, allora DEVE essere impostato sul valore ``deferred_object_id`` che la Fonte Autentica ha utilizzato nel payload della risposta del `get attributes` verso il Credential Issuer per ottenere gli Attributi relativi a un Attestato Elettronico specifico (vedere :ref:`authentic-source-endpoint:Get Attribute Claims`);
-      - ``UPDATE``, allora DEVE essere impostato sull'identificatore univoco del database della Fonte Autentica degli Attributi dell'Attestato Elettronico a cui si riferisce il Segnale (ovvero l'``object_id`` come definito nella sezione :ref:`authentic-source-endpoint:Get Attribute Claims).
+      - ``UPDATE``, allora DEVE essere impostato sull'identificatore univoco del database della Fonte Autentica degli Attributi dell'Attestato Elettronico a cui si riferisce il Segnale (ovvero l'``object_id`` come definito nella sezione :ref:`authentic-source-endpoint:Get Attribute Claims`).
       
   * - **signalType**
     - OBBLIGATORIO. Tipo di Segnale. DEVE essere uno dei seguenti:

--- a/docs/it/signal-hub-endpoint.rst
+++ b/docs/it/signal-hub-endpoint.rst
@@ -67,8 +67,7 @@ L'endpoint dell'e-Service di Raccolta Segnali viene utilizzato dalle Fonti Auten
   * - **objectType**
     - OBBLIGATORIO. Questo è un campo libero che la Fonte Autentica PUÒ utilizzare per specificare ulteriormente il Segnale.
   * - **objectId**
-    - OBBLIGATORIO. Il soggetto a cui è legato il Segnale. DEVE essere impostato sul valore ``object_id`` che la Fonte Autentica ha utilizzato nel payload della risposta del `get attributes` verso il Credential Issuer e che corrisponde all'identificativo univoco del database della Fonte Autentica relativo al set di dati dell'Attributo (vedi :ref:`authentic-source-endpoint:Get Attribute Claims`). 
-    Il ``signalType`` del Segnale DEVE essere valorizzato con uno dei seguenti:
+    - OBBLIGATORIO. Il soggetto a cui è legato il Segnale. DEVE essere impostato sul valore ``object_id`` che la Fonte Autentica ha utilizzato nel payload della risposta del `get attributes` verso il Credential Issuer e che corrisponde all'identificativo univoco del database della Fonte Autentica relativo al set di dati dell'Attributo (vedi :ref:`authentic-source-endpoint:Get Attribute Claims`). Il ``signalType`` del Segnale DEVE essere valorizzato con uno dei seguenti:
       
       - ``CREATE``, al fine di notificare la disponibilità degli attributi relativi ad un specifico Attestato Elettronico.
       - ``UPDATE``, al fine di notificare l'aggiornamento degli attributi relativi ad un specifico Attestato Elettronico.

--- a/docs/it/signal-hub-endpoint.rst
+++ b/docs/it/signal-hub-endpoint.rst
@@ -67,10 +67,11 @@ L'endpoint dell'e-Service di Raccolta Segnali viene utilizzato dalle Fonti Auten
   * - **objectType**
     - OBBLIGATORIO. Questo è un campo libero che la Fonte Autentica PUÒ utilizzare per specificare ulteriormente il Segnale.
   * - **objectId**
-    - OBBLIGATORIO. Il soggetto a cui è legato il Segnale. Se il Segnale ha ``signalType``:
+    - OBBLIGATORIO. Il soggetto a cui è legato il Segnale. DEVE essere impostato sul valore ``object_id`` che la Fonte Autentica ha utilizzato nel payload della risposta del `get attributes` verso il Credential Issuer e che corrisponde all'identificativo univoco del database della Fonte Autentica relativo al set di dati dell'Attributo (vedi :ref:`authentic-source-endpoint:Get Attribute Claims`). 
+    Il ``signalType`` del Segnale DEVE essere valorizzato con uno dei seguenti:
       
-      - ``CREATE``, allora DEVE essere impostato sul valore ``deferred_object_id`` che la Fonte Autentica ha utilizzato nel payload della risposta del `get attributes` verso il Credential Issuer per ottenere gli Attributi relativi a un Attestato Elettronico specifico (vedere :ref:`authentic-source-endpoint:Get Attribute Claims`);
-      - ``UPDATE``, allora DEVE essere impostato sull'identificatore univoco del database della Fonte Autentica degli Attributi dell'Attestato Elettronico a cui si riferisce il Segnale (ovvero l'``object_id`` come definito nella sezione :ref:`authentic-source-endpoint:Get Attribute Claims`).
+      - ``CREATE``, al fine di notificare la disponibilità degli attributi relativi ad un specifico Attestato Elettronico.
+      - ``UPDATE``, al fine di notificare l'aggiornamento degli attributi relativi ad un specifico Attestato Elettronico.
       
   * - **signalType**
     - OBBLIGATORIO. Tipo di Segnale. DEVE essere uno dei seguenti:
@@ -82,7 +83,7 @@ L'endpoint dell'e-Service di Raccolta Segnali viene utilizzato dalle Fonti Auten
     - OBBLIGATORIO. e-Service a cui è legato il Segnale. DEVE corrispondere al valore dell'Id dell'e-Service di cui la Fonte Autentica è Provider.
 
 .. note::
-  Nel Deferred Issuance Flow, cioè quando la Fonte Autentica notifica al Fornitore di Attestati Elettronici la disponibilità degli Attributi dell'Attestato Elettronico tramite Signal Hub; entrambe le entità DEVONO tenere traccia del valore ``deferred_object_id`` della Fonte Autentica utilizzato nella risposta del `get attributes`. Questo è necessario poiché l'``objectId`` del Segnale DEVE essere impostato su quel valore ``deferred_object_id`` quando il Segnale ha il ``signalType`` valorizzato con ``CREATE``.
+  Nel Deferred Issuance Flow, cioè quando la Fonte Autentica notifica al Fornitore di Attestati Elettronici la disponibilità degli Attributi dell'Attestato Elettronico tramite Signal Hub; entrambe le entità DEVONO tenere traccia del valore ``object_id`` della Fonte Autentica utilizzato nella risposta del `get attributes`. Questo è necessario poiché l'``objectId`` del Segnale DEVE essere impostato su quel valore ``object_id`` quando il Segnale ha il ``signalType`` valorizzato con ``CREATE``.
 
 Un esempio non normativo di richiesta di richiesta di Raccolta Segnali può essere trovato nel `Signal Hub push`_.
 
@@ -156,7 +157,7 @@ Dopo che i Segnali sono stati recuperati con successo dal Fornitore di Attestati
   - Per ogni Segnale, il Fornitore di Attestati Elettronici DEVE verificare il valore ``SignalType``:
     
     - se il ``SignalType`` del Segnale è ``UPDATE`` (l'``objectId`` fa riferimento all'**identificativo univoco presente nella base dati della Fonte Autentica relativo agli Attributi dell'Attestato Elettronico**), lo stato e/o il valore dell'Attributo associato a un Attestato Elettronico necessitano di aggiornamenti;    
-    - se il ``SignalType`` del Segnale è ``CREATE`` (l'``objectId`` corrisponde al **``deferred_object_id`` della risposta**), gli Attributi richiesti di un Attestato Elettronico specifico sono ora disponibili;
+    - se il ``SignalType`` del Segnale è ``CREATE`` (l'``objectId`` corrisponde al **identificativo univoco presente nella base dati della Fonte Autentica relativo agli Attributi dell'Attestato Elettronico**), gli Attributi richiesti di un Attestato Elettronico specifico sono ora disponibili;
 
     Se l'``objectId`` non corrisponde ad alcun identificativo valido noto al Fornitore di Attestati Elettronici, il Segnale DEVE essere ignorato. Altrimenti, se corrisponde a un identificativo noto e valido, il Fornitore di Attestati Elettronici DEVE utilizzare l'endpoint PDND :ref:`authentic-source-endpoint:Get Attribute Claims` della Fonte Autentica per recuperare le informazioni aggiornate e, se possibile, applicare il nuovo stato/attributo all'Attestato Elettronico corrispondente.
     

--- a/docs/it/signal-hub-endpoint.rst
+++ b/docs/it/signal-hub-endpoint.rst
@@ -69,8 +69,8 @@ L'endpoint dell'e-Service di Raccolta Segnali viene utilizzato dalle Fonti Auten
   * - **objectId**
     - OBBLIGATORIO. Il soggetto a cui è legato il Segnale. Se il Segnale ha ``signalType``:
       
-      - ``CREATE``, allora DEVE essere impostato sul valore ``jti`` che il Fornitore di Attestati Elettronici ha utilizzato nel token Agid-JWT-Signature della richiesta `get attributes` alla Fonte Autentica per ottenere gli Attributi relativi a un Attestato Elettronico specifico (vedere :ref:`authentic-source-endpoint:Get Attribute Claims`);
-      - ``UPDATE``, allora DEVE essere impostato sull'identificatore univoco del database della Fonte Autentica degli Attributi dell'Attestato Elettronico a cui si riferisce il Segnale.
+      - ``CREATE``, allora DEVE essere impostato sul valore ``deferred_object_id`` che la Fonte Autentica ha utilizzato nel payload della risposta del `get attributes` verso il Credential Issuer per ottenere gli Attributi relativi a un Attestato Elettronico specifico (vedere :ref:`authentic-source-endpoint:Get Attribute Claims`);
+      - ``UPDATE``, allora DEVE essere impostato sull'identificatore univoco del database della Fonte Autentica degli Attributi dell'Attestato Elettronico a cui si riferisce il Segnale (ovvero l'``object_id`` come definito nella sezione :ref:`authentic-source-endpoint:Get Attribute Claims).
       
   * - **signalType**
     - OBBLIGATORIO. Tipo di Segnale. DEVE essere uno dei seguenti:
@@ -82,7 +82,7 @@ L'endpoint dell'e-Service di Raccolta Segnali viene utilizzato dalle Fonti Auten
     - OBBLIGATORIO. e-Service a cui è legato il Segnale. DEVE corrispondere al valore dell'Id dell'e-Service di cui la Fonte Autentica è Provider.
 
 .. note::
-  Nel Deferred Issuance Flow, cioè quando la Fonte Autentica notifica al Fornitore di Attestati Elettronici la disponibilità degli Attributi dell'Attestato Elettronico tramite Signal Hub; entrambe le entità DEVONO tenere traccia del valore ``jti`` del Fornitore di Attestati Elettronici utilizzato nell'Agid-JWT-Signature della richiesta `get attributes`. Questo è necessario poiché l'``objectId`` del Segnale DEVE essere impostato su quel valore ``jti`` quando il Segnale ha ``signalType`` valorizzato con ``CREATE``.
+  Nel Deferred Issuance Flow, cioè quando la Fonte Autentica notifica al Fornitore di Attestati Elettronici la disponibilità degli Attributi dell'Attestato Elettronico tramite Signal Hub; entrambe le entità DEVONO tenere traccia del valore ``deferred_object_id`` della Fonte Autentica utilizzato nella risposta del `get attributes`. Questo è necessario poiché l'``objectId`` del Segnale DEVE essere impostato su quel valore ``deferred_object_id`` quando il Segnale ha il ``signalType`` valorizzato con ``CREATE``.
 
 Un esempio non normativo di richiesta di richiesta di Raccolta Segnali può essere trovato nel `Signal Hub push`_.
 
@@ -156,7 +156,7 @@ Dopo che i Segnali sono stati recuperati con successo dal Fornitore di Attestati
   - Per ogni Segnale, il Fornitore di Attestati Elettronici DEVE verificare il valore ``SignalType``:
     
     - se il ``SignalType`` del Segnale è ``UPDATE`` (l'``objectId`` fa riferimento all'**identificativo univoco presente nella base dati della Fonte Autentica relativo agli Attributi dell'Attestato Elettronico**), lo stato e/o il valore dell'Attributo associato a un Attestato Elettronico necessitano di aggiornamenti;    
-    - se il ``SignalType`` del Segnale è ``CREATE`` (l'``objectId`` corrisponde al **``jti`` della richiesta**), gli Attributi richiesti di un Attestato Elettronico specifico sono ora disponibili;
+    - se il ``SignalType`` del Segnale è ``CREATE`` (l'``objectId`` corrisponde al **``deferred_object_id`` della risposta**), gli Attributi richiesti di un Attestato Elettronico specifico sono ora disponibili;
 
     Se l'``objectId`` non corrisponde ad alcun identificativo valido noto al Fornitore di Attestati Elettronici, il Segnale DEVE essere ignorato. Altrimenti, se corrisponde a un identificativo noto e valido, il Fornitore di Attestati Elettronici DEVE utilizzare l'endpoint PDND :ref:`authentic-source-endpoint:Get Attribute Claims` della Fonte Autentica per recuperare le informazioni aggiornate e, se possibile, applicare il nuovo stato/attributo all'Attestato Elettronico corrispondente.
     


### PR DESCRIPTION
This PR resolves #1024.

This PR contains:

- `object_id` MUST be present also in case of deferred issuance since each `object_id` corresponds to a `credential_identifier` that corresponds to a `transaction_id` singularly used in the Deferred Endpoint. So `object_id` replaces `deferred_object_id`. 
- Reorganized claims position between `AttributeClaims `(these claims will be present in the future Credential) and `MetadataClaims `(these  will not be present in the Credential).
- Added `description` and `status_description` in the `metadataClaims`