### PR TITLE
chore: openid federation 1.0 final

### DIFF
--- a/docs/common/common_definitions.rst
+++ b/docs/common/common_definitions.rst
@@ -37,7 +37,7 @@
 .. _OAUTH2: https://www.rfc-editor.org/rfc/rfc6749
 .. _OAuthCrossDeviceSec: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-cross-device-security-08
 .. _OID-FED-WALLET: https://openid.net/specs/openid-federation-wallet-1_0.html
-.. _OID-FED: https://openid.net/specs/openid-federation-1_0-46.html
+.. _OID-FED: https://openid.net/specs/openid-federation-1_0.html
 .. _OID-FED-SUBORDINATE-EVENTS: https://openid.net/specs/openid-federation-subordinate-events-1_0.html
 .. _OIDC-FED#Federation_Entity: https://openid.net/specs/openid-federation-1_0.html#Section-4.6
 .. _OIDC-FED#RP_metadata: https://openid.net/specs/openid-federation-1_0.html#Section-4.1

--- a/docs/common/standards-lostnfound.rst
+++ b/docs/common/standards-lostnfound.rst
@@ -9,7 +9,7 @@ Infrastructure of Trust
     :header-rows: 0
 
     * - `OID-FED`_
-      - Hedberg, R., Jones, M.B., Solberg, A.Å., Bradley, J., De Marco, G., Dzhuvinov, V.,  "OpenID Federation 1.0", December 2024, Draft 41.
+      - Hedberg, R., Jones, M.B., Solberg, A.Å., Bradley, J., De Marco, G., Dzhuvinov, V.,  "OpenID Federation 1.0", February 2026, Final.
     * - DTS/ESI-0019602
       - Electronic Signatures and Trust Infrastructures (ESI); Trusted lists; Data model. Trusted lists in other formats, such as JSON, CBOR or ASN.1.
     * - ISO-IEC_7367

--- a/docs/common/standards.rst
+++ b/docs/common/standards.rst
@@ -48,7 +48,7 @@ Infrastructure of Trust
     * - `OID-FED-WALLET`_
       - De Marco, G., Hedberg, R., Jones, M.B., Bradley, J., Dzhuvinov, V., "OpenID Federation Wallet Architectures 1.0", October 2024, Draft 03.
     * - `OID-FED`_
-      - Hedberg, R., Jones, M.B., Solberg, A.A., Bradley, J., De Marco, G., Dzhuvinov, V., "OpenID Federation 1.0", December 2025, Draft 46.
+      - Hedberg, R., Jones, M.B., Solberg, A.A., Bradley, J., De Marco, G., Dzhuvinov, V., "OpenID Federation 1.0", February 2026, Final.
     * - `OID-FED-SUBORDINATE-EVENTS`_
       - De Marco, G., Jones, M.B., "OpenID Federation Subordinate Events Endpoint 1.0", January 2026, Draft 00.
     * - `ETSI TS 119 412-6`_

--- a/docs/en/relying-party-metadata.rst
+++ b/docs/en/relying-party-metadata.rst
@@ -29,7 +29,7 @@ The *openid_credential_verifier* metadata MUST contain the *client_metadata*, as
   * - **vp_formats_supported**
     - JSON object defining the formats and proof types of Verifiable Presentations and Verifiable Credentials the RP supports. It consists of a list of name/value pairs, where each name uniquely identifies a supported type. The RP MUST support at least ``dc+sd-jwt``. For SD-JWT VC, the value associated with each name/value pair MUST include ``sd-jwt_alg_values`` listing acceptable signing algorithms; for mdoc-CBOR, the value MUST include ``issuerauth_alg_values`` and ``deviceauth_alg_values``. The JOSE/COSE headers of presented artifacts MUST match one of the advertised values. See `OpenID4VP`_ §11 and Appendix B.
   * - **jwks**
-    - JSON Web Key Set document, passed by value, containing the protocol specific keys for the Relying Party. See `OID-FED`_ Draft 41 Section 5.2.1 and `JWK`_.
+    - JSON Web Key Set document, passed by value, containing the protocol specific keys for the Relying Party. See `OID-FED`_ Section 5.2.1 and `JWK`_.
   * - **erasure_endpoint**
     - [CONDITIONAL] JSON String that represents the URI to which the Wallet Instance can request deletion of Users' attributes. This URL MUST use the *https* scheme. This endpoint MUST be present whenever the Relying Parties requested attributes that can uniquely identify Users such as the tax_id_code claim of the PID.
 

--- a/docs/it/relying-party-metadata.rst
+++ b/docs/it/relying-party-metadata.rst
@@ -29,7 +29,7 @@ I metadata *openid_credential_verifier* DEVONO contenere il *client_metadata*, c
   * - **vp_formats_supported**
     - Oggetto JSON che definisce i formati e i tipi di prova delle Verifiable Presentations e delle Verifiable Credentials supportati dalla RP. È composto da una lista di coppie nome/valore, dove ogni nome identifica in modo univoco un tipo supportato. La RP DEVE supportare almeno ``dc+sd-jwt``. Per le SD-JWT VC, il valore associato a ciascuna coppia nome/valore DEVE includere ``sd-jwt_alg_values`` che elenca gli algoritmi di firma accettati; per mdoc-CBOR, la valore DEVE includere ``issuerauth_alg_values`` e ``deviceauth_alg_values``. Gli header JOSE/COSE degli artefatti presentati DEVONO corrispondere a uno dei valori dichiarati. Vedi `OpenID4VP`_ Sezione 11 e Appendice B.
   * - **jwks**
-    - Documento JSON Web Key Set, passato per valore, contenente le chiavi specifiche del protocollo per la Relying Party. Vedi `OID-FED`_ Draft 41 Sezione 5.2.1 e `JWK`_.
+    - Documento JSON Web Key Set, passato per valore, contenente le chiavi specifiche del protocollo per la Relying Party. Vedi `OID-FED`_ Sezione 5.2.1 e `JWK`_.
   * - **erasure_endpoint**
     - [CONDIZIONALE] Stringa JSON che rappresenta l'URI a cui l'Istanza del Wallet può richiedere la cancellazione degli attributi degli Utenti. Questo URL DEVE utilizzare lo schema ``https``. Questo endpoint DEVE essere presente ogni volta che le Relying Party richiedono attributi che possono identificare in modo univoco gli Utenti, come il claim ``tax_id_code`` del PID.
 


### PR DESCRIPTION
Thisk PR aligns the documentation with the **published OpenID Federation 1.0** specification ([OpenID Federation 1.0](https://openid.net/specs/openid-federation-1_0.html)) instead of the numbered implementer’s draft URL (previously **draft 46**).

- **`OID-FED` link**: point `common_definitions.rst` at the stable final spec URL so all `OID-FED`_ references resolve correctly.
- **Bibliography**: update citation metadata to **Final**, **February 2026** (per OpenID publication).
- **Relying Party metadata (EN/IT)**: remove stale “Draft 41” wording; keep the normative pointer to `OID-FED` Section 5.2.1.
Rebuild Sphinx if HTML under `_build/` is committed or published from CI.
---
## Technical differences: OpenID Federation **draft 46** vs **1.0 (Final)**
Publication path was **draft 46 → draft 47 → Final 1.0** (17 February 2026). The OpenID **Document History** in draft 47 records the substantive edits after draft 46 under the **-47** entry; the Final specification incorporates that work and completes the standards track (stable URL, Final status; the draft-only history appendix is not part of the shipped final document in the same form).
### Changes recorded after draft 46 (Document History **-47**)
1. **Acknowledgements**: credit to Pål Axelsson.
2. **`crit` in typed JWTs**: added guidance on enabling use of the **`crit`** (critical) claim in the definition of a kind of JWT.
3. **Editorial structure**: more consistent **section and figure titles**.
4. **Reordering**: grouped **protocol-independent** text separately from **protocol-specific** text.
5. **`constraints` and `delegation` claims**: clarifications from Nat Sakimura’s review.
6. **Issue #317**: corrected the **Trust Chain** example.
7. **1.1 spec split**: clarifications applied while splitting material into **OpenID Federation 1.1** and **OpenID Federation for OpenID Connect 1.1** (plus informative references to those specs).
8. **Trust Mark Delegation**: validation adjusted to handle an optional **`exp`** claim.
9. **Issue #327**: **separate examples** for **Intermediate** vs **OP** Entity Configurations.
10. **Examples**: revised **`iss` / `exp`** values in examples for consistency/readability.
11. **Examples**: **`kid`** values set to plausible **JWK thumbprints** for the illustrated keys.
12. **Informative references** added to **OpenID Federation 1.1** and **OpenID Federation for OpenID Connect 1.1**.
### Scope note
- Items introduced **in draft 46** (vs earlier drafts) appear under the **-46** block in the same Document History (e.g. issues #292–#311, `peer_trust_chain` rules, `aud` in explicit registration, resolve endpoint wording, etc.); those are **not** “46 → 1.0” deltas unless you are comparing **1.0** all the way back to **draft 45** or earlier.
- Any **draft 47 → Final** edits are typically **minor editorial / publication** changes; they are not enumerated in the same appendix once the Final document is published.
