### PR TITLE
fix: removed wrong scope parameter in grants for credential offer

### DIFF
--- a/docs/common/contributors.rst
+++ b/docs/common/contributors.rst
@@ -26,6 +26,7 @@
 - Mart Aarma
 - Marta Sciunnach
 - Matteo Fortini
+- Michele Massetti
 - Michele Silletti
 - Nicola Saitto
 - Niels van Dijk

--- a/docs/en/credential-issuance-low-level.rst
+++ b/docs/en/credential-issuance-low-level.rst
@@ -699,7 +699,7 @@ The Credential Offer can be transmitted by value using any supported invocation 
 
 .. code-block:: text
 
-  openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A//credential-issuer.example.org%22%2C%22credential_configuration_ids%22%3A%5B%22dc_sd_jwt_Education_degree%22%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%22scope%22%3A%22Education_degree%22%7D%7D%7D
+  openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A//credential-issuer.example.org%22%2C%22credential_configuration_ids%22%3A%5B%22dc_sd_jwt_Education_degree%22%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%issuer_state%22%3A%22eyJhbGciOiJSU0Et...F77QK8%22%7D%7D%7D
 
 The decoded Credential Offer object:
 
@@ -710,7 +710,7 @@ The decoded Credential Offer object:
     "credential_configuration_ids": ["dc_sd_jwt_Education_degree"],
     "grants": {
       "authorization_code": {
-        "scope": "Education_degree"
+        "issuer_state": "eyJhbGciOiJSU0Et...F77QK8",
       }
     }
   }
@@ -745,7 +745,6 @@ The Credential Issuer responds:
     "grants": {
       "authorization_code": {
         "issuer_state": "eyJhbGciOiJSU0Et...F77QK8",
-        "scope": "EuropeanDisabilityCard"
       }
     }
   }
@@ -781,7 +780,7 @@ The Authentic Source responds:
     "credential_configuration_ids": ["mso_mdoc_mDL"],
     "grants": {
       "authorization_code": {
-        "scope": "mDL"
+        "issuer_state": "eyJhbGciOiJSU0Et...F77QK8",
       }
     }
   }

--- a/docs/en/credential-issuance-low-level.rst
+++ b/docs/en/credential-issuance-low-level.rst
@@ -684,7 +684,6 @@ The Credential Offer object is a JSON object containing the parameters defined i
 
         - **issuer_state**: OPTIONAL. Opaque string created by the Credential Issuer used to bind the subsequent Authorization Request with the Credential Issuer. The Wallet MUST include it in the subsequent Authorization Request when present.
         - **authorization_server**: REQUIRED when the Credential Issuer uses more than one authorization server in its Issuer Solution. This string identifies the Authorization Server to use. The value MUST match with one of the values mapped in the ``authorization_servers`` array of the Credential Issuer metadata. It MUST NOT be used if ``authorization_servers`` is absent or it has no multiple entries.
-        - **scope**: REQUIRED. String value that maps to a specific Credential type. The Wallet MUST use this scope value in the Authorization Request. See Section 4.1 of [`OPENID4VC-HAIP`_] for details.
     - Section 4.1.1 of [`OpenID4VCI`_] and Section 4.1 of [`OPENID4VC-HAIP`_].
 
 .. note::

--- a/docs/it/credential-issuance-low-level.rst
+++ b/docs/it/credential-issuance-low-level.rst
@@ -648,7 +648,6 @@ L'oggetto Credential Offer è un oggetto JSON contenente i parametri definiti ne
 
         - **issuer_state**: OPZIONALE. Stringa opaca creata dal Credential Issuer utilizzata per legare la successiva Authorization Request con il Credential Issuer. Il Wallet DEVE includerlo nella successiva Authorization Request quando presente.
         - **authorization_server**: REQUIRED quando il Credential Issuer utilizza più di un authorization server nella sua soluzione. Stringa che identifica l'Authorization Server da utilizzare. Il valore DEVE corrispondere a uno dei valori mappati nell'array ``authorization_servers`` dei metadata del Credential Issuer. NON DEVE essere utilizzato se ``authorization_servers`` è assente o non ha voci multiple.
-        - **scope**: REQUIRED. Valore stringa che mappa a uno specifico tipo di Attestato Elettronico. Il Wallet DEVE utilizzare questo valore di scope nell'Authorization Request. Vedere Sezione 4.1 di [`OPENID4VC-HAIP`_] per i dettagli.
     - Sezione 4.1.1 di [`OpenID4VCI`_] e Sezione 4.1 di [`OPENID4VC-HAIP`_].
 
 .. note::
@@ -664,7 +663,7 @@ La Credential Offer può essere trasmessa per valore utilizzando qualsiasi metod
 
 .. code-block:: text
 
-  openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A//credential-issuer.example.org%22%2C%22credential_configuration_ids%22%3A%5B%22dc_sd_jwt_Education_degree%22%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%22scope%22%3A%22Education_degree%22%7D%7D%7D
+  openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A//credential-issuer.example.org%22%2C%22credential_configuration_ids%22%3A%5B%22dc_sd_jwt_Education_degree%22%5D%2C%22grants%22%3A%7B%22authorization_code%22%3A%7B%22issuer_state%22%3A%22eyJhbGciOiJSU0Et...F77QK8%22%7D%7D%7D
 
 L'oggetto Credential Offer decodificato:
 
@@ -675,7 +674,7 @@ L'oggetto Credential Offer decodificato:
     "credential_configuration_ids": ["dc_sd_jwt_Education_degree"],
     "grants": {
       "authorization_code": {
-        "scope": "Education_degree"
+        "issuer_state": "eyJhbGciOiJSU0Et...F77QK8",
       }
     }
   }
@@ -710,7 +709,6 @@ Il Credential Issuer risponde:
     "grants": {
       "authorization_code": {
         "issuer_state": "eyJhbGciOiJSU0Et...F77QK8",
-        "scope": "EuropeanDisabilityCard"
       }
     }
   }
@@ -746,7 +744,7 @@ L'Authentic Source risponde:
     "credential_configuration_ids": ["mso_mdoc_mDL"],
     "grants": {
       "authorization_code": {
-        "scope": "mDL"
+       "issuer_state": "eyJhbGciOiJSU0Et...F77QK8",
       }
     }
   }


### PR DESCRIPTION
This pull request updates the documentation for the Credential Offer object in both English and Italian to remove references to the required use of the scope parameter in the `authorization_code` grant and to update all related examples to use the `issuer_state` parameter instead. These changes bring the documentation in line with current protocol specifications.

Documentation updates for Credential Offer parameters:

* Removed references to the `scope` parameter as a required field in the Credential Offer object and its examples in both the English (`docs/en/credential-issuance-low-level.rst`) and Italian (`docs/it/credential-issuance-low-level.rst`) documentation. [[1]](diffhunk://#diff-1c0af979a980594cec65d6f19f5a39492fb5532a870fa9decd4ad6f1811b717dL687) [[2]](diffhunk://#diff-34d054fb0d2d9e3b3955619293ee4d1e764ca071d81db2b2fcbb1dfeab7f46c9L651)

* Updated all example Credential Offer objects and responses to use the `issuer_state` parameter instead of `scope` in both English and Italian documentation. [[1]](diffhunk://#diff-1c0af979a980594cec65d6f19f5a39492fb5532a870fa9decd4ad6f1811b717dL703-R702) [[2]](diffhunk://#diff-1c0af979a980594cec65d6f19f5a39492fb5532a870fa9decd4ad6f1811b717dL714-R713) [[3]](diffhunk://#diff-1c0af979a980594cec65d6f19f5a39492fb5532a870fa9decd4ad6f1811b717dL749) [[4]](diffhunk://#diff-1c0af979a980594cec65d6f19f5a39492fb5532a870fa9decd4ad6f1811b717dL785-R783) [[5]](diffhunk://#diff-34d054fb0d2d9e3b3955619293ee4d1e764ca071d81db2b2fcbb1dfeab7f46c9L667-R666) [[6]](diffhunk://#diff-34d054fb0d2d9e3b3955619293ee4d1e764ca071d81db2b2fcbb1dfeab7f46c9L678-R677) [[7]](diffhunk://#diff-34d054fb0d2d9e3b3955619293ee4d1e764ca071d81db2b2fcbb1dfeab7f46c9L713) [[8]](diffhunk://#diff-34d054fb0d2d9e3b3955619293ee4d1e764ca071d81db2b2fcbb1dfeab7f46c9L749-R747)