### PR TITLE
User's email address in the PID Issuance

### DIFF
--- a/docs/en/credential-issuance-endpoint.rst
+++ b/docs/en/credential-issuance-endpoint.rst
@@ -115,7 +115,7 @@ The ``request`` JWT payload contained in the HTTP POST message is given with the
 
             - **type**: REQUIRED. It MUST be set to ``openid_credential``,
             - **credential_configuration_id**: REQUIRED. JSON String. String specifying a unique identifier of the Credential in a specific format that MUST be mapped in the `credential_configurations_supported` metadata claim of the Credential Issuer. For instance,``dc_sd_jwt_pid`` can be used for PID in SD-JWT VC format, ``dc_sd_jwt_mDL`` for mobile driving licence in SD-JWT VC format and ``mso_mdoc_mDL`` for mobile driving license in mdoc format.
-            - **email**: OPTIONAl in case of PID issuance, otherwise it MUST not be present. If present, it MUST contain the User's email address to be used for notifying PID revocation events.
+            - **email**: OPTIONAL in case of PID issuance, otherwise it MUST not be present. If present, it MUST contain the User's email address to be used for notifying PID revocation events.
 
         When eID Substantial Authentication with MRTD Verification is requested, an additional JSON Object MUST be included with the following claims:
 

--- a/docs/en/credential-issuance-endpoint.rst
+++ b/docs/en/credential-issuance-endpoint.rst
@@ -111,10 +111,11 @@ The ``request`` JWT payload contained in the HTTP POST message is given with the
       - JSON String. String specifying a unique identifier of the Credential regardless of its format. It MUST be mapped in the `credential_configurations_supported` metadata claim of the Credential Issuer. Unique identifier value MUST match the `credential_type` parameter of the :ref:`registry:Digital Credentials Catalog`. For instance, in the case of the PID, it may be set to ``pid`` while in case of mobile driving licence ``mDL``. Since it may be multivalued, when this occurs each value MUST be separated by a space.
       - :rfc:`6749`
     * - **authorization_details**
-      - Array of JSON Objects. Each JSON Object MUST include the following claims:
+      - Array of JSON Objects. Each JSON Object includes the following claims:
 
-            - **type**: it MUST be set to ``openid_credential``,
-            - **credential_configuration_id**: JSON String. String specifying a unique identifier of the Credential in a specific format that MUST be mapped in the `credential_configurations_supported` metadata claim of the Credential Issuer. For instance,``dc_sd_jwt_pid`` can be used for PID in SD-JWT VC format, ``dc_sd_jwt_mDL`` for mobile driving licence in SD-JWT VC format and ``mso_mdoc_mDL`` for mobile driving license in mdoc format.
+            - **type**: REQUIRED. It MUST be set to ``openid_credential``,
+            - **credential_configuration_id**: REQUIRED. JSON String. String specifying a unique identifier of the Credential in a specific format that MUST be mapped in the `credential_configurations_supported` metadata claim of the Credential Issuer. For instance,``dc_sd_jwt_pid`` can be used for PID in SD-JWT VC format, ``dc_sd_jwt_mDL`` for mobile driving licence in SD-JWT VC format and ``mso_mdoc_mDL`` for mobile driving license in mdoc format.
+            - **email**: OPTIONAl in case of PID issuance, otherwise it MUST not be present. If present, it MUST contain the User's email address to be used for notifying PID revocation events.
 
         When eID Substantial Authentication with MRTD Verification is requested, an additional JSON Object MUST be included with the following claims:
 

--- a/docs/it/credential-issuance-endpoint.rst
+++ b/docs/it/credential-issuance-endpoint.rst
@@ -112,10 +112,11 @@ Il payload del JWT ``request`` contenuto nel messaggio HTTP POST contiene i segu
       - Stringa JSON. Stringa contenente un identificativo univoco dell'Attestato Elettronico indipendentemente dal suo formato. DEVE essere mappato nel claim `credential_configurations_supported` presente nei Metadata del Credential Issuer. Il valore dell'identificativo univoco DEVE corrispondere al parametro `credential_type` del :ref:`registry:Catalogo degli Attestati Elettronici`. Ad esempio, nel caso del PID, può essere valorizzato con ``pid`` mentre nel caso della patente di guida ``mDL``. Poiché PUÒ essere multivalore, quando ciò si verifica ogni valore DEVE essere separato da uno spazio.
       - :rfc:`6749`
     * - **authorization_details**
-      - Array di Oggetti JSON. Ogni Oggetto JSON DEVE includere i seguenti claim:
+      - Array di Oggetti JSON. Ogni Oggetto JSON include i seguenti claim:
 
-            - **type**: DEVE essere valorizzato con ``openid_credential``,
-            - **credential_configuration_id**: Stringa JSON. Stringa che indica un identificativo univoco dell'Attestato Elettronico in uno specifico formato che DEVE essere mappato nel claim `credential_configurations_supported` presente nei Metadata del Credential Issuer. Ad esempio, ``dc_sd_jwt_pid`` può essere utilizzato per il PID in formato SD-JWT VC, ``dc_sd_jwt_mDL`` per la patente di guida in formato SD-JWT VC e ``mso_mdoc_mDL`` per la patente di guida in formato mdoc.
+            - **type**: OBBLIGATORIO. DEVE essere valorizzato con ``openid_credential``,
+            - **credential_configuration_id**: OBBLIGATORIO. Stringa JSON. Stringa che indica un identificativo univoco dell'Attestato Elettronico in uno specifico formato che DEVE essere mappato nel claim `credential_configurations_supported` presente nei Metadata del Credential Issuer. Ad esempio, ``dc_sd_jwt_pid`` può essere utilizzato per il PID in formato SD-JWT VC, ``dc_sd_jwt_mDL`` per la patente di guida in formato SD-JWT VC e ``mso_mdoc_mDL`` per la patente di guida in formato mdoc.
+            - **email**: OPZIONALE in caso di PID issuance, altrimenti non DEVE essere presente. Se presente, DEVE contenere l'indirizzo email dell'utente da utilizzare per la notifica degli eventi di revoca del PID.
 
         Inoltre, nel caso in cui l'Autenticazione eID Substantial con Verifica MRTD viene richiesta, DEVE essere incluso un Oggetto JSON opzionale con i seguenti claim:
 


### PR DESCRIPTION
This PR introduces **`email`** claim in the `authorization_details` object in the PAR request for PID Issuance.