### PR TITLE
Fix Credential Issuer Metadata Example

### DIFF
--- a/examples/ec-eaa.json
+++ b/examples/ec-eaa.json
@@ -640,9 +640,9 @@
                         "cose_key"
                     ],
                     "credential_signing_alg_values_supported": [
-                        "-7",
-                        "-35",
-                        "-36"
+                        -7,
+                        -35,
+                        -36
                     ],
                     "credential_metadata": {
                         "display": [

--- a/examples/ec-eaa.json
+++ b/examples/ec-eaa.json
@@ -640,9 +640,9 @@
                         "cose_key"
                     ],
                     "credential_signing_alg_values_supported": [
-                        "ES256",
-                        "ES384",
-                        "ES512"
+                        "-7",
+                        "-35",
+                        "-36"
                     ],
                     "credential_metadata": {
                         "display": [


### PR DESCRIPTION
This PR fixes the example value of the metadata `credential_signing_alg_values_supported` for mdoc Credentials.
