### PR TITLE
Adding dataset_id and object_id definitions within the defined-terms section

### DIFF
--- a/docs/en/defined-terms.rst
+++ b/docs/en/defined-terms.rst
@@ -12,6 +12,14 @@ Below is the description of acronyms and definitions which are useful for furthe
 .. glossary::
     :sorted:
 
+    **Dataset_id**
+      Alphanumeric string defined by the Authentic Source that uniquely identifies a specific dataset relating to an Electronic Attestation of Attributes.
+      Not present in ARF 2.7.3; specific to IT-Wallet.
+
+    **Object_id**
+      Alphanumeric string defined by the Authentic Source that uniquely identifies a specific instance of an Electronic Attestation of Attributes associated with a particular User.
+      Not present in ARF 2.7.3; specific to IT-Wallet.
+
     **Accreditation Process**
       Process performed by the National Accreditation Body to accredit CABs, resulting in an accreditation certificate.
       Not present in ARF 2.7.3; specific to IT-Wallet.

--- a/docs/en/entity-onboarding.rst
+++ b/docs/en/entity-onboarding.rst
@@ -257,7 +257,7 @@ The Authentic Source registration follows a technical process as described below
      - REQUIRED. Array containing data capability specifications.
    * - **data_capabilities[].dataset_id**
      - string
-     - REQUIRED. The unique identifier of the dataset within the scope of the Authentic Source, which MAY be used as a query parameter for the ``GetAttributeClaims`` service.
+     - REQUIRED. The :term:`Dataset_id` within the scope of the Authentic Source, which MAY be used as a query parameter for the ``GetAttributeClaims`` service.
    * - **data_capabilities[].data_origin**
      - JSON Object Array
      - REQUIRED. Object array containing the human-readable name of the data origin or department providing the data in multiple languages. It MUST contain ``locale`` and ``name`` claims.

--- a/docs/en/registry.rst
+++ b/docs/en/registry.rst
@@ -420,7 +420,7 @@ The Authentic Source Registry MUST contain the following parameters for each reg
      - REQUIRED. Array containing data capability specifications.
    * - **data_capabilities[].dataset_id**
      - string
-     - REQUIRED. The unique identifier of the dataset within the scope of the Authentic Source, which MAY be used as a query parameter for the ``GetAttributeClaims`` service.
+     - REQUIRED. The :term:`Dataset_id` within the scope of the Authentic Source, which MAY be used as a query parameter for the ``GetAttributeClaims`` service.
    * - **data_capabilities[].data_origin_l10n_id**
      - string
      - REQUIRED. Localization key referencing the human-readable name of the data origin or department providing the data (e.g., ``authentic_source1.dataset1.origin``).

--- a/docs/en/signal-hub-endpoint.rst
+++ b/docs/en/signal-hub-endpoint.rst
@@ -67,7 +67,7 @@ The Signal Collection e-Service endpoint is used by Authentic Sources to deposit
   * - **objectType**
     - REQUIRED. Using this field the Authentic Source MAY use to further specify the Signal.
   * - **objectId**
-    - REQUIRED. The subject to which the Signal is bound. It MUST be set to the ``object_id`` that the Authentic Source used in the `get attributes` payload response to the the Credential Issuer and that corresponds to the Authentic Source's unique database identifier of the dataset of Attribute (see :ref:`authentic-source-endpoint:Get Attribute Claims`). The Signal ``signalType`` MUST be valued with one of the following:
+    - REQUIRED. The subject to which the Signal is bound. It MUST be set to the Authentic Source's :term:`Object_id` (``object_id``) used in the `get attributes` payload response to the Credential Issuer (see :ref:`authentic-source-endpoint:Get Attribute Claims`). The Signal ``signalType`` MUST be valued with one of the following:
       
       - ``CREATE``, in order to notify the availability of the attributes related to a specific Digital Credential.
       - ``UPDATE``, in order to notify the updating of the attributes related to a specific Digital Credential.
@@ -155,8 +155,8 @@ After the Signals have been successfully recovered by the Credential Issuer, the
 
   - For each Signal, the Credential Issuer MUST check the ``SignalType`` value:
     
-    - if the Signal ``SignalType`` is ``UPDATE`` (where ``objectId`` refers to the **Authentic Source's unique database identifier of the Digital Credential's attributes**), the status and/or value of the attribute associated with a Digital Credential need updates;
-    - if the Signal ``SignalType`` is ``CREATE`` (where ``objectId`` refers to the **Authentic Source's unique database identifier of the Digital Credential's attributes**), the requested attributes of a specific Digital Credential are now available; 
+    - if the Signal ``SignalType`` is ``UPDATE`` (where ``objectId`` refers to the :term:`Object_id` of the Authentic Source), the status and/or value of the attribute associated with a Digital Credential need updates;
+    - if the Signal ``SignalType`` is ``CREATE`` (where ``objectId`` refers to the :term:`Object_id` of the Authentic Source), the requested attributes of a specific Digital Credential are now available; 
 
     If the ``objectId`` does not correspond to any valid identifier known to the Credential Issuer, the Signal MUST be ignored. Otherwise, if it corresponds to a known and valid identifier, the Credential Issuer MUST use the :ref:`authentic-source-endpoint:Get Attribute Claims` PDND endpoint of the Authentic Source to retrieve the updated information and, if applicable, apply the new status to the corresponding Credential.
     

--- a/docs/it/defined-terms.rst
+++ b/docs/it/defined-terms.rst
@@ -13,6 +13,14 @@ Di seguito le descrizioni di acronimi e definizioni, correlati al presente docum
 .. glossary::
     :sorted:
 
+    **Dataset_id**
+      Stringa alfanumerica definita dalla Fonte Autentica e che identifica univocamente uno specifico dataset relativo a un Attestato Elettronico di Attributi.
+      Non presente in ARF 2.7.3; specifico di IT-Wallet.
+
+    **Object_id**
+      Stringa alfanumerica definita dalla Fonte Autentica e che identifica univocamente una specifica istanza di Attestato Elettronico di Attributi associata a un determinato Utente.
+      Non presente in ARF 2.7.3; specifico di IT-Wallet.
+
     **Processo di Accreditamento**
       Procedura svolta dall'Ente di Accreditamento Nazionale per accreditare gli Organismi di Valutazione della conformità (CABs), che si conclude con il rilascio di un certificato di accreditamento.
       Non presente in ARF 2.7.3; specifico di IT-Wallet.

--- a/docs/it/entity-onboarding.rst
+++ b/docs/it/entity-onboarding.rst
@@ -257,7 +257,7 @@ La registrazione della Fonte Autentica segue un processo tecnico descritto di se
      - OBBLIGATORIO. Array contenente le specifiche delle capacità sui dati.
    * - **data_capabilities[].dataset_id**
      - string
-     - OBBLIGATORIO. L'identificatore univoco del dataset nell'ambito della Fonte Autentica, che PUÒ essere utilizzato come parametro di query per il servizio ``GetAttributeClaims``.
+     - OBBLIGATORIO. Il :term:`Dataset_id` nell'ambito della Fonte Autentica, che PUÒ essere utilizzato come parametro di query per il servizio ``GetAttributeClaims``.
    * - **data_capabilities[].data_origin**
      - JSON Object Array
      - OBBLIGATORIO. Array di oggetti contenente il nome leggibile dell'origine o del dipartimento che fornisce i dati in più lingue. DEVE contenere i claim ``locale`` e ``name``.

--- a/docs/it/registry.rst
+++ b/docs/it/registry.rst
@@ -420,7 +420,7 @@ Il Registro delle Fonti Autentiche DEVE contenere i seguenti parametri per ciasc
      - OBBLIGATORIO. Array contenente le specifiche delle capacità sui dati.
    * - **data_capabilities[].dataset_id**
      - string
-     - OBBLIGATORIO. L'identificatore univoco del dataset nell'ambito della Fonte Autentica, che PUÒ essere utilizzato come parametro di query per il servizio ``GetAttributeClaims``.
+     - OBBLIGATORIO. Il :term:`Dataset_id` nell'ambito della Fonte Autentica, che PUÒ essere utilizzato come parametro di query per il servizio ``GetAttributeClaims``.
    * - **data_capabilities[].data_origin_l10n_id**
      - string
      - OBBLIGATORIO. Chiave di localizzazione che fa riferimento al nome leggibile dell'origine o del dipartimento che fornisce i dati (es. ``authentic_source1.dataset1.origin``).

--- a/docs/it/signal-hub-endpoint.rst
+++ b/docs/it/signal-hub-endpoint.rst
@@ -67,7 +67,7 @@ L'endpoint dell'e-Service di Raccolta Segnali viene utilizzato dalle Fonti Auten
   * - **objectType**
     - OBBLIGATORIO. Questo è un campo libero che la Fonte Autentica PUÒ utilizzare per specificare ulteriormente il Segnale.
   * - **objectId**
-    - OBBLIGATORIO. Il soggetto a cui è legato il Segnale. DEVE essere impostato sul valore ``object_id`` che la Fonte Autentica ha utilizzato nel payload della risposta del `get attributes` verso il Credential Issuer e che corrisponde all'identificativo univoco del database della Fonte Autentica relativo al set di dati dell'Attributo (vedi :ref:`authentic-source-endpoint:Get Attribute Claims`). Il ``signalType`` del Segnale DEVE essere valorizzato con uno dei seguenti:
+    - OBBLIGATORIO. Il soggetto a cui è legato il Segnale. DEVE essere impostato sul valore :term:`Object_id` (``object_id``) che la Fonte Autentica ha utilizzato nel payload della risposta del `get attributes` verso il Credential Issuer (vedi :ref:`authentic-source-endpoint:Get Attribute Claims`). Il ``signalType`` del Segnale DEVE essere valorizzato con uno dei seguenti:
       
       - ``CREATE``, al fine di notificare la disponibilità degli attributi relativi ad un specifico Attestato Elettronico.
       - ``UPDATE``, al fine di notificare l'aggiornamento degli attributi relativi ad un specifico Attestato Elettronico.
@@ -155,8 +155,8 @@ Dopo che i Segnali sono stati recuperati con successo dal Fornitore di Attestati
 
   - Per ogni Segnale, il Fornitore di Attestati Elettronici DEVE verificare il valore ``SignalType``:
     
-    - se il ``SignalType`` del Segnale è ``UPDATE`` (l'``objectId`` fa riferimento all'**identificativo univoco presente nella base dati della Fonte Autentica relativo agli Attributi dell'Attestato Elettronico**), lo stato e/o il valore dell'Attributo associato a un Attestato Elettronico necessitano di aggiornamenti;    
-    - se il ``SignalType`` del Segnale è ``CREATE`` (l'``objectId`` corrisponde al **identificativo univoco presente nella base dati della Fonte Autentica relativo agli Attributi dell'Attestato Elettronico**), gli Attributi richiesti di un Attestato Elettronico specifico sono ora disponibili;
+    - se il ``SignalType`` del Segnale è ``UPDATE`` (l'``objectId`` fa riferimento al :term:`Object_id` della Fonte Autentica), lo stato e/o il valore dell'Attributo associato a un Attestato Elettronico necessitano di aggiornamenti;
+    - se il ``SignalType`` del Segnale è ``CREATE`` (l'``objectId`` corrisponde al :term:`Object_id` della Fonte Autentica), gli Attributi richiesti di un Attestato Elettronico specifico sono ora disponibili;
 
     Se l'``objectId`` non corrisponde ad alcun identificativo valido noto al Fornitore di Attestati Elettronici, il Segnale DEVE essere ignorato. Altrimenti, se corrisponde a un identificativo noto e valido, il Fornitore di Attestati Elettronici DEVE utilizzare l'endpoint PDND :ref:`authentic-source-endpoint:Get Attribute Claims` della Fonte Autentica per recuperare le informazioni aggiornate e, se possibile, applicare il nuovo stato/attributo all'Attestato Elettronico corrispondente.
     


### PR DESCRIPTION
This PR resolves the issue #1121 
