### PR TITLE
feat: wallet rp intermediary according to eudiw

### DIFF
--- a/docs/common/common_definitions.rst
+++ b/docs/common/common_definitions.rst
@@ -16,6 +16,7 @@
 .. _ETSI TS 119 602: https://www.etsi.org/deliver/etsi_ts/119600_119699/119602/01.01.01_60/ts_119602v010101p.pdf
 .. _ETSI EN 319 411-1: https://www.etsi.org/deliver/etsi_en/319400_319499/31941101/01.03.00_20/en_31941101v010300a.pdf
 .. _ETSI TS 119 411-8: https://www.etsi.org/deliver/etsi_ts/119400_119499/11941108/01.01.01_60/ts_11941108v010101p.pdf
+.. _ETSI TS 119 472-2: https://www.etsi.org/deliver/etsi_ts/119400_119499/11947202/01.02.01_60/ts_11947202v010201p.pdf
 .. _ETSI TS 119 475: https://www.etsi.org/deliver/etsi_ts/119400_119499/119475/01.01.01_60/ts_119475v010101p.pdf
 .. _ETSI TS 119 615: https://www.etsi.org/deliver/etsi_ts/119600_119699/119615/01.01.01_60/ts_119615v010101p.pdf
 .. _ETSI EN 319 132-1: https://www.etsi.org/deliver/etsi_en/319100_319199/31913201/01.03.01_60/en_31913201v010301p.pdf

--- a/docs/en/remote-flow.rst
+++ b/docs/en/remote-flow.rst
@@ -4,6 +4,8 @@
 Remote Flow
 ===========
 
+The IT-Wallet remote presentation profile builds on `OpenID4VP`_, `OPENID4VC-HAIP`_, and `ETSI TS 119 472-2`_, which specifies how Relying Party registration information — including transactions mediated by a :term:`Relying Party Intermediary` — is transferred in the Authorization Request. See :ref:`remote-flow-verifier-info` and :ref:`remote-flow-rp-intermediary`.
+
 Depending on whether the User is using a mobile device or a workstation, the Relying Party MUST support the following remote flows (:ref:`RPR-84 <test-plans-remote-presentation:Remote Credential Verifier Test Matrix>`):
 
 * **Same Device**, the Relying Party MUST provide an ``HTTP`` location to the Wallet Instance using a redirect (``302``) or an HTML href in a web page (:ref:`RPR-01 <test-plans-remote-presentation:Remote Credential Verifier Test Matrix>`);
@@ -561,6 +563,8 @@ The JWT payload parameters are described herein:
         - **credential_ids**. Array referencing one or more Credentials from the ``dcql_query`` that can authorize the transaction.  
   * - **transaction_data_hashes_alg** 
     - OPTIONAL. Array of strings, each representing a hash algorithm identifier, corresponding to a hash algorithm name listed in the `IANA <https://www.iana.org/assignments/named-information/named-information.xhtml#hash-alg>`_.  One of these algorithms MUST be used to calculate the hashes in the ``transaction_data_hashes`` response parameter.  If omitted, the default hash algorithm is ``sha-256``.
+  * - **verifier_info**
+    - REQUIRED per `ETSI TS 119 472-2`_. A non-empty JSON array defined in `OpenID4VP`_ Section 5.11. Each element is a JSON Object with a ``format`` and a ``data`` member, and MUST NOT contain ``credential_ids``. The array MUST include one element with ``format`` set to ``registrar_dataset`` carrying the Registrar-provided registration data of the Relying Party for the current intended use (see :ref:`remote-flow-verifier-info`). If a Registration Certificate is available, the array MUST also include one element with ``format`` set to ``registration_cert`` carrying the serialized certificate by value. In an intermediated transaction, the ``registrar_dataset`` and ``registration_cert`` elements refer to the **intermediated** Relying Party, while the access certificate in the JWT header identifies the **intermediary** (see :ref:`remote-flow-rp-intermediary`).
   * - **response_type**
     - REQUIRED. It MUST be set to ``vp_token`` (:ref:`RPR-107 <test-plans-remote-presentation:Remote Credential Verifier Test Matrix>`).
   * - **wallet_nonce**
@@ -595,6 +599,181 @@ The JWT payload parameters are described herein:
 
 .. note::
   The ``client_metadata`` parameter usage is conditional. If ``client_id`` uses the ``x509_hash`` prefix, all the Relying Party metadata, other than its public key used for signing the Request Object, MUST be provided in ``client_metadata``. However, if it is present and ``client_id`` uses the ``openid_federation`` prefix, the Wallet Instance MUST obtain the Relying Party metadata through the OpenID Federation Trust Chain (:ref:`RPR-113 <test-plans-remote-presentation:Remote Credential Verifier Test Matrix>`), and MUST NOT use ``client_metadata`` to override or replace resolved metadata. The only exception is ``client_metadata.jwks`` (and related encrypted-response capability parameters such as ``encrypted_response_enc_values_supported``), which MAY be used exclusively to carry request-specific (ephemeral) public keys for encrypting the Authorization Response in ``direct_post.jwt`` (see `OpenID4VP`_ Section 8.3). 
+
+.. _remote-flow-verifier-info:
+
+``verifier_info`` and Relying Party registration data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`ETSI TS 119 472-2`_ profiles the OpenID4VC-HAIP remote presentation flow for the EUDI Wallet ecosystem. It requires the Request Object to carry Relying Party registration information through the ``verifier_info`` parameter defined in `OpenID4VP`_ Section 5.11.
+
+Each ``verifier_info`` element is a JSON Object. The following ``format`` values are defined for IT-Wallet:
+
+.. list-table::
+  :class: longtable
+  :widths: 25 75
+  :header-rows: 1
+
+  * - **format**
+    - **Description**
+  * - **registrar_dataset**
+    - REQUIRED. Carries Registrar-provided registration data for the Relying Party and intended use relevant to the presentation request. The ``data`` member MUST be a non-empty JSON Object as specified in :ref:`table-registrar-dataset-fields`.
+  * - **registration_cert**
+    - REQUIRED when a Registration Certificate is available for the intended use. The ``data`` member MUST be the base64url encoding of the serialized Registration Certificate (by value, not by reference).
+
+.. _table-registrar-dataset-fields:
+
+The ``data`` object of a ``registrar_dataset`` element MUST contain the following members:
+
+.. list-table::
+  :class: longtable
+  :widths: 25 75
+  :header-rows: 1
+
+  * - **Member**
+    - **Description**
+  * - **identifier**
+    - REQUIRED. The EU-wide unique identifier of the Relying Party for the current intended use, as registered with the Member State Registrar.
+  * - **srvDescription**
+    - REQUIRED. A non-empty array of localized strings (``lang``, ``content``) describing the Relying Party Service registered for the intended use.
+  * - **registryURI**
+    - REQUIRED. URI of the Registrar API where the Wallet Instance MAY verify the registered information about the Relying Party, if requested by the User.
+  * - **intendedUseIdentifier**
+    - REQUIRED. Registrar-provided identifier of the intended use of the Relying Party.
+  * - **purpose**
+    - REQUIRED. A non-empty array of localized strings describing the registered purposes of the intended data processing.
+  * - **policyURI**
+    - REQUIRED. URI of the privacy policy applicable to the registered intended use.
+  * - **credential**
+    - OPTIONAL. Array of Credential objects listing the attestation types and attributes registered for the intended use.
+
+When the presentation is not intermediated, the identity conveyed in ``verifier_info`` matches the Relying Party authenticated through the access certificate in the JWT ``x5c`` header.
+
+.. _remote-flow-rp-intermediary:
+
+Presentation through a Relying Party Intermediary
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A :term:`Relying Party Intermediary` acts on behalf of one or more intermediated Relying Parties. OpenID4VP does not define a dedicated ``is_intermediary`` flag. Instead, the Wallet Instance infers an intermediated transaction from the **combination** of:
+
+1. **Intermediary authentication** — the Request Object is signed by the intermediary and the JWT ``x5c`` header contains the intermediary's access certificate (authenticated via ``x509_hash`` ``client_id`` or an OpenID Federation Trust Chain).
+2. **Intermediated Relying Party registration data** — the ``verifier_info`` ``registrar_dataset`` element carries the name, identifier, Registrar URL, intended use, and related registration data of the **intermediated** Relying Party.
+3. **Optional Registration Certificate** — when available, a ``verifier_info`` ``registration_cert`` element carries the Registration Certificate of the intermediated Relying Party. That certificate MAY contain the association to the intermediary.
+
+The Wallet Instance MUST treat the request as intermediated when the Relying Party identity in the access certificate differs from the Relying Party identity in ``verifier_info`` (ARF Topic 52, requirement RPI_07). In that case, the Wallet Instance MUST:
+
+- authenticate the **intermediary** using its access certificate;
+- display to the User the trade names of **both** the intermediary (from the access certificate) and the intermediated Relying Party (from ``verifier_info`` and, if present, the Registration Certificate) when asking for approval;
+- verify, if the User requests it, that the contractual relationship between the intermediated Relying Party and the intermediary is registered with the competent Registrar — either by inspecting the Registration Certificate or by querying the Registrar API indicated in ``registryURI``;
+- send the Authorization Response to the intermediary's ``response_uri``;
+- record both the intermediary and the intermediated Relying Party in the transaction log.
+
+The intermediated Relying Party itself does not need an access certificate for the transaction; the intermediary holds and presents the Registration Certificate on its behalf when one has been issued.
+
+Non-normative examples
+^^^^^^^^^^^^^^^^^^^^^^
+
+The following examples illustrate the structure of ``verifier_info``. They use fictional endpoints and identifiers.
+
+Direct presentation (no intermediary)
+"""""""""""""""""""""""""""""""""""""
+
+In a direct transaction, the access certificate and ``verifier_info`` refer to the same Relying Party:
+
+.. code-block:: json
+
+  {
+    "client_id": "x509_hash:sha-256:abc123...",
+    "response_mode": "direct_post.jwt",
+    "response_type": "vp_token",
+    "response_uri": "https://comune.esempio.it/oid4vp/response",
+    "verifier_info": [
+      {
+        "format": "registrar_dataset",
+        "data": {
+          "identifier": "urn:eu:wrp:it:12345678901:0001",
+          "srvDescription": [
+            { "lang": "it", "content": "Servizio SPID del Comune di Esempio" }
+          ],
+          "registryURI": "https://registro.eid.gov.it/api/v1",
+          "intendedUseIdentifier": "urn:eu:wrp-intended-use:it:comune-spid-login",
+          "purpose": [
+            { "lang": "it", "content": "Autenticazione dell'utente per l'accesso ai servizi online del Comune" }
+          ],
+          "policyURI": "https://comune.esempio.it/privacy/spid"
+        }
+      },
+      {
+        "format": "registration_cert",
+        "data": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9..."
+      }
+    ],
+    "dcql_query": { "...": "..." }
+  }
+
+The JWT header ``x5c`` contains the access certificate of ``Comune di Esempio``, whose identifier matches ``verifier_info[0].data.identifier``.
+
+Presentation through a Relying Party Intermediary
+"""""""""""""""""""""""""""""""""""""""""""""""""
+
+In an intermediated transaction, the intermediary authenticates with its own access certificate while ``verifier_info`` describes the intermediated Relying Party:
+
+.. code-block:: json
+
+  {
+    "client_id": "x509_hash:sha-256:def456...",
+    "response_mode": "direct_post.jwt",
+    "response_type": "vp_token",
+    "response_uri": "https://intermediary.provider.it/oid4vp/response",
+    "verifier_info": [
+      {
+        "format": "registrar_dataset",
+        "data": {
+          "identifier": "urn:eu:wrp:it:98765432109:0001",
+          "srvDescription": [
+            { "lang": "it", "content": "Verifica età — Cinema Multiplex" }
+          ],
+          "registryURI": "https://registro.eid.gov.it/api/v1",
+          "intendedUseIdentifier": "urn:eu:wrp-intended-use:it:cinema-age-check",
+          "purpose": [
+            { "lang": "it", "content": "Verifica del limite di età per l'accesso a contenuti riservati" }
+          ],
+          "policyURI": "https://cinema.esempio.it/privacy/age-verification"
+        }
+      },
+      {
+        "format": "registration_cert",
+        "data": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9..."
+      }
+    ],
+    "dcql_query": { "...": "..." }
+  }
+
+The JWT header ``x5c`` contains the access certificate of the intermediary ``Provider Intermediario S.r.l.`` (identifier ``urn:eu:wrp:it:11111111111:0001``), which differs from the intermediated Relying Party identifier ``urn:eu:wrp:it:98765432109:0001`` in ``verifier_info``. The Wallet Instance therefore displays both identities to the User and verifies the intermediary–Relying Party relationship before asking for consent.
+
+Non-normative Request Object excerpt (intermediary)
+"""""""""""""""""""""""""""""""""""""""""""""""""""
+
+.. code-block:: text
+
+  # JWT header (abbreviated)
+  {
+    "alg": "ES256",
+    "typ": "oauth-authz-req+jwt",
+    "kid": "intermediary-key-2026",
+    "x5c": ["MIIC...intermediary-access-certificate..."]
+  }
+
+  # JWT payload (abbreviated)
+  {
+    "iss": "x509_hash:sha-256:def456...",
+    "client_id": "x509_hash:sha-256:def456...",
+    "response_uri": "https://intermediary.provider.it/oid4vp/response",
+    "verifier_info": [ "... see JSON example above ..." ],
+    "dcql_query": { "...": "..." },
+    "nonce": "n-0Z3k9Qm7xP2vL8wR4tY6uI1oA5sD",
+    "exp": 1744203600
+  }
 
 Authorization Response
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/it/remote-flow.rst
+++ b/docs/it/remote-flow.rst
@@ -4,6 +4,8 @@
 Flusso Remoto
 =============
 
+Il profilo di presentazione remota IT-Wallet si basa su `OpenID4VP`_, `OPENID4VC-HAIP`_ e `ETSI TS 119 472-2`_, che specifica come trasferire nell'Authorization Request le informazioni di registrazione della Relying Party — incluse le transazioni gestite da un :term:`Intermediario di Relying Party`. Vedere :ref:`remote-flow-verifier-info` e :ref:`remote-flow-rp-intermediary`.
+
 A seconda di come l'Utente stia interagendo con il frontend dell'App di Verifica Web, usando cioè il dispositivo in cui risiede l'Unità Wallet (**Same Device**) oppure un altro dispositivo (**Cross Device**), la Relying Party DEVE supportare i seguenti flussi remoti (:ref:`RPR-84 <test-plans-remote-presentation:Matrice di Test per il Verificatore di Credenziali in Remoto>`):
 
 * **Same Device**: essa DEVE fornire un indirizzo ``HTTP`` all'Istanza del Wallet utilizzando un *redirect* (``302``) o un href HTML nella pagina web (:ref:`RPR-01 <test-plans-remote-presentation:Matrice di Test per il Verificatore di Credenziali in Remoto>`);
@@ -560,6 +562,8 @@ I parametri del payload JWT sono descritti qui:
         - **credential_ids**. Array che fa riferimento a una o più Credenziali provenienti dalla ``dcql_query`` che possono autorizzare la transazione.
   * - **transaction_data_hashes_alg**  
     - OPZIONALE. Un array di stringhe, ciascuna delle quali rappresenta un identificatore di algoritmo di hash, corrispondente a un nome di algoritmo di hash elencato nel registro IANA. Uno di questi algoritmi DEVE essere utilizzato per calcolare gli hash nel parametro di risposta ``transaction_data_hashes``. Se omesso, l’algoritmo di hash predefinito è sha-256.
+  * - **verifier_info**
+    - OBBLIGATORIO secondo `ETSI TS 119 472-2`_. Array JSON non vuoto definito nella Sezione 5.11 di `OpenID4VP`_. Ogni elemento è un Oggetto JSON con i membri ``format`` e ``data`` e NON DEVE contenere ``credential_ids``. L'array DEVE includere un elemento con ``format`` impostato su ``registrar_dataset`` che trasporta i dati di registrazione forniti dal Registrar della Relying Party per l'uso previsto corrente (vedere :ref:`remote-flow-verifier-info`). Se è disponibile un Certificato di Registrazione, l'array DEVE includere anche un elemento con ``format`` impostato su ``registration_cert`` che trasporta il certificato serializzato per valore. In una transazione intermediata, gli elementi ``registrar_dataset`` e ``registration_cert`` si riferiscono alla Relying Party **intermediata**, mentre il certificato di accesso nell'header JWT identifica l'**intermediario** (vedere :ref:`remote-flow-rp-intermediary`).
   * - **response_type**
     - OBBLIGATORIO. DEVE essere impostato su ``vp_token`` (:ref:`RPR-107 <test-plans-remote-presentation:Matrice di Test per il Verificatore di Credenziali in Remoto>`).
   * - **wallet_nonce**
@@ -593,6 +597,181 @@ I parametri del payload JWT sono descritti qui:
 
 .. note::
   L'utilizzo del parametro ``client_metadata`` è condizionale. Se ``client_id`` utilizza il prefisso ``x509_hash``, tutti i metadata della Relying Party, oltre alla sua chiave pubblica utilizzata per firmare il Request Object, DEVONO essere forniti in ``client_metadata``. Tuttavia, se il parametro è presente e ``client_id`` utilizza il prefisso ``openid_federation``, l'Istanza del Wallet DEVE ottenere i metadata della Relying Party attraverso la Trust Chain OpenID Federation (:ref:`RPR-113 <test-plans-remote-presentation:Matrice di Test per il Verificatore di Credenziali in Remoto>`) e NON DEVE utilizzare ``client_metadata`` per sovrascrivere o sostituire i metadata risolti. L'unica eccezione è ``client_metadata.jwks`` (e i relativi parametri sulle capacità di cifratura della risposta, come ``encrypted_response_enc_values_supported``), che PUÒ essere utilizzato esclusivamente per trasportare chiavi pubbliche specifiche della richiesta (effimere) per cifrare la Authorization Response in ``direct_post.jwt`` (vedere `OpenID4VP`_ Sezione 8.3).
+
+.. _remote-flow-verifier-info:
+
+``verifier_info`` e dati di registrazione della Relying Party
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`ETSI TS 119 472-2`_ profila il flusso di presentazione remota OpenID4VC-HAIP per l'ecosistema EUDI Wallet. Richiede che il Request Object trasporti le informazioni di registrazione della Relying Party tramite il parametro ``verifier_info`` definito nella Sezione 5.11 di `OpenID4VP`_.
+
+Ogni elemento di ``verifier_info`` è un Oggetto JSON. Per IT-Wallet sono definiti i seguenti valori di ``format``:
+
+.. list-table::
+  :class: longtable
+  :widths: 25 75
+  :header-rows: 1
+
+  * - **format**
+    - **Descrizione**
+  * - **registrar_dataset**
+    - OBBLIGATORIO. Trasporta i dati di registrazione forniti dal Registrar per la Relying Party e per l'uso previsto rilevanti per la richiesta di presentazione. Il membro ``data`` DEVE essere un Oggetto JSON non vuoto come specificato in :ref:`table-registrar-dataset-fields`.
+  * - **registration_cert**
+    - OBBLIGATORIO quando è disponibile un Certificato di Registrazione per l'uso previsto. Il membro ``data`` DEVE essere la codifica base64url del Certificato di Registrazione serializzato (per valore, non per riferimento).
+
+.. _table-registrar-dataset-fields:
+
+L'oggetto ``data`` di un elemento ``registrar_dataset`` DEVE contenere i seguenti membri:
+
+.. list-table::
+  :class: longtable
+  :widths: 25 75
+  :header-rows: 1
+
+  * - **Membro**
+    - **Descrizione**
+  * - **identifier**
+    - OBBLIGATORIO. Identificatore univoco a livello UE della Relying Party per l'uso previsto corrente, come registrato presso il Registrar dello Stato Membro.
+  * - **srvDescription**
+    - OBBLIGATORIO. Array non vuoto di stringhe localizzate (``lang``, ``content``) che descrivono il Servizio della Relying Party registrato per l'uso previsto.
+  * - **registryURI**
+    - OBBLIGATORIO. URI dell'API del Registrar presso cui l'Istanza del Wallet PUÒ verificare le informazioni registrate sulla Relying Party, se richiesto dall'Utente.
+  * - **intendedUseIdentifier**
+    - OBBLIGATORIO. Identificatore fornito dal Registrar dell'uso previsto della Relying Party.
+  * - **purpose**
+    - OBBLIGATORIO. Array non vuoto di stringhe localizzate che descrivono le finalità registrate del trattamento dati previsto.
+  * - **policyURI**
+    - OBBLIGATORIO. URI dell'informativa privacy applicabile all'uso previsto registrato.
+  * - **credential**
+    - OPZIONALE. Array di oggetti Credential che elencano i tipi di attestato e gli attributi registrati per l'uso previsto.
+
+Quando la presentazione non è intermediata, l'identità veicolata in ``verifier_info`` coincide con la Relying Party autenticata tramite il certificato di accesso nell'header JWT ``x5c``.
+
+.. _remote-flow-rp-intermediary:
+
+Presentazione tramite Intermediario di Relying Party
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Un :term:`Intermediario di Relying Party` agisce per conto di una o più Relying Party intermediata. OpenID4VP non definisce un flag dedicato ``is_intermediary``. L'Istanza del Wallet deduce invece una transazione intermediata dalla **combinazione** di:
+
+1. **Autenticazione dell'intermediario** — il Request Object è firmato dall'intermediario e l'header JWT ``x5c`` contiene il certificato di accesso dell'intermediario (autenticato tramite ``client_id`` con prefisso ``x509_hash`` o una Trust Chain OpenID Federation).
+2. **Dati di registrazione della Relying Party intermediata** — l'elemento ``registrar_dataset`` di ``verifier_info`` trasporta il nome, l'identificatore, l'URL del Registrar, l'uso previsto e gli altri dati di registrazione della Relying Party **intermediata**.
+3. **Certificato di Registrazione opzionale** — quando disponibile, un elemento ``registration_cert`` di ``verifier_info`` trasporta il Certificato di Registrazione della Relying Party intermediata. Tale certificato PUÒ contenere l'associazione con l'intermediario.
+
+L'Istanza del Wallet DEVE considerare la richiesta come intermediata quando l'identità della Relying Party nel certificato di accesso differisce dall'identità della Relying Party in ``verifier_info`` (ARF Topic 52, requisito RPI_07). In tal caso, l'Istanza del Wallet DEVE:
+
+- autenticare l'**intermediario** utilizzando il suo certificato di accesso;
+- mostrare all'Utente le denominazioni commerciali di **entrambi** l'intermediario (dal certificato di accesso) e la Relying Party intermediata (da ``verifier_info`` e, se presente, dal Certificato di Registrazione) quando richiede l'approvazione;
+- verificare, se l'Utente lo richiede, che il rapporto contrattuale tra la Relying Party intermediata e l'intermediario sia registrato presso il Registrar competente — tramite ispezione del Certificato di Registrazione o interrogazione dell'API del Registrar indicata in ``registryURI``;
+- inviare la Authorization Response al ``response_uri`` dell'intermediario;
+- registrare sia l'intermediario sia la Relying Party intermediata nel registro delle transazioni.
+
+La Relying Party intermediata non necessita di un certificato di accesso per la transazione; l'intermediario detiene e presenta il Certificato di Registrazione per suo conto, ove emesso.
+
+Esempi non normativi
+^^^^^^^^^^^^^^^^^^^^
+
+Gli esempi seguenti illustrano la struttura di ``verifier_info``. Utilizzano endpoint e identificatori fittizi.
+
+Presentazione diretta (senza intermediario)
+"""""""""""""""""""""""""""""""""""""""""""
+
+In una transazione diretta, il certificato di accesso e ``verifier_info`` si riferiscono alla stessa Relying Party:
+
+.. code-block:: json
+
+  {
+    "client_id": "x509_hash:sha-256:abc123...",
+    "response_mode": "direct_post.jwt",
+    "response_type": "vp_token",
+    "response_uri": "https://comune.esempio.it/oid4vp/response",
+    "verifier_info": [
+      {
+        "format": "registrar_dataset",
+        "data": {
+          "identifier": "urn:eu:wrp:it:12345678901:0001",
+          "srvDescription": [
+            { "lang": "it", "content": "Servizio SPID del Comune di Esempio" }
+          ],
+          "registryURI": "https://registro.eid.gov.it/api/v1",
+          "intendedUseIdentifier": "urn:eu:wrp-intended-use:it:comune-spid-login",
+          "purpose": [
+            { "lang": "it", "content": "Autenticazione dell'utente per l'accesso ai servizi online del Comune" }
+          ],
+          "policyURI": "https://comune.esempio.it/privacy/spid"
+        }
+      },
+      {
+        "format": "registration_cert",
+        "data": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9..."
+      }
+    ],
+    "dcql_query": { "...": "..." }
+  }
+
+L'header JWT ``x5c`` contiene il certificato di accesso del ``Comune di Esempio``, il cui identificatore coincide con ``verifier_info[0].data.identifier``.
+
+Presentazione tramite Intermediario di Relying Party
+""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+In una transazione intermediata, l'intermediario si autentica con il proprio certificato di accesso mentre ``verifier_info`` descrive la Relying Party intermediata:
+
+.. code-block:: json
+
+  {
+    "client_id": "x509_hash:sha-256:def456...",
+    "response_mode": "direct_post.jwt",
+    "response_type": "vp_token",
+    "response_uri": "https://intermediary.provider.it/oid4vp/response",
+    "verifier_info": [
+      {
+        "format": "registrar_dataset",
+        "data": {
+          "identifier": "urn:eu:wrp:it:98765432109:0001",
+          "srvDescription": [
+            { "lang": "it", "content": "Verifica età — Cinema Multiplex" }
+          ],
+          "registryURI": "https://registro.eid.gov.it/api/v1",
+          "intendedUseIdentifier": "urn:eu:wrp-intended-use:it:cinema-age-check",
+          "purpose": [
+            { "lang": "it", "content": "Verifica del limite di età per l'accesso a contenuti riservati" }
+          ],
+          "policyURI": "https://cinema.esempio.it/privacy/age-verification"
+        }
+      },
+      {
+        "format": "registration_cert",
+        "data": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9..."
+      }
+    ],
+    "dcql_query": { "...": "..." }
+  }
+
+L'header JWT ``x5c`` contiene il certificato di accesso dell'intermediario ``Provider Intermediario S.r.l.`` (identificatore ``urn:eu:wrp:it:11111111111:0001``), che differisce dall'identificatore della Relying Party intermediata ``urn:eu:wrp:it:98765432109:0001`` in ``verifier_info``. L'Istanza del Wallet mostra quindi entrambe le identità all'Utente e verifica il rapporto intermediario–Relying Party prima di richiedere il consenso.
+
+Estratto non normativo del Request Object (intermediario)
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+.. code-block:: text
+
+  # Header JWT (abbreviato)
+  {
+    "alg": "ES256",
+    "typ": "oauth-authz-req+jwt",
+    "kid": "intermediary-key-2026",
+    "x5c": ["MIIC...certificato-accesso-intermediario..."]
+  }
+
+  # Payload JWT (abbreviato)
+  {
+    "iss": "x509_hash:sha-256:def456...",
+    "client_id": "x509_hash:sha-256:def456...",
+    "response_uri": "https://intermediary.provider.it/oid4vp/response",
+    "verifier_info": [ "... vedi esempio JSON sopra ..." ],
+    "dcql_query": { "...": "..." },
+    "nonce": "n-0Z3k9Qm7xP2vL8wR4tY6uI1oA5sD",
+    "exp": 1744203600
+  }
 
 Authorization Response
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This pull request updates the documentation to clarify and expand the requirements for Relying Party registration data in the IT-Wallet remote presentation flow, aligning with ETSI TS 119 472-2 and OpenID4VP Section 5.11. It introduces detailed explanations and examples for the new `verifier_info` parameter, including its structure, mandatory fields, and behavior in both direct and intermediated transactions. These changes are made in both the English and Italian documentation, and a new normative reference is added.

**Documentation updates for remote flow and Relying Party registration:**

* Added a new normative reference for `ETSI TS 119 472-2` in `common_definitions.rst`.

* Updated English (`remote-flow.rst`) and Italian (`remote-flow.rst`) documentation to:
  - Introduce and explain the `verifier_info` parameter, required by `ETSI TS 119 472-2`, including its structure, required formats (`registrar_dataset`, `registration_cert`), and the fields required in the registration dataset. [[1]](diffhunk://#diff-49b422a54bf6c8ac0ba7c115989fc1e59cca9b661758d9df668df4ee8bd0d406R7-R8) [[2]](diffhunk://#diff-ff62bfdb95a3f88e9f3a9f733f49030c697c5b30215cdd993b9620cb4562da46R7-R8) [[3]](diffhunk://#diff-49b422a54bf6c8ac0ba7c115989fc1e59cca9b661758d9df668df4ee8bd0d406R566-R567) [[4]](diffhunk://#diff-ff62bfdb95a3f88e9f3a9f733f49030c697c5b30215cdd993b9620cb4562da46R565-R566)
  - Provide detailed guidance and non-normative examples for both direct and intermediated remote presentation flows, including how the Wallet Instance should handle and display Relying Party and intermediary identities, and how to verify the intermediary–Relying Party relationship.

These changes ensure that implementers have clear, standards-aligned guidance on handling Relying Party registration data and intermediated transactions in the IT-Wallet remote credential presentation flow.