### PR TITLE
Changed dpop specs for ASs

### DIFF
--- a/docs/en/e-service-pdnd.rst
+++ b/docs/en/e-service-pdnd.rst
@@ -68,7 +68,7 @@ This specification is based on the following set of requirements:
 .. note::
     In the current specifications, the ``REST_JWS_2021_POP`` security pattern is implemented in accordance with :rfc:`9449`.
 
-    Alternatively, the proof of possession MAY be attested by the ``TrackingEvidence`` JWT (as detailed below). However, while the ``TrackingEvidence`` is defined in ``AUDIT_REST_02`` to provide additional tracked data, in this context, it acts as proof of possession of the Voucher. Such implementation choices will be referred to as ``POP_DPoP`` and ``POP_TPoP``, respectively.
+    Alternatively, the proof of possession MAY be attested using the ``TrackingEvidence`` JWT to provide additional data. In this context, ``TrackingEvidence`` JWT acts as a proof of possession of the PDND Voucher. Such implementation choices will be referred to as ``POP_DPoP`` and ``POP_TPoP``, respectively.
 
 The following security patterns defined in `PDND`_ and `MODI`_ MUST NOT be used as they do not comply with the requirements defined above:
 

--- a/docs/en/e-service-pdnd.rst
+++ b/docs/en/e-service-pdnd.rst
@@ -66,7 +66,9 @@ This specification is based on the following set of requirements:
     - R1, R2, R4, R5
 
 .. note::
-    In these specifications, the ``REST_JWS_2021_POP`` security pattern is implemented by default in accordance with :rfc:`9449`. If DPoP is not supported by the PDND Infrastructure, the proof of possession is attested by the ``TrackingEvidence`` JWT (as detailed below). However, while the ``TrackingEvidence`` is defined in ``AUDIT_REST_02`` to provide additional tracked data, in this context, it acts as proof of possession of the Voucher. Such implementation choices will be referred to as ``POP_DPoP`` and ``POP_TPoP``, respectively.
+    In these specifications, the ``REST_JWS_2021_POP`` security pattern is implemented by default in accordance with :rfc:`9449`.
+
+    Alternatively, the proof of possession COULD be attested by the ``TrackingEvidence`` JWT (as detailed below). However, while the ``TrackingEvidence`` is defined in ``AUDIT_REST_02`` to provide additional tracked data, in this context, it acts as proof of possession of the Voucher. Such implementation choices will be referred to as ``POP_DPoP`` and ``POP_TPoP``, respectively.
 
 The following security patterns defined in `PDND`_ and `MODI`_ MUST NOT be used as they do not comply with the requirements defined above:
 

--- a/docs/en/e-service-pdnd.rst
+++ b/docs/en/e-service-pdnd.rst
@@ -66,7 +66,7 @@ This specification is based on the following set of requirements:
     - R1, R2, R4, R5
 
 .. note::
-    In these specifications, the ``REST_JWS_2021_POP`` security pattern is implemented by default in accordance with :rfc:`9449`.
+    In the current specifications, the ``REST_JWS_2021_POP`` security pattern is implemented in accordance with :rfc:`9449`.
 
     Alternatively, the proof of possession MAY be attested by the ``TrackingEvidence`` JWT (as detailed below). However, while the ``TrackingEvidence`` is defined in ``AUDIT_REST_02`` to provide additional tracked data, in this context, it acts as proof of possession of the Voucher. Such implementation choices will be referred to as ``POP_DPoP`` and ``POP_TPoP``, respectively.
 

--- a/docs/en/e-service-pdnd.rst
+++ b/docs/en/e-service-pdnd.rst
@@ -68,7 +68,7 @@ This specification is based on the following set of requirements:
 .. note::
     In these specifications, the ``REST_JWS_2021_POP`` security pattern is implemented by default in accordance with :rfc:`9449`.
 
-    Alternatively, the proof of possession COULD be attested by the ``TrackingEvidence`` JWT (as detailed below). However, while the ``TrackingEvidence`` is defined in ``AUDIT_REST_02`` to provide additional tracked data, in this context, it acts as proof of possession of the Voucher. Such implementation choices will be referred to as ``POP_DPoP`` and ``POP_TPoP``, respectively.
+    Alternatively, the proof of possession MAY be attested by the ``TrackingEvidence`` JWT (as detailed below). However, while the ``TrackingEvidence`` is defined in ``AUDIT_REST_02`` to provide additional tracked data, in this context, it acts as proof of possession of the Voucher. Such implementation choices will be referred to as ``POP_DPoP`` and ``POP_TPoP``, respectively.
 
 The following security patterns defined in `PDND`_ and `MODI`_ MUST NOT be used as they do not comply with the requirements defined above:
 

--- a/docs/it/e-service-pdnd.rst
+++ b/docs/it/e-service-pdnd.rst
@@ -66,7 +66,7 @@ Questa specifica si basa sul seguente insieme di requisiti:
     - R1, R2, R4, R5
 
 .. note::
-    In queste specifiche, il pattern di sicurezza ``REST_JWS_2021_POP`` è implementato di default in conformità con :rfc:`9449`.
+    In queste specifiche, il pattern di sicurezza ``REST_JWS_2021_POP`` è implementato in conformità a :rfc:`9449`.
 
     In alternativa, la prova di possesso PUÒ essere attestata dal JWT ``TrackingEvidence`` (come dettagliato di seguito). Tuttavia, mentre il ``TrackingEvidence`` è definito in ``AUDIT_REST_02`` per fornire dati tracciati aggiuntivi, in questo contesto funge da prova di possesso del Voucher. Tali scelte di implementazione saranno indicate rispettivamente come ``POP_DPoP`` e ``POP_TPoP``.
 

--- a/docs/it/e-service-pdnd.rst
+++ b/docs/it/e-service-pdnd.rst
@@ -66,7 +66,9 @@ Questa specifica si basa sul seguente insieme di requisiti:
     - R1, R2, R4, R5
 
 .. note::
-    In queste specifiche, il pattern di sicurezza ``REST_JWS_2021_POP`` è implementato di default in conformità con :rfc:`9449`. Se DPoP non è supportato dall'Infrastruttura PDND, la prova di possesso è attestata dal JWT ``TrackingEvidence`` (come dettagliato di seguito). Tuttavia, mentre il ``TrackingEvidence`` è definito in ``AUDIT_REST_02`` per fornire dati tracciati aggiuntivi, in questo contesto funge da prova di possesso del Voucher. Tali scelte di implementazione saranno indicate rispettivamente come ``POP_DPoP`` e ``POP_TPoP``.
+    In queste specifiche, il pattern di sicurezza ``REST_JWS_2021_POP`` è implementato di default in conformità con :rfc:`9449`.
+
+    In alternativa, la prova di possesso PUÒ essere attestata dal JWT ``TrackingEvidence`` (come dettagliato di seguito). Tuttavia, mentre il ``TrackingEvidence`` è definito in ``AUDIT_REST_02`` per fornire dati tracciati aggiuntivi, in questo contesto funge da prova di possesso del Voucher. Tali scelte di implementazione saranno indicate rispettivamente come ``POP_DPoP`` e ``POP_TPoP``.
 
 I seguenti pattern di sicurezza definiti in `PDND`_ e `MODI`_ NON DEVONO essere utilizzati in quanto non conformi ai requisiti definiti in precedenza:
 


### PR DESCRIPTION
## Updated DPoP specs for Authentic Sources

## Content
DPoP is now fully supported by PDND; nevertheless, both patterns (DPoP and AUDIT_REST_02) are maintained for backward compatibility.

## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [ ] Example files 
- [x] Ask for review
