### PR TITLE
"name" renamed into "label"

### DIFF
--- a/docs/en/credential-data-model.rst
+++ b/docs/en/credential-data-model.rst
@@ -259,6 +259,10 @@ Digital Credential Type Metadata Document
 
 When provided, the Type Metadata Document MUST be a *JSON object* compliant with Section 6.2 of [`SD-JWT-VC`_].
 
+In addition to the properties defined in section 9.2 of [`SD-JWT-VC`_] the following property SHOULD included:
+
+  - ``name``: A human-readable label for the claim, intended for end users.
+
 The Credential Type Metadata JSON Document MAY be retrieved through a *well-known* endpoint. See Section 6.3.3 of `SD-JWT-VC`_.
 This endpoint, provided by the Credential Issuer, MUST have the following format: ``https://{Credential Issuer Domain}/.well-known/type-metadata``. The ``vct`` query parameter MUST be added to that endpoint.
 The Endpoint returns a ``200 OK`` status code and supports ``application/json`` as content type.

--- a/docs/en/credential-issuer-metadata.rst
+++ b/docs/en/credential-issuer-metadata.rst
@@ -128,11 +128,12 @@ The *openid_credential_issuer* metadata contains the following claims.
             - **path**: It contains the pointer that specifies the path to a specific claim within the Digital Credential as defined in Appendix C of `OpenID4VCI`_.
             - **mandatory**: Boolean which, when set to `true`, indicates that the Credential Issuer will always include this claim in the issued Credential.
             - **sd**: String indicating whether the claim is selectively disclosable. It MUST be set to `always` if the claim is selectively disclosure or `never` if not.
-            - **display**: Array of objects containing display language properties. Array containing display information about the claim indicated in the ``path``. The array contains an object for each language supported. The parameters that MUST be included are
+            - **display**: Array of objects containing display language properties. Array containing display information about the claim indicated in the ``path``. The array contains an object for each language supported. It contains the following parameters:
 
-                - **label**: String value of a display name for the claim.
-                - **description**: human-readable description for the claim.
-                - **locale**: String value that identifies the language of this object represented as a language tag taken from values defined in *BCP47* :rfc:`5646`. There MUST be only one object for each language identifier.
+                - **name**: REQUIRED. String value of a display name for the claim.
+                - **label**: OPTIONAL. String value of a display name for the claim.
+                - **description**: REQUIRED. human-readable description for the claim.
+                - **locale**: REQUIRED. String value that identifies the language of this object represented as a language tag taken from values defined in *BCP47* :rfc:`5646`. There MUST be only one object for each language identifier.
                 
         - **schema_id**: REQUIRED. Identifier of the credential schema as defined in the :ref:`registry:Schema Registry`.
         - **authentic_sources**: REQUIRED. Object containing ``entity_id`` and ``dataset_id`` parameters valued with the respective identifiers as registered in the :ref:`registry:Authentic Source Registry`.

--- a/docs/en/credential-issuer-metadata.rst
+++ b/docs/en/credential-issuer-metadata.rst
@@ -130,7 +130,7 @@ The *openid_credential_issuer* metadata contains the following claims.
             - **sd**: String indicating whether the claim is selectively disclosable. It MUST be set to `always` if the claim is selectively disclosure or `never` if not.
             - **display**: Array of objects containing display language properties. Array containing display information about the claim indicated in the ``path``. The array contains an object for each language supported. The parameters that MUST be included are
 
-                - **name**: String value of a display name for the claim.
+                - **label**: String value of a display name for the claim.
                 - **description**: human-readable description for the claim.
                 - **locale**: String value that identifies the language of this object represented as a language tag taken from values defined in *BCP47* :rfc:`5646`. There MUST be only one object for each language identifier.
                 

--- a/docs/it/credential-data-model.rst
+++ b/docs/it/credential-data-model.rst
@@ -261,6 +261,10 @@ Type Metadata dell'Attestato Elettronico
 
 Il documento di *Type Metadata*, se fornito, DEVE essere un *JSON object* e DEVE essere conforme con la Sezione 6.2 di [`SD-JWT-VC`_].
 
+In aggiunta ai parametri definiti nella sezione 9.2 di [`SD-JWT-VC`_], il seguente parametro PUO' essere incluso:
+
+  - ``name``: Nome "human-readable" dell'Attributo destinato agli utenti finali.
+
 In conformità con la Sezione 6.3.3 di `SD-JWT-VC`_, il documento JSON del *Type Metadata* PUÒ essere recuperato tramite un *well-known* endpoint.
 Questo endpoint, fornito dal Fornitore di Attestati Elettronici, DEVE avere il seguente formato: ``https://{Dominio Credential Issuer}/.well-known/type-metadata``. A tale endpoint DEVE essere aggiunto il parametro di query ``vct``.
 L'endpoint restituisce un codice di stato ``200 OK`` e supporta ``application/json`` come content type.

--- a/docs/it/credential-issuer-metadata.rst
+++ b/docs/it/credential-issuer-metadata.rst
@@ -126,11 +126,12 @@ I Metadata *openid_credential_issuer* contiene i seguenti *claims*.
             - **path**: Contiene il puntatore che specifica il percorso all'attributo specifico all'interno dell'Attestato Elettronico come definito nell'Appendice C di `OpenID4VCI`_.
             - **mandatory**: Valore booleano che, se impostato su `true`, indica che il Credential Issuer includerà sempre questo attributo nelle Credenziali che emette.
             - **sd**: Stringa che indica se il claim è divulgabile selettivamente. DEVE essere impostato su `always` se il claim è divulgabile selettivamente o `never` se non lo è.
-            - **display**: Array di oggetti contenenti le proprietà di visualizzazione. Array contenente informazioni di visualizzazione relative al claim indicato nel ``path``. L'array contiene un oggetto per ogni lingua supportata. I parametri che DEVONO essere inclusi sono:
+            - **display**: Array di oggetti contenenti le proprietà di visualizzazione. Array contenente informazioni di visualizzazione relative al claim indicato nel ``path``. L'array contiene un oggetto per ogni lingua supportata. Contiene i seguenti parametri:
 
-                - **name**: Nome dell'attributo in formato stringa.
-                - **description**: Descrizione "human-readable" dell'Attributo.
-                - **locale**: Stringa che identifica la localizzazione con un tag linguistico come definito in *BCP47* :rfc:`5646`. DEVE esserci un solo oggetto per ogni identificativo di localizzazione.
+                - **name**: OBBLIGATORIO. Nome dell'attributo in formato stringa.
+                - **label**: OPZIONALE. Nome dell'attributo in formato stringa.
+                - **description**: OBBLIGATORIO. Descrizione "human-readable" dell'Attributo.
+                - **locale**: OBBLIGATORIO. Stringa che identifica la localizzazione con un tag linguistico come definito in *BCP47* :rfc:`5646`. DEVE esserci un solo oggetto per ogni identificativo di localizzazione.
 
         - **schema_id**: OBBLIGATORIO. Identificativo dello schema delle credenziali come definito nel :ref:`registry:Registro degli Schema`.
         - **authentic_sources**: OBBLIGATORIO. Oggetto contenente il parametro ``entity_id`` e ``dataset_id``, valorizzato con i rispettivi dentificativi come censiti all'interno del :ref:`registry:Registro delle Fonti Autentiche`.

--- a/examples/ec-eaa.json
+++ b/examples/ec-eaa.json
@@ -192,12 +192,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Numero Documento",
+                                        "name": "Numero Documento",
                                         "locale": "it-IT",
                                         "description": "Numero Documento della carta europea della disabilità"
                                     },
                                     {
-                                        "label": "Document Number",
+                                        "name": "Document Number",
                                         "locale": "en-US",
                                         "description": "Document number of the European Disability Card"
                                     }
@@ -209,12 +209,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Nome",
+                                        "name": "Nome",
                                         "locale": "it-IT",
                                         "description": "Nome del titolare della carta"
                                     },
                                     {
-                                        "label": "Name",
+                                        "name": "Name",
                                         "locale": "en-US",
                                         "description": "Cardholder name"
                                     }
@@ -226,12 +226,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Cognome",
+                                        "name": "Cognome",
                                         "locale": "it-IT",
                                         "description": "Cognome del titolare della carta"
                                     },
                                     {
-                                        "label": "Family Name",
+                                        "name": "Family Name",
                                         "locale": "en-US",
                                         "description": "cardholder last name"
                                     }
@@ -243,13 +243,13 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Data di Nascita (YYYY-MM-GG)",
+                                        "name": "Data di Nascita (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di nascita del titolare della carta"
 
                                     },
                                     {
-                                        "label": "Date of Birth (YYYY-MM-GG)",
+                                        "name": "Date of Birth (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "cardholder birth date"
                                     }
@@ -261,12 +261,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Codice Fiscale",
+                                        "name": "Codice Fiscale",
                                         "locale": "it-IT",
                                         "description": "Codice fiscale del titolare della carta"
                                     },
                                     {
-                                        "label": "Tax Identification Number",
+                                        "name": "Tax Identification Number",
                                         "locale": "en-US",
                                         "description": "cardholder tax identification number"
                                     }
@@ -278,12 +278,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Data di Scadenza (YYYY-MM-GG)",
+                                        "name": "Data di Scadenza (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di scadenza della carta"
                                     },
                                     {
-                                        "label": "Expiration Date (YYYY-MM-GG)",
+                                        "name": "Expiration Date (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Card expiration date"
                                     }
@@ -295,12 +295,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Diritto accompagnatore",
+                                        "name": "Diritto accompagnatore",
                                         "locale": "it-IT",
                                         "description": "Questo campo indica se il titolare della carta ha diritto all'indennità di accompagnamento"
                                     },
                                     {
-                                        "label": "Constant attendance allowance",
+                                        "name": "Constant attendance allowance",
                                         "locale": "en-US",
                                         "description": "This field indicates whether the cardholder is entitled to the accompanying allowance"
                                     }
@@ -312,13 +312,13 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Foto",
+                                        "name": "Foto",
                                         "locale": "it-IT",
                                         "description": "Fotografia del titolare della carta"
 
                                     },
                                     {
-                                        "label": "Portrait",
+                                        "name": "Portrait",
                                         "locale": "en-US",
                                         "description": "Photo of the cardholder"
                                     }
@@ -330,12 +330,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Link QR Code",
+                                        "name": "Link QR Code",
                                         "locale": "it-IT",
                                         "description": "Questo campo contiene il QR-Code"
                                     },
                                     {
-                                        "label": "Link QR Code",
+                                        "name": "Link QR Code",
                                         "locale": "en-US",
                                         "description": "This field contains the QR-Code"
                                     }
@@ -405,12 +405,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Nome",
+                                        "name": "Nome",
                                         "locale": "it-IT",
                                         "description": "Nome del titolare della patente"
                                     },
                                     {
-                                        "label": "First Name",
+                                        "name": "First Name",
                                         "locale": "en-US",
                                         "description": "Name of the driving license holder"
                                     }
@@ -422,12 +422,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Cognome",
+                                        "name": "Cognome",
                                         "locale": "it-IT",
                                         "description": "Cognome del titolare della patente"
                                     },
                                     {
-                                        "label": "Family Name",
+                                        "name": "Family Name",
                                         "locale": "en-US",
                                         "description": "last name of the driving license holder"
                                     }
@@ -439,12 +439,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Data di nascita (YYYY-MM-GG)",
+                                        "name": "Data di nascita (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di nascita del titolare della patente"
                                     },
                                     {
-                                        "label": "Date of Birth (YYYY-MM-GG)",
+                                        "name": "Date of Birth (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Date of birth of the driving license holder"
                                     }
@@ -456,12 +456,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Luogo di Nascita",
+                                        "name": "Luogo di Nascita",
                                         "locale": "it-IT",
                                         "description": "Luogo di nascita del titolare della patente"
                                     },
                                     {
-                                        "label": "Place of Birth",
+                                        "name": "Place of Birth",
                                         "locale": "en-US",
                                         "description": "Place of birth of the driving license holder"
                                     }
@@ -473,12 +473,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Data di rilascio (YYYY-MM-GG)",
+                                        "name": "Data di rilascio (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di rilascio della patente"
                                     },
                                     {
-                                        "label": "Issue Date (YYYY-MM-GG)",
+                                        "name": "Issue Date (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Date of issuance of the driving license"
                                     }
@@ -490,12 +490,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Data di scadenza (YYYY-MM-GG)",
+                                        "name": "Data di scadenza (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di scadenza della patente"
                                     },
                                     {
-                                        "label": "Expiry Date (YYYY-MM-GG)",
+                                        "name": "Expiry Date (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Date of expiry of the driving license"
                                     }
@@ -507,13 +507,13 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Paese di rilascio",
+                                        "name": "Paese di rilascio",
                                         "locale": "it-IT",
                                         "description": "Paese di rilascio della patente"
 
                                     },
                                     {
-                                        "label": "Issuing Country",
+                                        "name": "Issuing Country",
                                         "locale": "en-US",
                                         "description": "Issuing country of the driving license"
                                     }
@@ -525,12 +525,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Autorità di rilascio",
+                                        "name": "Autorità di rilascio",
                                         "locale": "it-IT",
                                         "description": "Autorità che ha rilasciato la patente"
                                     },
                                     {
-                                        "label": "Issuing Authority",
+                                        "name": "Issuing Authority",
                                         "locale": "en-US",
                                         "description": "Issuing authority of the driving license"
                                     }
@@ -542,12 +542,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Numero di documento",
+                                        "name": "Numero di documento",
                                         "locale": "it-IT",
                                         "description": "Numero Documento della patente"
                                     },
                                     {
-                                        "label": "Document Number",
+                                        "name": "Document Number",
                                         "locale": "en-US",
                                         "description": "Document number of the driving license"
                                     }
@@ -559,12 +559,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Foto codificata",
+                                        "name": "Foto codificata",
                                         "locale": "it-IT",
                                         "description": "Fotografia del titolare della patente"
                                     },
                                     {
-                                        "label": "Portrait base64 encoded",
+                                        "name": "Portrait base64 encoded",
                                         "locale": "en-US",
                                         "description": "Photo of of the driving licence holder"
                                     }
@@ -576,12 +576,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Abilitazioni alla guida",
+                                        "name": "Abilitazioni alla guida",
                                         "locale": "it-IT",
                                         "description": "Elenco delle categorie di abilitazione"
                                     },
                                     {
-                                        "label": "Driving Privileges",
+                                        "name": "Driving Privileges",
                                         "locale": "en-US",
                                         "description": "Driving Privileges list"
                                     }
@@ -593,12 +593,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Annotazioni/Restrizioni",
+                                        "name": "Annotazioni/Restrizioni",
                                         "locale": "it-IT",
                                         "description": "Annotazioni/Restrizioni valide per tutte le categorie separate da spazio"
                                     },
                                     {
-                                        "label": "Restrictions/Conditions",
+                                        "name": "Restrictions/Conditions",
                                         "locale": "en-US",
                                         "description": "Restriction/Condition for all driving privileges separated by space"
                                     }
@@ -610,12 +610,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Dettagli delle categorie di abilitazione",
+                                        "name": "Dettagli delle categorie di abilitazione",
                                         "locale": "it-IT",
                                         "description": "Dettagli relativi alle specifiche categorie di abilitazione"
                                     },
                                     {
-                                        "label": "Driving privilege details",
+                                        "name": "Driving privilege details",
                                         "locale": "en-US",
                                         "description": "Details related to the specific driving privileges"
                                     }
@@ -676,12 +676,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Nome",
+                                        "name": "Nome",
                                         "locale": "it-IT",
                                         "description": "Nome del titolare della patente"
                                     },
                                     {
-                                        "label": "First Name",
+                                        "name": "First Name",
                                         "locale": "en-US",
                                         "description": "Name of the driving license holder"
                                     }
@@ -693,12 +693,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Cognome",
+                                        "name": "Cognome",
                                         "locale": "it-IT",
                                         "description": "Cognome del titolare della patente"
                                     },
                                     {
-                                        "label": "Family Name",
+                                        "name": "Family Name",
                                         "locale": "en-US",
                                         "description": "last name of the driving license holder"
                                     }
@@ -710,12 +710,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Data di nascita (YYYY-MM-GG)",
+                                        "name": "Data di nascita (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di nascita del titolare della patente"
                                     },
                                     {
-                                        "label": "Date of Birth (YYYY-MM-GG)",
+                                        "name": "Date of Birth (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Date of birth of the driving license holder"
                                     }
@@ -727,12 +727,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Luogo di Nascita",
+                                        "name": "Luogo di Nascita",
                                         "locale": "it-IT",
                                         "description": "Luogo di nascita del titolare della patente"
                                     },
                                     {
-                                        "label": "Place of Birth",
+                                        "name": "Place of Birth",
                                         "locale": "en-US",
                                         "description": "Place of birth of the driving license holder"
                                     }
@@ -744,12 +744,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Data di rilascio (YYYY-MM-GG)",
+                                        "name": "Data di rilascio (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di emissione della patente"
                                     },
                                     {
-                                        "label": "Issue Date (YYYY-MM-GG)",
+                                        "name": "Issue Date (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Date of issuance of the driving license"
                                     }
@@ -761,12 +761,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Data di scadenza (YYYY-MM-GG)",
+                                        "name": "Data di scadenza (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di scadenza della patente"
                                     },
                                     {
-                                        "label": "Expiry Date (YYYY-MM-GG)",
+                                        "name": "Expiry Date (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Date of expiry of the driving license"
                                     }
@@ -778,12 +778,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Paese di rilascio",
+                                        "name": "Paese di rilascio",
                                         "locale": "it-IT",
                                         "description": "Paese di rilascio della patente"
                                     },
                                     {
-                                        "label": "Issuing Country",
+                                        "name": "Issuing Country",
                                         "locale": "en-US",
                                         "description": "Issuing country of the driving license"
                                     }
@@ -795,12 +795,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Autorità di rilascio",
+                                        "name": "Autorità di rilascio",
                                         "locale": "it-IT",
                                         "description": "Autorità che ha rilasciato la patente"
                                     },
                                     {
-                                        "label": "Issuing Authority",
+                                        "name": "Issuing Authority",
                                         "locale": "en-US",
                                         "description": "Issuing authority of the driving license"
                                     }
@@ -812,12 +812,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Numero di documento",
+                                        "name": "Numero di documento",
                                         "locale": "it-IT",
                                         "description": "Numero Documento della patente"
                                     },
                                     {
-                                        "label": "Document Number",
+                                        "name": "Document Number",
                                         "locale": "en-US",
                                         "description": "Document number of the driving license"
                                     }
@@ -829,12 +829,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Foto codificata",
+                                        "name": "Foto codificata",
                                         "locale": "it-IT",
                                         "description": "Fotografia del titolare della patente"
                                     },
                                     {
-                                        "label": "Portrait",
+                                        "name": "Portrait",
                                         "locale": "en-US",
                                         "description": "Photo of of the driving licence holder"
                                     }
@@ -846,12 +846,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Abilitazioni alla guida",
+                                        "name": "Abilitazioni alla guida",
                                         "locale": "it-IT",
                                         "description": "Elenco delle categorie di abilitazione"
                                     },
                                     {
-                                        "label": "Driving Privileges",
+                                        "name": "Driving Privileges",
                                         "locale": "en-US",
                                         "description": "Driving Privileges list"
                                     }
@@ -863,12 +863,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "label": "Codice identificativo della Nazione",
+                                        "name": "Codice identificativo della Nazione",
                                         "locale": "it-IT",
                                         "description": "Segno distintivo del paese che emette la patente"
                                     },
                                     {
-                                        "label": "Distinguishing sign of the issuing country",
+                                        "name": "Distinguishing sign of the issuing country",
                                         "locale": "en-US",
                                         "description": "Distinguishing sign of the issuing country"
                                     }

--- a/examples/ec-eaa.json
+++ b/examples/ec-eaa.json
@@ -192,12 +192,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Numero Documento",
+                                        "label": "Numero Documento",
                                         "locale": "it-IT",
                                         "description": "Numero Documento della carta europea della disabilità"
                                     },
                                     {
-                                        "name": "Document Number",
+                                        "label": "Document Number",
                                         "locale": "en-US",
                                         "description": "Document number of the European Disability Card"
                                     }
@@ -209,12 +209,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Nome",
+                                        "label": "Nome",
                                         "locale": "it-IT",
                                         "description": "Nome del titolare della carta"
                                     },
                                     {
-                                        "name": "Name",
+                                        "label": "Name",
                                         "locale": "en-US",
                                         "description": "Cardholder name"
                                     }
@@ -226,12 +226,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Cognome",
+                                        "label": "Cognome",
                                         "locale": "it-IT",
                                         "description": "Cognome del titolare della carta"
                                     },
                                     {
-                                        "name": "Family Name",
+                                        "label": "Family Name",
                                         "locale": "en-US",
                                         "description": "cardholder last name"
                                     }
@@ -243,13 +243,13 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Data di Nascita (YYYY-MM-GG)",
+                                        "label": "Data di Nascita (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di nascita del titolare della carta"
 
                                     },
                                     {
-                                        "name": "Date of Birth (YYYY-MM-GG)",
+                                        "label": "Date of Birth (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "cardholder birth date"
                                     }
@@ -261,12 +261,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Codice Fiscale",
+                                        "label": "Codice Fiscale",
                                         "locale": "it-IT",
                                         "description": "Codice fiscale del titolare della carta"
                                     },
                                     {
-                                        "name": "Tax Identification Number",
+                                        "label": "Tax Identification Number",
                                         "locale": "en-US",
                                         "description": "cardholder tax identification number"
                                     }
@@ -278,12 +278,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Data di Scadenza (YYYY-MM-GG)",
+                                        "label": "Data di Scadenza (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di scadenza della carta"
                                     },
                                     {
-                                        "name": "Expiration Date (YYYY-MM-GG)",
+                                        "label": "Expiration Date (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Card expiration date"
                                     }
@@ -295,12 +295,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Diritto accompagnatore",
+                                        "label": "Diritto accompagnatore",
                                         "locale": "it-IT",
                                         "description": "Questo campo indica se il titolare della carta ha diritto all'indennità di accompagnamento"
                                     },
                                     {
-                                        "name": "Constant attendance allowance",
+                                        "label": "Constant attendance allowance",
                                         "locale": "en-US",
                                         "description": "This field indicates whether the cardholder is entitled to the accompanying allowance"
                                     }
@@ -312,13 +312,13 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Foto",
+                                        "label": "Foto",
                                         "locale": "it-IT",
                                         "description": "Fotografia del titolare della carta"
 
                                     },
                                     {
-                                        "name": "Portrait",
+                                        "label": "Portrait",
                                         "locale": "en-US",
                                         "description": "Photo of the cardholder"
                                     }
@@ -330,12 +330,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Link QR Code",
+                                        "label": "Link QR Code",
                                         "locale": "it-IT",
                                         "description": "Questo campo contiene il QR-Code"
                                     },
                                     {
-                                        "name": "Link QR Code",
+                                        "label": "Link QR Code",
                                         "locale": "en-US",
                                         "description": "This field contains the QR-Code"
                                     }
@@ -405,12 +405,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Nome",
+                                        "label": "Nome",
                                         "locale": "it-IT",
                                         "description": "Nome del titolare della patente"
                                     },
                                     {
-                                        "name": "First Name",
+                                        "label": "First Name",
                                         "locale": "en-US",
                                         "description": "Name of the driving license holder"
                                     }
@@ -422,12 +422,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Cognome",
+                                        "label": "Cognome",
                                         "locale": "it-IT",
                                         "description": "Cognome del titolare della patente"
                                     },
                                     {
-                                        "name": "Family Name",
+                                        "label": "Family Name",
                                         "locale": "en-US",
                                         "description": "last name of the driving license holder"
                                     }
@@ -439,12 +439,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Data di nascita (YYYY-MM-GG)",
+                                        "label": "Data di nascita (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di nascita del titolare della patente"
                                     },
                                     {
-                                        "name": "Date of Birth (YYYY-MM-GG)",
+                                        "label": "Date of Birth (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Date of birth of the driving license holder"
                                     }
@@ -456,12 +456,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Luogo di Nascita",
+                                        "label": "Luogo di Nascita",
                                         "locale": "it-IT",
                                         "description": "Luogo di nascita del titolare della patente"
                                     },
                                     {
-                                        "name": "Place of Birth",
+                                        "label": "Place of Birth",
                                         "locale": "en-US",
                                         "description": "Place of birth of the driving license holder"
                                     }
@@ -473,12 +473,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Data di rilascio (YYYY-MM-GG)",
+                                        "label": "Data di rilascio (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di rilascio della patente"
                                     },
                                     {
-                                        "name": "Issue Date (YYYY-MM-GG)",
+                                        "label": "Issue Date (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Date of issuance of the driving license"
                                     }
@@ -490,12 +490,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Data di scadenza (YYYY-MM-GG)",
+                                        "label": "Data di scadenza (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di scadenza della patente"
                                     },
                                     {
-                                        "name": "Expiry Date (YYYY-MM-GG)",
+                                        "label": "Expiry Date (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Date of expiry of the driving license"
                                     }
@@ -507,13 +507,13 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Paese di rilascio",
+                                        "label": "Paese di rilascio",
                                         "locale": "it-IT",
                                         "description": "Paese di rilascio della patente"
 
                                     },
                                     {
-                                        "name": "Issuing Country",
+                                        "label": "Issuing Country",
                                         "locale": "en-US",
                                         "description": "Issuing country of the driving license"
                                     }
@@ -525,12 +525,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Autorità di rilascio",
+                                        "label": "Autorità di rilascio",
                                         "locale": "it-IT",
                                         "description": "Autorità che ha rilasciato la patente"
                                     },
                                     {
-                                        "name": "Issuing Authority",
+                                        "label": "Issuing Authority",
                                         "locale": "en-US",
                                         "description": "Issuing authority of the driving license"
                                     }
@@ -542,12 +542,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Numero di documento",
+                                        "label": "Numero di documento",
                                         "locale": "it-IT",
                                         "description": "Numero Documento della patente"
                                     },
                                     {
-                                        "name": "Document Number",
+                                        "label": "Document Number",
                                         "locale": "en-US",
                                         "description": "Document number of the driving license"
                                     }
@@ -559,12 +559,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Foto codificata",
+                                        "label": "Foto codificata",
                                         "locale": "it-IT",
                                         "description": "Fotografia del titolare della patente"
                                     },
                                     {
-                                        "name": "Portrait base64 encoded",
+                                        "label": "Portrait base64 encoded",
                                         "locale": "en-US",
                                         "description": "Photo of of the driving licence holder"
                                     }
@@ -576,12 +576,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Abilitazioni alla guida",
+                                        "label": "Abilitazioni alla guida",
                                         "locale": "it-IT",
                                         "description": "Elenco delle categorie di abilitazione"
                                     },
                                     {
-                                        "name": "Driving Privileges",
+                                        "label": "Driving Privileges",
                                         "locale": "en-US",
                                         "description": "Driving Privileges list"
                                     }
@@ -593,12 +593,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Annotazioni/Restrizioni",
+                                        "label": "Annotazioni/Restrizioni",
                                         "locale": "it-IT",
                                         "description": "Annotazioni/Restrizioni valide per tutte le categorie separate da spazio"
                                     },
                                     {
-                                        "name": "Restrictions/Conditions",
+                                        "label": "Restrictions/Conditions",
                                         "locale": "en-US",
                                         "description": "Restriction/Condition for all driving privileges separated by space"
                                     }
@@ -610,12 +610,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Dettagli delle categorie di abilitazione",
+                                        "label": "Dettagli delle categorie di abilitazione",
                                         "locale": "it-IT",
                                         "description": "Dettagli relativi alle specifiche categorie di abilitazione"
                                     },
                                     {
-                                        "name": "Driving privilege details",
+                                        "label": "Driving privilege details",
                                         "locale": "en-US",
                                         "description": "Details related to the specific driving privileges"
                                     }
@@ -676,12 +676,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Nome",
+                                        "label": "Nome",
                                         "locale": "it-IT",
                                         "description": "Nome del titolare della patente"
                                     },
                                     {
-                                        "name": "First Name",
+                                        "label": "First Name",
                                         "locale": "en-US",
                                         "description": "Name of the driving license holder"
                                     }
@@ -693,12 +693,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Cognome",
+                                        "label": "Cognome",
                                         "locale": "it-IT",
                                         "description": "Cognome del titolare della patente"
                                     },
                                     {
-                                        "name": "Family Name",
+                                        "label": "Family Name",
                                         "locale": "en-US",
                                         "description": "last name of the driving license holder"
                                     }
@@ -710,12 +710,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Data di nascita (YYYY-MM-GG)",
+                                        "label": "Data di nascita (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di nascita del titolare della patente"
                                     },
                                     {
-                                        "name": "Date of Birth (YYYY-MM-GG)",
+                                        "label": "Date of Birth (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Date of birth of the driving license holder"
                                     }
@@ -727,12 +727,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Luogo di Nascita",
+                                        "label": "Luogo di Nascita",
                                         "locale": "it-IT",
                                         "description": "Luogo di nascita del titolare della patente"
                                     },
                                     {
-                                        "name": "Place of Birth",
+                                        "label": "Place of Birth",
                                         "locale": "en-US",
                                         "description": "Place of birth of the driving license holder"
                                     }
@@ -744,12 +744,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Data di rilascio (YYYY-MM-GG)",
+                                        "label": "Data di rilascio (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di emissione della patente"
                                     },
                                     {
-                                        "name": "Issue Date (YYYY-MM-GG)",
+                                        "label": "Issue Date (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Date of issuance of the driving license"
                                     }
@@ -761,12 +761,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Data di scadenza (YYYY-MM-GG)",
+                                        "label": "Data di scadenza (YYYY-MM-GG)",
                                         "locale": "it-IT",
                                         "description": "Data di scadenza della patente"
                                     },
                                     {
-                                        "name": "Expiry Date (YYYY-MM-GG)",
+                                        "label": "Expiry Date (YYYY-MM-GG)",
                                         "locale": "en-US",
                                         "description": "Date of expiry of the driving license"
                                     }
@@ -778,12 +778,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Paese di rilascio",
+                                        "label": "Paese di rilascio",
                                         "locale": "it-IT",
                                         "description": "Paese di rilascio della patente"
                                     },
                                     {
-                                        "name": "Issuing Country",
+                                        "label": "Issuing Country",
                                         "locale": "en-US",
                                         "description": "Issuing country of the driving license"
                                     }
@@ -795,12 +795,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Autorità di rilascio",
+                                        "label": "Autorità di rilascio",
                                         "locale": "it-IT",
                                         "description": "Autorità che ha rilasciato la patente"
                                     },
                                     {
-                                        "name": "Issuing Authority",
+                                        "label": "Issuing Authority",
                                         "locale": "en-US",
                                         "description": "Issuing authority of the driving license"
                                     }
@@ -812,12 +812,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Numero di documento",
+                                        "label": "Numero di documento",
                                         "locale": "it-IT",
                                         "description": "Numero Documento della patente"
                                     },
                                     {
-                                        "name": "Document Number",
+                                        "label": "Document Number",
                                         "locale": "en-US",
                                         "description": "Document number of the driving license"
                                     }
@@ -829,12 +829,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Foto codificata",
+                                        "label": "Foto codificata",
                                         "locale": "it-IT",
                                         "description": "Fotografia del titolare della patente"
                                     },
                                     {
-                                        "name": "Portrait",
+                                        "label": "Portrait",
                                         "locale": "en-US",
                                         "description": "Photo of of the driving licence holder"
                                     }
@@ -846,12 +846,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Abilitazioni alla guida",
+                                        "label": "Abilitazioni alla guida",
                                         "locale": "it-IT",
                                         "description": "Elenco delle categorie di abilitazione"
                                     },
                                     {
-                                        "name": "Driving Privileges",
+                                        "label": "Driving Privileges",
                                         "locale": "en-US",
                                         "description": "Driving Privileges list"
                                     }
@@ -863,12 +863,12 @@
                                 "sd": "always",
                                 "display": [
                                     {
-                                        "name": "Codice identificativo della Nazione",
+                                        "label": "Codice identificativo della Nazione",
                                         "locale": "it-IT",
                                         "description": "Segno distintivo del paese che emette la patente"
                                     },
                                     {
-                                        "name": "Distinguishing sign of the issuing country",
+                                        "label": "Distinguishing sign of the issuing country",
                                         "locale": "en-US",
                                         "description": "Distinguishing sign of the issuing country"
                                     }


### PR DESCRIPTION
This PR renames the following Credential Issuer Metadata:

`openid_credential_issuer.credential_configurations_supported.dc_sd_jwt_pid.credential_metadata.claims.display.name  `  

into

`openid_credential_issuer.credential_configurations_supported.dc_sd_jwt_pid.credential_metadata.claims.display.label`