### PR TITLE
fix: removed faulty haip uri scheme

### DIFF
--- a/docs/en/remote-flow.rst
+++ b/docs/en/remote-flow.rst
@@ -456,7 +456,7 @@ The request and its parameters are defined in Section 5 (Authorization Request) 
 
 .. note::
   For the ``authorization_endpoint`` the use of universal links are preferred over custom url-schemes because, when properly configured using Assetlinks JSON for Android and Apple App Site Association for iOS, they provide enhanced security by reducing the risk of URL hijacking.
-  Furthermore, universal links offer fallback mechanisms, allowing the flow to continue seamlessly in a browser even if the Wallet Instance is not installed, ensuring a smoother User experience. To ensure interoperability, support custom url-schemes is also RECOMMENDED according to HAIP `OPENID4VC-HAIP`_, and in particular using the custom url ``haip://``.
+  Furthermore, universal links offer fallback mechanisms, allowing the flow to continue seamlessly in a browser even if the Wallet Instance is not installed, ensuring a smoother User experience. To ensure interoperability, support for custom URL schemes is also RECOMMENDED according to HAIP `OPENID4VC-HAIP`_, and in particular using the custom URL schemes ``openid4vp://`` and ``haip-vp://``.
 
 Request URI Response
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/en/remote-flow.rst
+++ b/docs/en/remote-flow.rst
@@ -456,7 +456,7 @@ The request and its parameters are defined in Section 5 (Authorization Request) 
 
 .. note::
   For the ``authorization_endpoint`` the use of universal links are preferred over custom url-schemes because, when properly configured using Assetlinks JSON for Android and Apple App Site Association for iOS, they provide enhanced security by reducing the risk of URL hijacking.
-  Furthermore, universal links offer fallback mechanisms, allowing the flow to continue seamlessly in a browser even if the Wallet Instance is not installed, ensuring a smoother User experience. To ensure interoperability, support for custom URL schemes is also RECOMMENDED according to HAIP `OPENID4VC-HAIP`_, and in particular using the custom URL schemes ``openid4vp://`` and ``haip-vp://``.
+  Furthermore, universal links offer fallback mechanisms, allowing the flow to continue seamlessly in a browser even if the Wallet Instance is not installed, ensuring a smoother User experience. The URL schemes openid4vp:// and haip-vp:// defined in `OPENID4VP`_ and `OPENID4VC-HAIP`_are supported to ensure interoperability.
 
 Request URI Response
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/en/remote-flow.rst
+++ b/docs/en/remote-flow.rst
@@ -456,7 +456,7 @@ The request and its parameters are defined in Section 5 (Authorization Request) 
 
 .. note::
   For the ``authorization_endpoint`` the use of universal links are preferred over custom url-schemes because, when properly configured using Assetlinks JSON for Android and Apple App Site Association for iOS, they provide enhanced security by reducing the risk of URL hijacking.
-  Furthermore, universal links offer fallback mechanisms, allowing the flow to continue seamlessly in a browser even if the Wallet Instance is not installed, ensuring a smoother User experience. The URL schemes openid4vp:// and haip-vp:// defined in `OPENID4VP`_ and `OPENID4VC-HAIP`_are supported to ensure interoperability.
+  Furthermore, universal links offer fallback mechanisms, allowing the flow to continue seamlessly in a browser even if the Wallet Instance is not installed, ensuring a smoother User experience. The URL schemes ``openid4vp://`` and ``haip-vp://`` defined in `OPENID4VP`_ and `OPENID4VC-HAIP`_are supported to ensure interoperability.
 
 Request URI Response
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/it/remote-flow.rst
+++ b/docs/it/remote-flow.rst
@@ -456,7 +456,7 @@ La richiesta e i suoi parametri sono definiti nella Sezione 5 (Authorization Req
 
 .. note::
   Per l'``authorization_endpoint`` l'uso di *univarsal link* è preferito rispetto a *URL scheme* personalizzati perché, quando configurati correttamente utilizzando Assetlinks JSON per Android e Apple App Site Association per iOS, forniscono una sicurezza migliorata riducendo il rischio di dirottamento degli URL.
-  Inoltre, gli *univarsal link* offrono meccanismi di fallback, consentendo al flusso di continuare senza problemi in un browser anche se l'Istanza del Wallet non è installata, garantendo un'esperienza Utente più fluida. Per garantire l'interoperabilità, il supporto degli *URL scheme* personalizzati è anche RACCOMANDATO secondo il profilo di interoperabilità HAIP `OPENID4VC-HAIP`_, e in particolare utilizzando gli schemi URL personalizzati ``openid4vp://`` e ``haip-vp://``.
+  Inoltre, gli *univarsal link* offrono meccanismi di fallback, consentendo al flusso di continuare senza problemi in un browser anche se l'Istanza del Wallet non è installata, garantendo un'esperienza Utente più fluida. Il supporto degli *URL scheme* ``openid4vp://`` e ``haip-vp://`` definiti in `OPENID4VC-HAIP`_, e `OPENID4VP`_ è supportato per garantire l'interoperabilità.
 
 Risposta dell'Endpoint URI Request
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/it/remote-flow.rst
+++ b/docs/it/remote-flow.rst
@@ -456,7 +456,7 @@ La richiesta e i suoi parametri sono definiti nella Sezione 5 (Authorization Req
 
 .. note::
   Per l'``authorization_endpoint`` l'uso di *univarsal link* è preferito rispetto a *URL scheme* personalizzati perché, quando configurati correttamente utilizzando Assetlinks JSON per Android e Apple App Site Association per iOS, forniscono una sicurezza migliorata riducendo il rischio di dirottamento degli URL.
-  Inoltre, gli *univarsal link* offrono meccanismi di fallback, consentendo al flusso di continuare senza problemi in un browser anche se l'Istanza del Wallet non è installata, garantendo un'esperienza Utente più fluida. Per garantire l'interoperabilità, il supporto degli *URL scheme* personalizzati è anche RACCOMANDATO secondo il profilo di interoperabilità HAIP `OPENID4VC-HAIP`_, e in particolare utilizzando l'url personalizzato ``haip://``.
+  Inoltre, gli *univarsal link* offrono meccanismi di fallback, consentendo al flusso di continuare senza problemi in un browser anche se l'Istanza del Wallet non è installata, garantendo un'esperienza Utente più fluida. Per garantire l'interoperabilità, il supporto degli *URL scheme* personalizzati è anche RACCOMANDATO secondo il profilo di interoperabilità HAIP `OPENID4VC-HAIP`_, e in particolare utilizzando gli schemi URL personalizzati ``openid4vp://`` e ``haip-vp://``.
 
 Risposta dell'Endpoint URI Request
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This pull request updates the documentation in both English and Italian to clarify and expand the recommended custom URL schemes for interoperability in the authorization flow. The changes ensure the documentation aligns with the latest HAIP recommendations, specifying the use of `openid4vp://` and `haip-vp://` schemes instead of only `haip://`.

**Documentation updates for interoperability:**

* [`docs/en/remote-flow.rst`](diffhunk://#diff-49b422a54bf6c8ac0ba7c115989fc1e59cca9b661758d9df668df4ee8bd0d406L459-R459): Updated the note in the authorization request section to recommend supporting the custom URL schemes `openid4vp://` and `haip-vp://`, replacing the previous reference to only `haip://`.
* [`docs/it/remote-flow.rst`](diffhunk://#diff-ff62bfdb95a3f88e9f3a9f733f49030c697c5b30215cdd993b9620cb4562da46L459-R459): Made the same update in the Italian documentation, recommending `openid4vp://` and `haip-vp://` as the custom URL schemes for HAIP interoperability.
