### PR TITLE
How to read spec from editorials lts

### DIFF
--- a/docs/en/how-to-read-spec.rst
+++ b/docs/en/how-to-read-spec.rst
@@ -8,67 +8,66 @@ Specification Structure Overview
 
 The specification is organized into the following major sections:
 
-**Section** :ref:`introduction:Introduction`: 
+- **Section** :ref:`introduction:Introduction`:
   Establishes scope, and normative language for the IT-Wallet ecosystem.
 
-**Section** :ref:`architecture-overview:Architecture Overview`:
+- **Section** :ref:`architecture-overview:Architecture Overview`:
   Provides high-level view on the Architecture in terms of governance and operational processes enabled.
 
-**Section** :ref:`brand-identity:Brand Identity`:
+- **Section** :ref:`brand-identity:Brand Identity`:
   Provides the IT-Wallet Brand Identity requirements, guidance on the naming convention and on the application of the visual elements that identify the ecosystem.
 
-**Section** :ref:`functionalities:User Experience Design`: 
+- **Section** :ref:`functionalities:User Experience Design`:
   Provides design principles and high-level functional requirements to ensure a high-quality User Experience across all stages of interaction between the User and the service.
 
-**Section** :ref:`trust-infrastructure:The Infrastructure of Trust`:
+- **Section** :ref:`trust-infrastructure:The Infrastructure of Trust`:
   Defines the federation-based trust model, entity relationships, and trust evaluation mechanisms that secure the entire ecosystem.
 
-**Section** :ref:`entities:Entities`: 
+- **Section** :ref:`entities:Entities`:
   Comprehensive implementation requirements for each ecosystem participant: Wallet Solutions, Credential Issuers, Relying Parties, and Authentic Sources, including their components, interaction patterns, and configuration requirements.
 
-**Section** :ref:`digital-credential-management:Digital Credential Management`: 
+- **Section** :ref:`digital-credential-management:Digital Credential Management`:
   Covers Digital Credential data models and formats, lifecycle management, validity verification, and the Credentials Catalog structure.
 
-**Section** :ref:`digital-credential-flows:Digital Credential Flows`:
+- **Section** :ref:`digital-credential-flows:Digital Credential Flows`:
   Detailed implementation guidance for Digital Credential issuance and presentation workflows, including both remote and proximity interaction flows.
 
-**Section** :ref:`endpoints:Endpoints`: 
+- **Section** :ref:`endpoints:Endpoints`:
   Technical specifications for all API endpoints exposed by each entity type, including federation endpoints and specialized service integrations.
 
-**Section** :ref:`algorithms:Cryptographic Algorithms`, :ref:`security-privacy-considerations:Security and Privacy Considerations`, and :ref:`log-retention-policy:General Log Retention Policies` (**Implementation Support**): 
+- **Section** :ref:`algorithms:Cryptographic Algorithms`, :ref:`security-privacy-considerations:Security and Privacy Considerations`, and :ref:`log-retention-policy:General Log Retention Policies` (**Implementation Support**):
   Cryptographic requirements, security and privacy considerations, and log retention policies essential for compliant implementations.
 
-**Section** :ref:`defined-terms-and-references:Defined Terms and References`, :ref:`official-resources:Official Resources`, :ref:`contribute:How to contribute`, and :ref:`open-source:Open Source Releases` (**Terminology and References**):
+- **Section** :ref:`defined-terms-and-references:Defined Terms and References`, :ref:`official-resources:Official Resources`, :ref:`contribute:How to contribute`, and :ref:`open-source:Open Source Releases` (**Terminology and References**):
   Comprehensive terminology, normative references, additional documentation, tools, resources and contribution guidelines.
 
-**Section** :ref:`appendix:Appendix`: 
+- **Section** :ref:`appendix:Appendix`:
   Provides supplementary technical details, implementation patterns, and testing frameworks including mobile application instance management, national platform integration specifications, and comprehensive test matrices for ecosystem validation.
 
 
+Reading Paths by Role
+^^^^^^^^^^^^^^^^^^^^^
 
-Reading paths by roles
-^^^^^^^^^^^^^^^^^^^^^^^^
+For easier access to the topics covered in these specifications, role-based reading paths are presented below. Each path is organized according to the different stages of onboarding to and participation in the IT-Wallet System, with direct references to the sections most relevant to each role.
 
-For easier access to the topics covered in these specifications, role-based reading paths are presented below. Each path is organized according to the different stages of onboarding to and participation the IT-Wallet System, with direct references to the sections most relevant to each role. 
+The proposed reading paths are intended as guidance and do not replace the need to consult other sections when a broader understanding of the system is required.
 
-The proposed reading paths are intended as guidance and do not replace the need to consult other sections when a broader understanding of the system is required. 
+For entities interested in addressing multiple roles, it is recommended to deepen all the reading paths related to relevant roles.
 
-For entities interested in addressing multiple roles, it is recommended to deepen all the reading paths related to relevant roles. 
+Authentic Source
+~~~~~~~~~~~~~~~~
 
-### Authentic Source
-
-
-The Authentic Source focuses on securely exposing, managing, and guaranteeing the absolute accuracy and integrity of the authoritative raw data underlying (Q)EAA. 
+The Authentic Source focuses on securely exposing, managing, and guaranteeing the absolute accuracy and integrity of the authoritative raw data underlying (Q)EAA.
 
 **Phase 1: Discovery**
 
 To understand the general functioning of the ecosystem, the technical architecture and the Infrastructure of Trust.
 
-- **Section** :ref:`introduction:Introduction`: Scope and regulatory context of the IT-Wallet System. 
+- **Section** :ref:`introduction:Introduction`: Scope and regulatory context of the IT-Wallet System.
 
-- **Section** :ref:`architecture-overview:Architecture Overview`: Overview of the IT-Wallet System architecture in terms of governance and enabled operational processes. 
+- **Section** :ref:`architecture-overview:Architecture Overview`: Overview of the IT-Wallet System architecture in terms of governance and enabled operational processes.
 
-- **Section** :ref:`trust-infrastructure:The Infrastructure of Trust`: Key requirements of the federation-based trust model and trust evaluation mechanisms between entities. 
+- **Section** :ref:`trust-infrastructure:The Infrastructure of Trust`: Key requirements of the federation-based trust model and trust evaluation mechanisms between entities.
 
 - **Section** :ref:`defined-terms-and-references:Defined Terms and References`: Comprehensive terminology, normative references, additional documentation, tools, resources and contribution guidelines.
 
@@ -76,45 +75,53 @@ To understand the general functioning of the ecosystem, the technical architectu
 
 To understand the requirements and design the features, functionalities and specific characteristics underlying a (Q)EAA to be issued.
 
-- **Section** :ref:`functionalities:User Experience Design`: Key requirements on how to enable Users to obtain (Q)EAAs, (Q)EAA structures, status and management over time. 
+- **Section** :ref:`functionalities:User Experience Design`: Key requirements on how to enable Users to obtain (Q)EAAs, (Q)EAA structures, status and management over time.
 
+- **Section** :ref:`digital-credential-management:Digital Credential Management`: Technical and functional requirements related to (Q)EAA lifecycle.
 
-- **Section** :ref:`digital-credential-management:Digital Credential Management`: Section digital-credential-management:Digital Credential Management: Technical and functional requirements related to (Q)EAA lifecycle. 
 - **Section** :ref:`e-service-pdnd-template:PDND e-Service Template`: Standardized blueprint containing all necessary technical and descriptive metadata for the e-service definition.
+
 **Phase 3: Implementation**
 
 To implement the technological interfaces required to communicate with Credential Issuers and to manage the entire (Q)EAA data lifecycle.
-- **Section** :ref:`authentic-sources:Authentic Sources`: Authentic Source’s role and responsabilities.
 
-- **Section** :ref:`e-service-pdnd:e-Service PDND`: Mandatory integration specifications with the PDND (National Digital Data Platform) and the associated interoperability requirements for publishing an e-service. 
-- **Section** :ref:`authentic-source-endpoint:Authentic Source Endpoints`: Key requirements for the implementation of APIs enabling the Credential Issuer to securely and consistently retrieve authoritative data and to manage the data lifecycle throught Signal Hub endpoint. 
+- **Section** :ref:`authentic-sources:Authentic Sources`: Authentic Source role and responsibilities.
 
-- **Section** :ref:`registry:Registry Infrastructure`: Focus on Registry components of interest to the Authentic Source. 
+- **Section** :ref:`e-service-pdnd:e-Service PDND`: Mandatory integration specifications with the PDND (National Digital Data Platform) and the associated interoperability requirements for publishing an e-service.
 
-- **Section** :ref:`log-retention-policy:General Log Retention Policies`: General Log retention requirements and specific requirements for Authentic Sources in accordance with ISO/IEC 27001. 
+- **Section** :ref:`authentic-source-endpoint:Authentic Source Endpoints`: Key requirements for the implementation of APIs enabling the Credential Issuer to securely and consistently retrieve authoritative data and to manage the data lifecycle through Signal Hub endpoints.
+
+- **Section** :ref:`registry:Registry Infrastructure`: Focus on Registry components of interest to the Authentic Source.
+
+- **Section** :ref:`log-retention-policy:General Log Retention Policies`: General log retention requirements and specific requirements for Authentic Sources in accordance with ISO/IEC 27001.
+
 - **Section** :ref:`test-plans:Test Plans`: Guide to set up the test environment and validate backend interactions with the test matrices provided by the ecosystem.
+
 **Phase 4: Registration**
 
-To become registered as an Authentic Source within the system by completing the administrative and technical procedures required. 
+To become registered as an Authentic Source within the system by completing the administrative and technical procedures required.
 
-- **Section** :ref:`onboarding-high-level:Onboarding System`: Overview of the onboarding system architecture and the Authentic Source registration process. 
+- **Section** :ref:`onboarding-high-level:Onboarding System`: Overview of the onboarding system architecture and the Authentic Source registration process.
+
 - **Section** :ref:`entity-onboarding:Entity Onboarding`: Focus on technical implementation procedures for Authentic Source registration.
+
 - **Section** :ref:`x5c-evaluation:X.509 Certificate Management Operations`: Operational procedures for managing X.509 Certificates within the IT-Wallet federation.
 
-### **Wallet Provider**
 
+Wallet Provider
+~~~~~~~~~~~~~~~
 
-The Wallet Provider focuses on designing and developing the Wallet Solution that enables the User to store, manage, and present their PID and (Q)EAAs. 
+The Wallet Provider focuses on designing and developing the Wallet Solution that enables the User to store, manage, and present their PID and (Q)EAAs.
 
 **Phase 1: Discovery**
 
-To understand the general functioning of the ecosystem, the technical architecture and the Infrastructure of Trust. 
+To understand the general functioning of the ecosystem, the technical architecture and the Infrastructure of Trust.
 
-- **Section** :ref:`introduction:Introduction`: Scope and regulatory context of the IT-Wallet System. 
+- **Section** :ref:`introduction:Introduction`: Scope and regulatory context of the IT-Wallet System.
 
-- **Section** :ref:`architecture-overview:Architecture Overview`: Overview of the IT-Wallet System architecture in terms of governance and enabled operational processes. 
+- **Section** :ref:`architecture-overview:Architecture Overview`: Overview of the IT-Wallet System architecture in terms of governance and enabled operational processes.
 
-- **Section** :ref:`trust-infrastructure:The Infrastructure of Trust`: Key requirements of the federation-based trust model and trust evaluation mechanisms between entities. 
+- **Section** :ref:`trust-infrastructure:The Infrastructure of Trust`: Key requirements of the federation-based trust model and trust evaluation mechanisms between entities.
 
 - **Section** :ref:`defined-terms-and-references:Defined Terms and References`: Comprehensive terminology, normative references, additional documentation, tools, resources and contribution guidelines.
 
@@ -122,49 +129,57 @@ To understand the general functioning of the ecosystem, the technical architectu
 
 To understand the User Experience requirements and design the Wallet Solution following common patterns to ensure the usability and accessibility of the solutions.
 
-- **Section** :ref:`brand-identity:Brand Identity`: Overview of the IT-Wallet Brand Identity and indications on assets to be adopted by the Wallet Provider.  
+- **Section** :ref:`brand-identity:Brand Identity`: Overview of the IT-Wallet Brand Identity and indications on assets to be adopted by the Wallet Provider.
 
-- **Section** :ref:`functionalities:User Experience Design`: Key requirements on Interaction Models and Interface layouts and graphic assets to ensure an effective and seamless User Experience and coherence among Wallet Solutions. 
-
+- **Section** :ref:`functionalities:User Experience Design`: Key requirements on Interaction Models and Interface layouts and graphic assets to ensure an effective and seamless User Experience and coherence among Wallet Solutions.
 
 - **Section** :ref:`digital-credential-management:Digital Credential Management`: Technical and functional requirements related to (Q)EAA lifecycle.
-
 
 **Phase 3: Implementation**
 
 To implement the Wallet Solution in line with specific technological standards to ensure the communication between the Wallet Solution and other actors.
-- **Section** :ref:`wallet-solution:Wallet Solution`: Technical and functional requirements on components, functionalities and lifecycle to configure the Wallet Solution. 
 
-- **Section** :ref:`digital-credential-flows:Digital Credential Flows`: Technical and functional requirements on (Q)EAA issuance and presentation flows. 
-- **Section** :ref:`wallet-provider-endpoint:Wallet Provider Endpoints`: Key requirements for the implementation of the Wallet Provider’s interfaces (APIs) required for interoperability among entities. 
-- **Section** :ref:`registry infrastructure`: Overview on Registry infrastructure and federation Registry. 
+- **Section** :ref:`wallet-solution:Wallet Solution`: Technical and functional requirements on components, functionalities and lifecycle to configure the Wallet Solution.
 
-- **Section** :ref:`algorithms:Cryptographic Algorithms`: Selection and implementation of cryptographic standards required to secure keys and transactions. 
+- **Section** :ref:`digital-credential-flows:Digital Credential Flows`: Technical and functional requirements on (Q)EAA issuance and presentation flows.
+
+- **Section** :ref:`wallet-provider-endpoint:Wallet Provider Endpoints`: Key requirements for the implementation of the Wallet Provider interfaces (APIs) required for interoperability among entities.
+
+- **Section** :ref:`registry:Registry Infrastructure`: Overview of Registry infrastructure and federation Registry.
+
+- **Section** :ref:`algorithms:Cryptographic Algorithms`: Selection and implementation of cryptographic standards required to secure keys and transactions.
+
 - **Section** :ref:`security-privacy-considerations:Security and Privacy Considerations`: Security and compliance requirements for Wallet Solutions.
 
-- **Section** :ref:`log-retention-policy:General Log Retention Policies`: General Log retention requirements and requirements specific for Wallet Providers, in accordance with ISO/IEC 27001. 
-- **Section** :ref:`mobile-application-instance: Mobile Application Instance`: Requirements for mobile application instance, related to initialization request and response. 
+- **Section** :ref:`log-retention-policy:General Log Retention Policies`: General log retention requirements and requirements specific for Wallet Providers, in accordance with ISO/IEC 27001.
 
-- **Section** :ref:`test-plans:Test Plans`: Guide to set up the test environment and validate backend interactions with the test matrices provided by the ecosystem. 
+- **Section** :ref:`mobile-application-instance:Mobile Application Instance`: Requirements for mobile application instance, related to initialization request and response.
+
+- **Section** :ref:`test-plans:Test Plans`: Guide to set up the test environment and validate backend interactions with the test matrices provided by the ecosystem.
+
 **Phase 4: Registration**
 
 To become registered as a Wallet Provider within the system by completing the administrative and technical procedures so that the Wallet Solution is recognized by the system.
-**Section** :ref:`entity-onboarding:Entity Onboarding`: Focus on technical implementation procedures for Wallet Provider registration. 
-- **Section** :ref:`onboarding-high-level:Onboarding System': Overview of the onboarding system architecture and the Wallet Provider registration process.  
-- **Section** :ref:`x5c-evaluation:X.509 Certificate Management Operations`: Operational procedures for managing X.509 Certificates within the IT-Wallet federation
+
+- **Section** :ref:`onboarding-high-level:Onboarding System`: Overview of the onboarding system architecture and the Wallet Provider registration process.
+
+- **Section** :ref:`entity-onboarding:Entity Onboarding`: Focus on technical implementation procedures for Wallet Provider registration.
+
+- **Section** :ref:`x5c-evaluation:X.509 Certificate Management Operations`: Operational procedures for managing X.509 Certificates within the IT-Wallet federation.
 
 
-### **Credential Issuer**
+Credential Issuer
+~~~~~~~~~~~~~~~~~
 
-The Credential Issuer focuses on transforming authoritative raw data from Authentic Source into (Q)EAAs, and managing their entire lifecycle from issuance and to revocation or expiration.
+The Credential Issuer focuses on transforming authoritative raw data from Authentic Sources into (Q)EAAs, and managing their entire lifecycle from issuance to revocation or expiration.
 
 **Phase 1: Discovery**
 
 To understand the general functioning of the ecosystem, the technical architecture and the Infrastructure of Trust.
 
-- **Section** :ref:`introduction:Introduction`: Scope and regulatory context of the IT-Wallet System. 
+- **Section** :ref:`introduction:Introduction`: Scope and regulatory context of the IT-Wallet System.
 
-- **Section** :ref:`architecture-overview:Architecture Overview`: Overview of the IT-Wallet System architecture in terms of governance and enabled operational processes. 
+- **Section** :ref:`architecture-overview:Architecture Overview`: Overview of the IT-Wallet System architecture in terms of governance and enabled operational processes.
 
 - **Section** :ref:`trust-infrastructure:The Infrastructure of Trust`: Key requirements of the federation-based trust model and trust evaluation mechanisms between entities.
 
@@ -176,35 +191,41 @@ To understand the requirements and technically design (Q)EAA by structuring meta
 
 - **Section** :ref:`functionalities:User Experience Design`: Key requirements on (Q)EAA structure, issuance, status and management over time.
 
-
-- **Section** :ref:`digital-credential-management:Digital Credential Management`: Technical and functional requirements related to(Q)EAA lifecycle.
-
+- **Section** :ref:`digital-credential-management:Digital Credential Management`: Technical and functional requirements related to (Q)EAA lifecycle.
 
 **Phase 3: Implementation**
 
 To develop endpoints based on specific protocols, and to implement (Q)EAA issuance, renewal, revocation and all the technical lifecycle management functions.
-- **Section** :ref:`credential-issuer-solution:Credential Issuer Solution`: Technical and functional requirements on components, and interaction patterns to issue and manage (Q)EAAs lifecycle.
+
+- **Section** :ref:`credential-issuer-solution:Credential Issuer Solution`: Technical and functional requirements on components and interaction patterns to issue and manage (Q)EAAs lifecycle.
+
 - **Section** :ref:`digital-credential-flows:Digital Credential Flows`: Technical and functional requirements on (Q)EAA issuance and presentation flows.
 
 - **Section** :ref:`credential-issuer-endpoint:Credential Issuer Endpoints`: Key requirements for the implementation of Credential Issuer metadata and authorization endpoints.
-- **Section** :ref:`algorithms:Cryptographic Algorithms`: To meet security requirements by designing digital signature systems that make attestations unfalsifiable.
+
+- **Section** :ref:`algorithms:Cryptographic Algorithms`: Selection and implementation of cryptographic standards required to secure keys and transactions.
 
 - **Section** :ref:`e-service-pdnd:e-Service PDND`: Mandatory integration specifications with the PDND (National Digital Data Platform) and the associated interoperability requirements for accessing authoritative data required for (Q)EAA issuance.
-- **Section** :ref:`security-privacy-considerations:Security and Privacy Considerations`: Security and compliance requirements for implemented solutions. 
 
-- **Section** :ref:`log-retention-policy:General Log Retention Policies`: General Log retention requirements and requirements specific for Credential Issuers in accordance with ISO/IEC 27001.
+- **Section** :ref:`security-privacy-considerations:Security and Privacy Considerations`: Security and compliance requirements for implemented solutions.
+
+- **Section** :ref:`log-retention-policy:General Log Retention Policies`: General log retention requirements and requirements specific for Credential Issuers in accordance with ISO/IEC 27001.
+
 - **Section** :ref:`test-plans:Test Plans`: Guide to set up the test environment and validate backend interactions with the test matrices provided by the ecosystem.
+
 **Phase 4: Registration**
 
-To become registered as Credential Issuer within the system, by completing the administrative and technical procedure so that (Q)EAA issued to the Wallet are officially trusted.
+To become registered as a Credential Issuer within the system, by completing the administrative and technical procedure so that (Q)EAA issued to the Wallet are officially trusted.
+
 - **Section** :ref:`onboarding-high-level:Onboarding System`: Overview of the onboarding system architecture and the Credential Issuer registration process.
 
-- **Section** :ref:`entity-onboarding:Entity Onboarding`: Focus on technical implementation procedures for Credential Issuer registration. 
+- **Section** :ref:`entity-onboarding:Entity Onboarding`: Focus on technical implementation procedures for Credential Issuer registration.
+
 - **Section** :ref:`x5c-evaluation:X.509 Certificate Management Operations`: Operational procedures for managing X.509 Certificates within the IT-Wallet federation.
 
 
-### **Relying Party**
-
+Relying Party
+~~~~~~~~~~~~~
 
 The Relying Party focuses on securely requesting, receiving, and verifying the authenticity and validity of the PID and (Q)EAAs presented by the User to grant access to online and offline services.
 
@@ -228,34 +249,30 @@ To understand the User Experience requirements and design the verification funct
 
 - **Section** :ref:`functionalities:User Experience Design`: Key requirements on Interaction Models, Interface layouts and graphic assets to ensure an effective and seamless User Experience, and coherence among presentation and verification systems.
 
-
 - **Section** :ref:`digital-credential-management:Digital Credential Management`: Technical and functional requirements related to (Q)EAA lifecycle.
-
 
 **Phase 3: Implementation**
 
-To implement verification functionalities following specific protocols, to send verification requests to the Wallet and receive a response with the User’s authorization.
+To implement verification functionalities following specific protocols, to send verification requests to the Wallet and receive a response with the User authorization.
+
 - **Section** :ref:`relying-party-solution:Relying Party Solution`: Technical and functional requirements on components and functionalities for PID and (Q)EAA verification.
-- **Section** ref:`digital-credential-flows:Digital Credential Flows`:  Technical and functional requirements on (Q)EAA presentation and verification flows.
 
-- **Section** :ref:`relying-party-endpoints:Relying Party Endpoints`: Key requirements for the implementation of (Q)EAAs verification endpoints.
+- **Section** :ref:`digital-credential-flows:Digital Credential Flows`: Technical and functional requirements on (Q)EAA presentation and verification flows.
 
-- **Section** :ref:`security-privacy-considerations:Security and Privacy Considerations`: Security and compliance requirements for implemented solutions. 
+- **Section** :ref:`relying-party-endpoints:Relying Party Endpoints`: Key requirements for the implementation of (Q)EAA verification endpoints.
 
-- **Section** :ref:`log-retention-policy:General Log Retention Policies`: General Log retention requirements and requirements specific for Relying Parties, in accordance with ISO/IEC 27001.
-- **Section** :ref:`test-plans:Test Plans`: Guide to set up the test environment and validate backend interactions with the test matrices provided by the ecosystem. 
+- **Section** :ref:`security-privacy-considerations:Security and Privacy Considerations`: Security and compliance requirements for implemented solutions.
+
+- **Section** :ref:`log-retention-policy:General Log Retention Policies`: General log retention requirements and requirements specific for Relying Parties, in accordance with ISO/IEC 27001.
+
+- **Section** :ref:`test-plans:Test Plans`: Guide to set up the test environment and validate backend interactions with the test matrices provided by the ecosystem.
+
 **Phase 4: Registration**
 
-To become registered as Relying Party within the system, by completing the administrative and technical procedure and be a reliable actor when requesting User’s data.
+To become registered as a Relying Party within the system, by completing the administrative and technical procedure and becoming a reliable actor when requesting User data.
 
 - **Section** :ref:`onboarding-high-level:Onboarding System`: Overview of the onboarding system architecture and the Relying Party registration process.
-- **Section** :ref:`entity-onboarding:Entity Onboarding`: Focus on implementation procedures for Relying Party registration. 
+
+- **Section** :ref:`entity-onboarding:Entity Onboarding`: Focus on implementation procedures for Relying Party registration.
+
 - **Section** :ref:`x5c-evaluation:X.509 Certificate Management Operations`: Operational procedures for managing X.509 Certificates within the IT-Wallet federation.
-
-
-
-
-
-
-
-

--- a/docs/en/how-to-read-spec.rst
+++ b/docs/en/how-to-read-spec.rst
@@ -1,169 +1,261 @@
-.. include:: ../common/common_definitions.rst
-.. Included via introduction.rst at title level '-' (level 1).
-
-
 How to Read the Specification
 -----------------------------
 
-This specification is designed to fulfil the requirements from multiple stakeholders within the IT-Wallet ecosystem. Each role has different responsibilities and scopes, and therefore different information needs. This section provides tailored reading paths to help you navigate efficiently to the content most relevant to the implementation goals.
+This specification is designed to fulfil the requirements from multiple stakeholders within the IT-Wallet System. Each role has different responsibilities and scopes, and therefore different information needs. This section provides tailored reading paths to help you navigate efficiently to the content most relevant to the implementation goals.
 
 Specification Structure Overview
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The specification is organized into the following major sections:
 
-**Section** :ref:`introduction:Introduction`:
+**Section** :ref:`introduction:Introduction`: 
   Establishes scope, and normative language for the IT-Wallet ecosystem.
-
-**Section** :ref:`brand-identity:Brand Identity`:
-  Provides the IT-Wallet Brand Identity requirements, guidance on the naming convention and on the application of the visual elements that identify the ecosystem.
 
 **Section** :ref:`architecture-overview:Architecture Overview`:
   Provides high-level view on the Architecture in terms of governance and operational processes enabled.
 
-**Section** :ref:`functionalities:User Experience Design`:
+**Section** :ref:`brand-identity:Brand Identity`:
+  Provides the IT-Wallet Brand Identity requirements, guidance on the naming convention and on the application of the visual elements that identify the ecosystem.
+
+**Section** :ref:`functionalities:User Experience Design`: 
   Provides design principles and high-level functional requirements to ensure a high-quality User Experience across all stages of interaction between the User and the service.
 
 **Section** :ref:`trust-infrastructure:The Infrastructure of Trust`:
   Defines the federation-based trust model, entity relationships, and trust evaluation mechanisms that secure the entire ecosystem.
 
-**Section** :ref:`entities:Entities`:
+**Section** :ref:`entities:Entities`: 
   Comprehensive implementation requirements for each ecosystem participant: Wallet Solutions, Credential Issuers, Relying Parties, and Authentic Sources, including their components, interaction patterns, and configuration requirements.
 
-**Section** :ref:`digital-credential-management:Digital Credential Management`:
+**Section** :ref:`digital-credential-management:Digital Credential Management`: 
   Covers Digital Credential data models and formats, lifecycle management, validity verification, and the Credentials Catalog structure.
 
 **Section** :ref:`digital-credential-flows:Digital Credential Flows`:
   Detailed implementation guidance for Digital Credential issuance and presentation workflows, including both remote and proximity interaction flows.
 
-**Section** :ref:`endpoints:Endpoints`:
+**Section** :ref:`endpoints:Endpoints`: 
   Technical specifications for all API endpoints exposed by each entity type, including federation endpoints and specialized service integrations.
 
-**Section** :ref:`algorithms:Cryptographic Algorithms`, :ref:`security-privacy-considerations:Security and Privacy Considerations`, and :ref:`log-retention-policy:General Log Retention Policies` (**Implementation Support**):
+**Section** :ref:`algorithms:Cryptographic Algorithms`, :ref:`security-privacy-considerations:Security and Privacy Considerations`, and :ref:`log-retention-policy:General Log Retention Policies` (**Implementation Support**): 
   Cryptographic requirements, security and privacy considerations, and log retention policies essential for compliant implementations.
 
 **Section** :ref:`defined-terms-and-references:Defined Terms and References`, :ref:`official-resources:Official Resources`, :ref:`contribute:How to contribute`, and :ref:`open-source:Open Source Releases` (**Terminology and References**):
   Comprehensive terminology, normative references, additional documentation, tools, resources and contribution guidelines.
 
-**Section** :ref:`appendix:Appendix`:
+**Section** :ref:`appendix:Appendix`: 
   Provides supplementary technical details, implementation patterns, and testing frameworks including mobile application instance management, national platform integration specifications, and comprehensive test matrices for ecosystem validation.
 
 
-Reading Paths by Role
-^^^^^^^^^^^^^^^^^^^^^
 
-Before diving into role-specific sections, all readers should be familiar with the foundational concepts outlined in Sections :ref:`introduction:Introduction`, :ref:`brand-identity:Brand Identity`, :ref:`architecture-overview:Architecture Overview`, and :ref:`trust-infrastructure:The Infrastructure of Trust`, which establish the common vocabulary, and trust infrastructure that provide the underlying framework for the entire ecosystem.
+Reading paths by roles
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-Wallet Provider
-"""""""""""""""
+For easier access to the topics covered in these specifications, role-based reading paths are presented below. Each path is organized according to the different stages of onboarding to and participation the IT-Wallet System, with direct references to the sections most relevant to each role. 
 
-Readers implementing or operating a **Wallet Provider** Solution should focus on understanding how to securely manage Digital Credentials and facilitate User interactions with other ecosystem participants.
+The proposed reading paths are intended as guidance and do not replace the need to consult other sections when a broader understanding of the system is required. 
 
-**Essential sections:**
+For entities interested in addressing multiple roles, it is recommended to deepen all the reading paths related to relevant roles. 
 
-* **Section** :ref:`functionalities:User Experience Design`: High-level functional requirements supporting the User Experience across all stages of interaction between the User and the service.
-* **Section** :ref:`wallet-solution:Wallet Solution`: Complete wallet implementation requirements, components, and interaction processes.
-* **Section** :ref:`digital-credential-management:Digital Credential Management`: Digital Credential data models, formats and lifecycle management.
-* **Section** :ref:`digital-credential-flows:Digital Credential Flows`: Issuance and presentation flows for Digital Credentials.
-* **Section** :ref:`wallet-provider-endpoint:Wallet Provider Endpoints`: Federation and IT-Wallet specific API specifications.
-* **Section** :ref:`algorithms:Cryptographic Algorithms`: Security and cryptographic implementation requirements.
-* **Section** :ref:`mobile-application-instance:Mobile Application Instance`: Mobile-specific implementation patterns.
-* **Section** :ref:`e-service-pdnd:e-Service PDND`: Integration with the National Data Interoperability Platform.
-
-**Secondary sections:**
-
-* **Section** :ref:`credential-issuer-solution:Credential Issuer Solution`: Understanding issuer interactions and requirements.
-* **Section** :ref:`relying-party-solution:Relying Party Solution`: Understanding RP interactions and presentation protocols.
+### Authentic Source
 
 
-Credential Issuer
-"""""""""""""""""
+The Authentic Source focuses on securely exposing, managing, and guaranteeing the absolute accuracy and integrity of the authoritative raw data underlying (Q)EAA. 
 
-For readers who are interested in implementing a **Credential Issuer** Solution, they should focus on the Digital Credential lifecycle and issuance interaction flows.
+**Phase 1: Discovery**
 
-**Essential sections:**
+To understand the general functioning of the ecosystem, the technical architecture and the Infrastructure of Trust.
 
-* **Section** :ref:`functionalities:User Experience Design`: High-level functional requirements supporting the User Experience across all stages of interaction between the User and the service.
-* **Section** :ref:`credential-issuer-solution:Credential Issuer Solution`: Credential Issuer Solution - Complete Issuer implementation requirements and component details.
-* **Section** :ref:`authentic-sources:Authentic Sources`: Understanding authoritative data source integration patterns.
-* **Section** :ref:`digital-credential-management:Digital Credential Management`: Digital Credential formats and lifecycle management.
-* **Section** :ref:`credential-issuance:Digital Credential Issuance`: Detailed issuance flow implementation.
-* **Section** :ref:`credential-issuer-endpoint:Credential Issuer Endpoints`: Federation and issuance-specific API specifications.
-* **Section** :ref:`algorithms:Cryptographic Algorithms`:  Signing algorithms and security implementation requirements.
+- **Section** :ref:`introduction:Introduction`: Scope and regulatory context of the IT-Wallet System. 
 
-**Secondary sections:**
+- **Section** :ref:`architecture-overview:Architecture Overview`: Overview of the IT-Wallet System architecture in terms of governance and enabled operational processes. 
 
-* **Section** :ref:`wallet-solution:Wallet Solution`: Understanding Wallet Instance interactions and requirements.
-* **Section** :ref:`credential-presentation:Digital Credential Presentation`: Understanding how Digital Credentials are presented in both remote and proximity scenario.
-* **Section** :ref:`e-service-pdnd:e-Service PDND`: Integration with the National Data Interoperability Platform.
+- **Section** :ref:`trust-infrastructure:The Infrastructure of Trust`: Key requirements of the federation-based trust model and trust evaluation mechanisms between entities. 
 
-.. note::
+- **Section** :ref:`defined-terms-and-references:Defined Terms and References`: Comprehensive terminology, normative references, additional documentation, tools, resources and contribution guidelines.
 
-    If the Credential Issuer authenticates the User it must comply with Section :ref:`credential-presentation:Digital Credential Presentation`. If the Authentic Source providing User's attributes belongs to the public sector it must comply with Section :ref:`e-service-pdnd:e-Service PDND`.
+**Phase 2: Design**
 
-Authentic Source
-""""""""""""""""
+To understand the requirements and design the features, functionalities and specific characteristics underlying a (Q)EAA to be issued.
 
-If the reader wants to operate an **Authentic Source**, the focus should be on secure data provision and integration with Credential Issuers.
+- **Section** :ref:`functionalities:User Experience Design`: Key requirements on how to enable Users to obtain (Q)EAAs, (Q)EAA structures, status and management over time. 
 
-**Essential sections:**
 
-* **Section** :ref:`functionalities:User Experience Design`: High-level functional requirements supporting the User Experience across all stages of interaction between the User and the service.
-* **Section** :ref:`authentic-sources:Authentic Sources`: Requirements and integration patterns with Credential Issuers.
-* **Section** :ref:`authentic-source-endpoint:Authentic Source Endpoints`: API specifications and catalog integration.
-* **Section** :ref:`algorithms:Cryptographic Algorithms`: Data integrity, authentication, and security requirements.
-* **Section** :ref:`e-service-pdnd:e-Service PDND`: PDND integration and interoperability requirements.
+- **Section** :ref:`digital-credential-management:Digital Credential Management`: Section digital-credential-management:Digital Credential Management: Technical and functional requirements related to (Q)EAA lifecycle. 
+- **Section** :ref:`e-service-pdnd-template:PDND e-Service Template`: Standardized blueprint containing all necessary technical and descriptive metadata for the e-service definition.
+**Phase 3: Implementation**
 
-**Secondary sections:**
+To implement the technological interfaces required to communicate with Credential Issuers and to manage the entire (Q)EAA data lifecycle.
+- **Section** :ref:`authentic-sources:Authentic Sources`: Authentic Source’s role and responsabilities.
 
-* **Section** :ref:`credential-issuer-solution:Credential Issuer Solution`: Understanding Credential Issuers main components and integration processes.
-* **Section** :ref:`digital-credential-management:Digital Credential Management`: Understanding how authoritative data and attributes becomes Digital Credentials, and how their lifecycle is managed.
+- **Section** :ref:`e-service-pdnd:e-Service PDND`: Mandatory integration specifications with the PDND (National Digital Data Platform) and the associated interoperability requirements for publishing an e-service. 
+- **Section** :ref:`authentic-source-endpoint:Authentic Source Endpoints`: Key requirements for the implementation of APIs enabling the Credential Issuer to securely and consistently retrieve authoritative data and to manage the data lifecycle throught Signal Hub endpoint. 
 
-Relying Party
-"""""""""""""
+- **Section** :ref:`registry:Registry Infrastructure`: Focus on Registry components of interest to the Authentic Source. 
 
-Readers interested in implementing or operating a **Relying Party** Solution to accept and verify Digital Credentials should focus on presentation protocols and verification mechanisms.
+- **Section** :ref:`log-retention-policy:General Log Retention Policies`: General Log retention requirements and specific requirements for Authentic Sources in accordance with ISO/IEC 27001. 
+- **Section** :ref:`test-plans:Test Plans`: Guide to set up the test environment and validate backend interactions with the test matrices provided by the ecosystem.
+**Phase 4: Registration**
 
-**Essential sections:**
+To become registered as an Authentic Source within the system by completing the administrative and technical procedures required. 
 
-* **Section** :ref:`functionalities:User Experience Design`: High-level functional requirements supporting the User Experience across all stages of interaction between the User and the service.
-* **Section** :ref:`relying-party-solution:Relying Party Solution`: Complete verifier implementation requirements and Entity Configuration.
-* **Section** :ref:`digital-credential-management:Digital Credential Management`: Understanding Digital Credential formats and validity verification.
-* **Section** :ref:`credential-presentation:Digital Credential Presentation`: Presentation flow implementation for both remote and proximity scenarios.
-* **Section** :ref:`relying-party-endpoints:Relying Party Endpoints`: Complete overview of all Relying Party endpoints and their scopes.
-* **Section** :ref:`algorithms:Cryptographic Algorithms`: Cryptographic suite requirements.
+- **Section** :ref:`onboarding-high-level:Onboarding System`: Overview of the onboarding system architecture and the Authentic Source registration process. 
+- **Section** :ref:`entity-onboarding:Entity Onboarding`: Focus on technical implementation procedures for Authentic Source registration.
+- **Section** :ref:`x5c-evaluation:X.509 Certificate Management Operations`: Operational procedures for managing X.509 Certificates within the IT-Wallet federation.
 
-**Secondary sections:**
+### **Wallet Provider**
 
-* **Section** :ref:`wallet-solution:Wallet Solution`: Understanding Wallet Instance interactions and presentation protocols.
-* **Section** :ref:`mobile-application-instance:Mobile Application Instance`: Mobile-specific implementation patterns.
 
-Cross-Cutting Topics
-^^^^^^^^^^^^^^^^^^^^
+The Wallet Provider focuses on designing and developing the Wallet Solution that enables the User to store, manage, and present their PID and (Q)EAAs. 
 
-Regardless of your primary role, certain sections contain information relevant to all ecosystem participants:
+**Phase 1: Discovery**
 
-**Security and Compliance:**
-    All implementers must implement their solutions according to Section :ref:`security-privacy-considerations:Security and Privacy Considerations` and Section :ref:`log-retention-policy:General Log Retention Policies`.
+To understand the general functioning of the ecosystem, the technical architecture and the Infrastructure of Trust. 
 
-**Standards and References:**
-    Section :ref:`defined-terms-and-references:Defined Terms and References` provides normative references, defined terms, and technical standards to enable secure and proper interoperability among all participants.
+- **Section** :ref:`introduction:Introduction`: Scope and regulatory context of the IT-Wallet System. 
 
-**Testing and Validation:**
-    Section :ref:`test-plans:Test Plans` provides a comprehensive test matrix for validating implementations across different roles and interaction flows.
+- **Section** :ref:`architecture-overview:Architecture Overview`: Overview of the IT-Wallet System architecture in terms of governance and enabled operational processes. 
 
-Implementation Approach
-^^^^^^^^^^^^^^^^^^^^^^^
+- **Section** :ref:`trust-infrastructure:The Infrastructure of Trust`: Key requirements of the federation-based trust model and trust evaluation mechanisms between entities. 
 
-The following phased reading approach is suggested:
+- **Section** :ref:`defined-terms-and-references:Defined Terms and References`: Comprehensive terminology, normative references, additional documentation, tools, resources and contribution guidelines.
 
-    1. **Foundation Phase**: Read  Sections :ref:`introduction:Introduction`, :ref:`brand-identity:Brand Identity`, :ref:`architecture-overview:Architecture Overview`, and :ref:`trust-infrastructure:The Infrastructure of Trust` to establish conceptual understanding of the IT-Wallet paradigm, Brand Identity elements and trust infrastructure.
-    2. **Role-Specific Phase**: Focus on primary role's essential sections to understand specific User Experience, functional and implementation requirements, main technical component, the general architecture and interaction flows (see Section :ref:`functionalities:User Experience Design`, :ref:`entities:Entities` and Section :ref:`endpoints:Endpoints` for more details).
-    3. **Integration Phase**: Review secondary sections relevant to interactions with other ecosystem participants and platform integration requirements.
-    4. **Validation Phase**: Study security considerations, testing guidance, and compliance requirements according to Sections :ref:`security-privacy-considerations:Security and Privacy Considerations`, :ref:`log-retention-policy:General Log Retention Policies`, and :ref:`test-plans:Test Plans` for additional information.
+**Phase 2: Design**
 
-.. note::
+To understand the User Experience requirements and design the Wallet Solution following common patterns to ensure the usability and accessibility of the solutions.
 
-    For implementers working on solutions that span multiple roles (e.g., a combined Issuer Relying Party Solutions), it is recommended reviewing the sections for all relevant roles before proceeding with the developments. It is important to take particular note of Entity Configuration requirements and federation flows that apply to multiple roles.
+- **Section** :ref:`brand-identity:Brand Identity`: Overview of the IT-Wallet Brand Identity and indications on assets to be adopted by the Wallet Provider.  
+
+- **Section** :ref:`functionalities:User Experience Design`: Key requirements on Interaction Models and Interface layouts and graphic assets to ensure an effective and seamless User Experience and coherence among Wallet Solutions. 
+
+
+- **Section** :ref:`digital-credential-management:Digital Credential Management`: Technical and functional requirements related to (Q)EAA lifecycle.
+
+
+**Phase 3: Implementation**
+
+To implement the Wallet Solution in line with specific technological standards to ensure the communication between the Wallet Solution and other actors.
+- **Section** :ref:`wallet-solution:Wallet Solution`: Technical and functional requirements on components, functionalities and lifecycle to configure the Wallet Solution. 
+
+- **Section** :ref:`digital-credential-flows:Digital Credential Flows`: Technical and functional requirements on (Q)EAA issuance and presentation flows. 
+- **Section** :ref:`wallet-provider-endpoint:Wallet Provider Endpoints`: Key requirements for the implementation of the Wallet Provider’s interfaces (APIs) required for interoperability among entities. 
+- **Section** :ref:`registry infrastructure`: Overview on Registry infrastructure and federation Registry. 
+
+- **Section** :ref:`algorithms:Cryptographic Algorithms`: Selection and implementation of cryptographic standards required to secure keys and transactions. 
+- **Section** :ref:`security-privacy-considerations:Security and Privacy Considerations`: Security and compliance requirements for Wallet Solutions.
+
+- **Section** :ref:`log-retention-policy:General Log Retention Policies`: General Log retention requirements and requirements specific for Wallet Providers, in accordance with ISO/IEC 27001. 
+- **Section** :ref:`mobile-application-instance: Mobile Application Instance`: Requirements for mobile application instance, related to initialization request and response. 
+
+- **Section** :ref:`test-plans:Test Plans`: Guide to set up the test environment and validate backend interactions with the test matrices provided by the ecosystem. 
+**Phase 4: Registration**
+
+To become registered as a Wallet Provider within the system by completing the administrative and technical procedures so that the Wallet Solution is recognized by the system.
+**Section** :ref:`entity-onboarding:Entity Onboarding`: Focus on technical implementation procedures for Wallet Provider registration. 
+- **Section** :ref:`onboarding-high-level:Onboarding System': Overview of the onboarding system architecture and the Wallet Provider registration process.  
+- **Section** :ref:`x5c-evaluation:X.509 Certificate Management Operations`: Operational procedures for managing X.509 Certificates within the IT-Wallet federation
+
+
+### **Credential Issuer**
+
+The Credential Issuer focuses on transforming authoritative raw data from Authentic Source into (Q)EAAs, and managing their entire lifecycle from issuance and to revocation or expiration.
+
+**Phase 1: Discovery**
+
+To understand the general functioning of the ecosystem, the technical architecture and the Infrastructure of Trust.
+
+- **Section** :ref:`introduction:Introduction`: Scope and regulatory context of the IT-Wallet System. 
+
+- **Section** :ref:`architecture-overview:Architecture Overview`: Overview of the IT-Wallet System architecture in terms of governance and enabled operational processes. 
+
+- **Section** :ref:`trust-infrastructure:The Infrastructure of Trust`: Key requirements of the federation-based trust model and trust evaluation mechanisms between entities.
+
+- **Section** :ref:`defined-terms-and-references:Defined Terms and References`: Comprehensive terminology, normative references, additional documentation, tools, resources and contribution guidelines.
+
+**Phase 2: Design**
+
+To understand the requirements and technically design (Q)EAA by structuring metadata to meet technical and regulatory requirements.
+
+- **Section** :ref:`functionalities:User Experience Design`: Key requirements on (Q)EAA structure, issuance, status and management over time.
+
+
+- **Section** :ref:`digital-credential-management:Digital Credential Management`: Technical and functional requirements related to(Q)EAA lifecycle.
+
+
+**Phase 3: Implementation**
+
+To develop endpoints based on specific protocols, and to implement (Q)EAA issuance, renewal, revocation and all the technical lifecycle management functions.
+- **Section** :ref:`credential-issuer-solution:Credential Issuer Solution`: Technical and functional requirements on components, and interaction patterns to issue and manage (Q)EAAs lifecycle.
+- **Section** :ref:`digital-credential-flows:Digital Credential Flows`: Technical and functional requirements on (Q)EAA issuance and presentation flows.
+
+- **Section** :ref:`credential-issuer-endpoint:Credential Issuer Endpoints`: Key requirements for the implementation of Credential Issuer metadata and authorization endpoints.
+- **Section** :ref:`algorithms:Cryptographic Algorithms`: To meet security requirements by designing digital signature systems that make attestations unfalsifiable.
+
+- **Section** :ref:`e-service-pdnd:e-Service PDND`: Mandatory integration specifications with the PDND (National Digital Data Platform) and the associated interoperability requirements for accessing authoritative data required for (Q)EAA issuance.
+- **Section** :ref:`security-privacy-considerations:Security and Privacy Considerations`: Security and compliance requirements for implemented solutions. 
+
+- **Section** :ref:`log-retention-policy:General Log Retention Policies`: General Log retention requirements and requirements specific for Credential Issuers in accordance with ISO/IEC 27001.
+- **Section** :ref:`test-plans:Test Plans`: Guide to set up the test environment and validate backend interactions with the test matrices provided by the ecosystem.
+**Phase 4: Registration**
+
+To become registered as Credential Issuer within the system, by completing the administrative and technical procedure so that (Q)EAA issued to the Wallet are officially trusted.
+- **Section** :ref:`onboarding-high-level:Onboarding System`: Overview of the onboarding system architecture and the Credential Issuer registration process.
+
+- **Section** :ref:`entity-onboarding:Entity Onboarding`: Focus on technical implementation procedures for Credential Issuer registration. 
+- **Section** :ref:`x5c-evaluation:X.509 Certificate Management Operations`: Operational procedures for managing X.509 Certificates within the IT-Wallet federation.
+
+
+### **Relying Party**
+
+
+The Relying Party focuses on securely requesting, receiving, and verifying the authenticity and validity of the PID and (Q)EAAs presented by the User to grant access to online and offline services.
+
+**Phase 1: Discovery**
+
+To understand the general functioning of the ecosystem, the technical architecture and the Infrastructure of Trust.
+
+- **Section** :ref:`introduction:Introduction`: Scope and regulatory context of the IT-Wallet System.
+
+- **Section** :ref:`architecture-overview:Architecture Overview`: Overview of the IT-Wallet System architecture in terms of governance and enabled operational processes.
+
+- **Section** :ref:`trust-infrastructure:The Infrastructure of Trust`: Key requirements of the federation-based trust model and trust evaluation mechanisms between entities.
+
+- **Section** :ref:`defined-terms-and-references:Defined Terms and References`: Comprehensive terminology, normative references, additional documentation, tools, resources and contribution guidelines.
+
+**Phase 2: Design**
+
+To understand the User Experience requirements and design the verification functionalities necessary to provide the service to the end User.
+
+- **Section** :ref:`brand-identity:Brand Identity`: Overview of the IT-Wallet Brand Identity and indications on assets to be adopted by the Relying Party.
+
+- **Section** :ref:`functionalities:User Experience Design`: Key requirements on Interaction Models, Interface layouts and graphic assets to ensure an effective and seamless User Experience, and coherence among presentation and verification systems.
+
+
+- **Section** :ref:`digital-credential-management:Digital Credential Management`: Technical and functional requirements related to (Q)EAA lifecycle.
+
+
+**Phase 3: Implementation**
+
+To implement verification functionalities following specific protocols, to send verification requests to the Wallet and receive a response with the User’s authorization.
+- **Section** :ref:`relying-party-solution:Relying Party Solution`: Technical and functional requirements on components and functionalities for PID and (Q)EAA verification.
+- **Section** ref:`digital-credential-flows:Digital Credential Flows`:  Technical and functional requirements on (Q)EAA presentation and verification flows.
+
+- **Section** :ref:`relying-party-endpoints:Relying Party Endpoints`: Key requirements for the implementation of (Q)EAAs verification endpoints.
+
+- **Section** :ref:`security-privacy-considerations:Security and Privacy Considerations`: Security and compliance requirements for implemented solutions. 
+
+- **Section** :ref:`log-retention-policy:General Log Retention Policies`: General Log retention requirements and requirements specific for Relying Parties, in accordance with ISO/IEC 27001.
+- **Section** :ref:`test-plans:Test Plans`: Guide to set up the test environment and validate backend interactions with the test matrices provided by the ecosystem. 
+**Phase 4: Registration**
+
+To become registered as Relying Party within the system, by completing the administrative and technical procedure and be a reliable actor when requesting User’s data.
+
+- **Section** :ref:`onboarding-high-level:Onboarding System`: Overview of the onboarding system architecture and the Relying Party registration process.
+- **Section** :ref:`entity-onboarding:Entity Onboarding`: Focus on implementation procedures for Relying Party registration. 
+- **Section** :ref:`x5c-evaluation:X.509 Certificate Management Operations`: Operational procedures for managing X.509 Certificates within the IT-Wallet federation.
+
+
+
+
+
+
 
 

--- a/docs/it/how-to-read-spec.rst
+++ b/docs/it/how-to-read-spec.rst
@@ -3,280 +3,287 @@
 Come leggere le Specifiche
 --------------------------
 
-Questa specifica è progettata per soddisfare i requisiti di molteplici stakeholder all'interno dell'ecosistema IT-Wallet. Ogni ruolo ha responsabilità e ambiti diversi e diverse esigenze informative. Questa sezione fornisce percorsi di lettura personalizzati per aiutare il lettore a navigare in modo efficiente verso i contenuti più rilevanti per gli obiettivi di implementazione.
+Questa specifica è progettata per soddisfare i requisiti di molteplici stakeholder all'interno del Sistema IT-Wallet. Ogni ruolo ha responsabilità e ambiti diversi e diverse esigenze informative. Questa sezione fornisce percorsi di lettura personalizzati per aiutare il lettore a navigare in modo efficiente verso i contenuti più rilevanti per gli obiettivi di implementazione.
 
 Panoramica della Struttura delle Specifiche
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 La specifica è organizzata nelle seguenti sezioni principali:
 
-**Sezione** :ref:`introduction:Introduzione`: 
+- **Sezione** :ref:`introduction:Introduzione`:
   Stabilisce l'ambito e il linguaggio normativo per l'ecosistema IT-Wallet.
 
-**Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`:
+- **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`:
   Fornisce una visione di alto livello dell'Architettura, in termini di governance e processi operativi abilitati.
 
-**Sezione** :ref:`brand-identity:Brand Identity`:
+- **Sezione** :ref:`brand-identity:Brand Identity`:
   Fornisce i requisiti relativi alla Brand Identity del Sistema IT-Wallet, le indicazioni relative al naming e all'applicazione degli elementi visivi che identificano l'ecosistema.
 
-**Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: 
-  Fornisce i principi di design e i requisiti funzionali di alto livello per garantire un’Esperienza Utente di qualità in tutte le fasi di interazione tra l’Utente e il servizio. 
+- **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`:
+  Fornisce i principi di design e i requisiti funzionali di alto livello per garantire un’Esperienza Utente di qualità in tutte le fasi di interazione tra l’Utente e il servizio.
 
-**Sezione** :ref:`trust-infrastructure:L'Infrastruttura di Trust`:
+- **Sezione** :ref:`trust-infrastructure:L'Infrastruttura di Trust`:
   Definisce il modello di trust basato sulla federazione, le relazioni tra entità e i meccanismi di valutazione della fiducia che proteggono l'intero ecosistema.
 
-**Sezione** :ref:`entities:Entità`: 
+- **Sezione** :ref:`entities:Entità`:
   Requisiti di implementazione completi per ogni partecipante all'ecosistema: Soluzioni Wallet, Fornitori di Credenziali, Relying Party e Fonti Autentiche, inclusi i loro componenti, modelli di interazione e requisiti di configurazione.
 
-**Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: 
+- **Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`:
   Copre i modelli di dati e i formati delle Credenziali Elettroniche, la gestione del ciclo di vita, la verifica della validità e la struttura del catalogo delle Credenziali.
 
-**Sezione** :ref:`digital-credential-flows:Flussi relativi agli Attestati Elettronici`:
+- **Sezione** :ref:`digital-credential-flows:Flussi relativi agli Attestati Elettronici`:
   Guida dettagliata all'implementazione per i flussi di emissione e presentazione delle Credenziali Elettroniche, inclusi i flussi di interazione remota e di prossimità.
 
-**Sezione** :ref:`endpoints:Endpoints`: 
+- **Sezione** :ref:`endpoints:Endpoints`:
   Specifiche tecniche per tutti gli endpoint API esposti da ciascun tipo di entità, inclusi gli endpoint di federazione e le integrazioni di servizi specializzati.
 
-**Sezione** :ref:`algorithms:Algoritmi Crittografici`, :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`, e :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log` (**Supporto all'Implementazione**): 
+- **Sezione** :ref:`algorithms:Algoritmi Crittografici`, :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`, e :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log` (**Supporto all'Implementazione**):
   Requisiti crittografici, considerazioni sulla sicurezza e sulla privacy, e politiche di conservazione dei log essenziali per implementazioni conformi.
 
-**Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`, :ref:`official-resources:Risorse Ufficiali`, :ref:`contribute:Come contribuire`, e :ref:`open-source:Rilasci Open Source` (**Terminologia e Riferimenti**):
+- **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`, :ref:`official-resources:Risorse Ufficiali`, :ref:`contribute:Come contribuire`, e :ref:`open-source:Rilasci Open Source` (**Terminologia e Riferimenti**):
   Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi.
 
-**Sezione** :ref:`appendix:Appendice`: 
+- **Sezione** :ref:`appendix:Appendice`:
   Fornisce dettagli tecnici supplementari, modelli di implementazione e framework di test, inclusa la gestione delle istanze di applicazioni mobili, specifiche di integrazione della piattaforma nazionale e matrici di test complete per la validazione dell'ecosistema.
 
 
 Percorsi di lettura per ruolo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-""""""""""""""""""""""""""""
 
-""""""""""""""""""""""""""""
+Per facilitare la consultazione degli argomenti trattati in queste specifiche, di seguito sono riportati percorsi di lettura organizzati per ruolo. Ogni percorso è strutturato in base alle diverse fasi di adesione e partecipazione al Sistema IT-Wallet e contiene riferimenti diretti alle sezioni più rilevanti per ciascun ruolo.
 
-Per facilitare la consultazione degli argomenti trattati in queste specifiche, di seguito sono riportati percorsi di lettura organizzati per ruolo. Ogni percorso è strutturato in base alle diverse fasi di adesione e partecipazione al Sistema IT-Wallet e contiene riferimenti diretti alle sezioni più rilevanti per ciascun ruolo. 
+I percorsi di lettura proposti hanno finalità orientativa e non sostituiscono la necessità di consultare le altre sezioni quando è richiesta una comprensione più ampia del sistema.
 
-I percorsi di lettura proposti hanno finalità orientativa e non sostituiscono la necessità di consultare le altre sezioni quando è richiesta una comprensione più ampia del sistema. 
+Per le entità interessate a operare in più ruoli, si raccomanda di approfondire tutti i percorsi di lettura relativi ai ruoli di interesse.
 
-Per le entità interessate a operare in più ruoli, si raccomanda di approfondire tutti i percorsi di lettura relativi ai ruoli di interesse. 
 Fonte Autentica
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-La Fonte Autentica si occupa di rendere disponibili i dati affidabili alla base dei (Q)EAA e di garantirne e gestirne in modo sicuro l’assoluta accuratezza e integrità. 
+La Fonte Autentica si occupa di rendere disponibili i dati affidabili alla base dei (Q)EAA e di garantirne e gestirne in modo sicuro l’assoluta accuratezza e integrità.
+
+**Fase 1: Scoperta**
+
+Comprendere il funzionamento generale dell’ecosistema, l’architettura tecnica e l’Infrastruttura di Trust.
 
 - **Sezione** :ref:`introduction:Introduzione`: Scopo e contesto normativo del Sistema IT-Wallet.
 
-- **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`: Panoramica dell’architettura del Sistema IT-Wallet in termini di governance e processi operativi abilitati. 
+- **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`: Panoramica dell’architettura del Sistema IT-Wallet in termini di governance e processi operativi abilitati.
 
 - **Sezione** :ref:`trust-infrastructure:L'Infrastruttura di Trust`: Requisiti chiave del modello di fiducia federato e dei meccanismi di valutazione della fiducia tra le entità.
 
-- **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`: Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi. 
+- **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`: Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi.
+
 **Fase 2: Progettazione**
 
-Comprendere i requisiti e progettare gli aspetti, le funzionalità e le caratteristiche specifiche del (Q)EAA da emettere. 
+Comprendere i requisiti e progettare gli aspetti, le funzionalità e le caratteristiche specifiche del (Q)EAA da emettere.
 
 
 - **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: Requisiti chiave relativi alle modalità con cui consentire agli Utenti di ottenere i (Q)EAA, alla struttura dei (Q)EAA, al loro stato e alla loro gestione nel tempo.
 
 
-**Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Requisiti tecnici e funzionali relativi al ciclo di vita dei (Q)EAA. 
+- **Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Requisiti tecnici e funzionali relativi al ciclo di vita dei (Q)EAA.
 
-- **Sezione** :ref:`e-service-pdnd-template:PDND e-Service Template`: Modello di riferimento contenente tutti i metadati tecnici e descrittivi necessari per la definizione dell’e-service. 
+- **Sezione** :ref:`e-service-pdnd-template:PDND e-Service Template`: Modello di riferimento contenente tutti i metadati tecnici e descrittivi necessari per la definizione dell’e-service.
 
 **Fase 3: Implementazione**
 
-Implementare le interfacce tecnologiche necessarie per comunicare con il Fornitore di Attestati Elettronici e gestire l’intero ciclo di vita dei dati associati ai (Q)EAA. 
+Implementare le interfacce tecnologiche necessarie per comunicare con il Fornitore di Attestati Elettronici e gestire l’intero ciclo di vita dei dati associati ai (Q)EAA.
 
-- **Sezione** :ref:`authentic-sources:Fonti Autentiche`: Ruolo e responsabilità della Fonte Autentica. 
-**Sezione** :ref:`e-service-pdnd:e-Service PDND`: Specifiche obbligatorie per l’integrazione con la PDND (Piattaforma Digitale Nazionale Dati) e relativi requisiti di interoperabilità per la pubblicazione di un e-service.
+- **Sezione** :ref:`authentic-sources:Fonti Autentiche`: Ruolo e responsabilità della Fonte Autentica.
 
-**Sezione** :ref:`authentic-source-endpoint:Endpoint delle Fonti Autentiche`: Requisiti chiave per l’implementazione delle API che consentono al Credential Issuer di recuperare in modo sicuro e coerente i dati autorevoli e di gestirne il ciclo di vita tramite gli endpoint del Signal Hub. 
-- **Sezione** :ref:`registry infrastructure:Infrastruttura del Registro`: Approfondimento sui componenti del Registro di interesse per la Fonte Autentica. 
+- **Sezione** :ref:`e-service-pdnd:e-Service PDND`: Specifiche obbligatorie per l'integrazione con la PDND (Piattaforma Digitale Nazionale Dati) e relativi requisiti di interoperabilità per la pubblicazione di un e-service.
 
-- **Sezione** :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log`: Requisiti generali per la conservazione dei log e requisiti specifici per le Fonti Autentiche, in conformità alla norma ISO/IEC 27001. 
-- **Sezione** :ref:`test-plans:Test Plans`: Guida alla configurazione dell’ambiente di test e alla validazione delle interazioni backend tramite l’utilizzo delle matrici di test fornite dall’ecosistema. 
+- **Sezione** :ref:`authentic-source-endpoint:Endpoint delle Fonti Autentiche`: Requisiti chiave per l'implementazione delle API che consentono al Credential Issuer di recuperare in modo sicuro e coerente i dati autorevoli e di gestirne il ciclo di vita tramite gli endpoint del Signal Hub.
+
+- **Sezione** :ref:`registry:Infrastruttura del Registro`: Approfondimento sui componenti del Registro di interesse per la Fonte Autentica.
+
+- **Sezione** :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log`: Requisiti generali per la conservazione dei log e requisiti specifici per le Fonti Autentiche, in conformità alla norma ISO/IEC 27001.
+
+- **Sezione** :ref:`test-plans:Test Plans`: Guida alla configurazione dell'ambiente di test e alla validazione delle interazioni backend tramite l'utilizzo delle matrici di test fornite dall'ecosistema.
+
 **Fase 4: Registrazione**
 
-Registrarsi al sistema come Fonte Autentica, completando le procedure amministrative e tecniche richieste. 
+Registrarsi al sistema come Fonte Autentica, completando le procedure amministrative e tecniche richieste.
 
-- **Sezione** :ref:`onboarding-high-level:Sistema di Onboarding`: Panoramica dell’architettura del sistema di onboarding e del processo di registrazione della Fonte Autentica. 
+- **Sezione** :ref:`onboarding-high-level:Sistema di Onboarding`: Panoramica dell’architettura del sistema di onboarding e del processo di registrazione della Fonte Autentica.
 
-- **Sezione** :ref:`entity-onboarding:Onboarding delle Entità`: Approfondimento sulle procedure tecniche per la registrazione della Fonte Autentica. 
+- **Sezione** :ref:`entity-onboarding:Onboarding delle Entità`: Approfondimento sulle procedure tecniche per la registrazione della Fonte Autentica.
 
-- **Sezione** :ref:`x5c-evaluation:Operazioni di Gestione dei Certificati X.509`: Procedure operative per la gestione dei certificati X.509 nell’ambito della federazione IT-Wallet. 
+- **Sezione** :ref:`x5c-evaluation:Operazioni di Gestione dei Certificati X.509`: Procedure operative per la gestione dei certificati X.509 nell’ambito della federazione IT-Wallet.
 
 
-**Fornitore di Wallet**
+Fornitore di Wallet
 ~~~~~~~~~~~~~~~~~~~
 
-Il Fornitore di Wallet si occupa della progettazione e dello sviluppo della Soluzione Wallet, che consente all’Utente di conservare, gestire e presentare il proprio PID e i propri (Q)EAA. 
+Il Fornitore di Wallet si occupa della progettazione e dello sviluppo della Soluzione Wallet, che consente all’Utente di conservare, gestire e presentare il proprio PID e i propri (Q)EAA.
 
 **Fase 1: Scoperta**
 
-Comprendere il funzionamento generale dell’ecosistema, l’architettura tecnica e l’Infrastruttura di Trust. 
+Comprendere il funzionamento generale dell’ecosistema, l’architettura tecnica e l’Infrastruttura di Trust.
 
 - **Sezione** :ref:`introduction:Introduzione`: Scopo e contesto normativo del Sistema IT-Wallet.
 
-- **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`: Panoramica dell’architettura del Sistema IT-Wallet in termini di governance e processi operativi abilitati. 
+- **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`: Panoramica dell’architettura del Sistema IT-Wallet in termini di governance e processi operativi abilitati.
 
 - **Sezione** :ref:`trust-infrastructure:L'Infrastruttura di Trust`: Requisiti chiave del modello di fiducia federato e dei meccanismi di valutazione della fiducia tra le entità.
 
-- **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`: Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi. 
+- **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`: Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi.
 
 **Fase 2: Progettazione**
 
-Comprendere i requisiti relativi all’Esperienza Utente e progettare la Soluzione Wallet secondo modelli comuni, al fine di garantirne l’usabilità e l’accessibilità. 
+Comprendere i requisiti relativi all’Esperienza Utente e progettare la Soluzione Wallet secondo modelli comuni, al fine di garantirne l’usabilità e l’accessibilità.
 
 - **Sezione** :ref:`brand-identity:Brand Identity`: Panoramica della Brand Identity del Sistema IT-Wallet e indicazioni sugli asset di riferimento per il Fornitore di Wallet.
 
 - **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: Requisiti chiave relativi ai modelli di interazione, ai layout delle interfacce e agli asset grafici, al fine di garantire un’esperienza utente efficace, fluida e assicurare coerenza tra le diverse Soluzioni Wallet.
 
-**Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Gestione degli Attestati Elettronici: Requisiti tecnici e funzionali relativi al ciclo di vita dei (Q)EAA. 
+- **Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Requisiti tecnici e funzionali relativi al ciclo di vita dei (Q)EAA.
 
 **Fase 3: Implementazione**
 
-Implementare la Soluzione Wallet in conformità a specifici standard tecnologici, al fine di garantire la comunicazione tra la Soluzione Wallet e gli altri attori del Sistema. 
+Implementare la Soluzione Wallet in conformità a specifici standard tecnologici, al fine di garantire la comunicazione tra la Soluzione Wallet e gli altri attori del Sistema.
 
-- **Sezione** :ref:`wallet-solution:Soluzione Wallet`: Requisiti tecnici e funzionali relativi ai componenti, alle funzionalità e al ciclo di vita necessari per la configurazione della Soluzione Wallet. 
+- **Sezione** :ref:`wallet-solution:Soluzione Wallet`: Requisiti tecnici e funzionali relativi ai componenti, alle funzionalità e al ciclo di vita necessari per la configurazione della Soluzione Wallet.
 
-- **Sezione** :ref:`digital-credential-flows: Flussi relativi agli Attestati Elettronici`: Requisiti tecnici e funzionali relativi ai flussi di emissione e presentazione dei (Q)EAA.
+- **Sezione** :ref:`digital-credential-flows:Flussi relativi agli Attestati Elettronici`: Requisiti tecnici e funzionali relativi ai flussi di emissione e presentazione dei (Q)EAA.
 
-- **Sezione** :ref:`wallet-provider-endpoint:Endpoint del Fornitore di Wallet`: Requisiti chiave per l’implementazione delle interfacce (API) del Fornitore di Wallet necessarie a garantire l’interoperabilità tra le entità. 
+- **Sezione** :ref:`wallet-provider-endpoint:Endpoint del Fornitore di Wallet`: Requisiti chiave per l’implementazione delle interfacce (API) del Fornitore di Wallet necessarie a garantire l’interoperabilità tra le entità.
 
-- **Sezione** :ref:`registry-infrastructure:Infrastruttura del Registro`: Approfondimento sui componenti del Registro. 
+- **Sezione** :ref:`registry:Infrastruttura del Registro`: Approfondimento sui componenti del Registro.
 
-- **Sezione** :ref:`algorithms:Algoritmi Crittografici’: Selezione e implementazione degli standard crittografici necessari a garantire la sicurezza delle chiavi e delle transazioni. 
+- **Sezione** :ref:`algorithms:Algoritmi Crittografici`: Selezione e implementazione degli standard crittografici necessari a garantire la sicurezza delle chiavi e delle transazioni.
 
-- **Sezione** :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`: Requisiti di sicurezza e conformità per le Soluzioni Wallet. 
+- **Sezione** :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`: Requisiti di sicurezza e conformità per le Soluzioni Wallet.
 
-- **Sezione** :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log`: Requisiti generali per la conservazione dei log e requisiti specifici per i Fornitori di Wallet, in conformità alla norma ISO/IEC 27001. 
+- **Sezione** :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log`: Requisiti generali per la conservazione dei log e requisiti specifici per i Fornitori di Wallet, in conformità alla norma ISO/IEC 27001.
 
-- **Sezione** :ref:`mobile-application-instance: Istanza dell'Applicazione Mobile`: Requisiti relativi all’istanza dell’applicazione mobile, con riferimento alla richiesta e alla risposta di inizializzazione. 
+- **Sezione** :ref:`mobile-application-instance:Istanza dell'Applicazione Mobile`: Requisiti relativi all’istanza dell’applicazione mobile, con riferimento alla richiesta e alla risposta di inizializzazione.
 
-- **Sezione** :ref:`test-plans:Test Plans`: Guida alla configurazione dell’ambiente di test e alla validazione delle interazioni backend tramite l’utilizzo delle matrici di test fornite dall’ecosistema. 
+- **Sezione** :ref:`test-plans:Test Plans`: Guida alla configurazione dell’ambiente di test e alla validazione delle interazioni backend tramite l’utilizzo delle matrici di test fornite dall’ecosistema.
 
 **Fase 4: Registrazione**
 
-Registrarsi al sistema come Fornitore di Wallet, completando le procedure amministrative e tecniche richieste per il riconoscimento della Soluzione Wallet da parte del sistema. 
+Registrarsi al sistema come Fornitore di Wallet, completando le procedure amministrative e tecniche richieste per il riconoscimento della Soluzione Wallet da parte del sistema.
 
 - **Sezione** :ref:`onboarding-high-level:Sistema di Onboarding`: Panoramica dell’architettura del sistema di onboarding e del processo di registrazione del Fornitore di Wallet.
 
-- **Sezione** :ref:`entity-onboarding:Onboarding delle Entità`: Approfondimento sulle procedure tecniche per la registrazione del Fornitore di Wallet. 
+- **Sezione** :ref:`entity-onboarding:Onboarding delle Entità`: Approfondimento sulle procedure tecniche per la registrazione del Fornitore di Wallet.
 
-- **Sezione** :ref:`x5c-evaluation:Operazioni di Gestione dei Certificati X.509`: Procedure operative per la gestione dei certificati X.509 nell’ambito della federazione IT-Wallet. 
+- **Sezione** :ref:`x5c-evaluation:Operazioni di Gestione dei Certificati X.509`: Procedure operative per la gestione dei certificati X.509 nell’ambito della federazione IT-Wallet.
 
 
 
-Fornitore di Attestati Elettronici 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Fornitore di Attestati Elettronici
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Il Fornitore di Attestati Elettronici si occupa di trasformare i dati autorevoli di origine provenienti dalle Fonti Autentiche in (Q)EAA e di gestirne l’intero ciclo di vita, dall’emissione alla revoca o alla scadenza. 
+Il Fornitore di Attestati Elettronici si occupa di trasformare i dati autorevoli di origine provenienti dalle Fonti Autentiche in (Q)EAA e di gestirne l’intero ciclo di vita, dall’emissione alla revoca o alla scadenza.
 
 **Fase 1: Scoperta**
 
-Comprendere il funzionamento generale dell’ecosistema, l’architettura tecnica e l’Infrastruttura di Trust. 
+Comprendere il funzionamento generale dell’ecosistema, l’architettura tecnica e l’Infrastruttura di Trust.
 
 - **Sezione** :ref:`introduction:Introduzione`: Scopo e contesto normativo del Sistema IT-Wallet.
 
-- **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`: Panoramica dell’architettura del Sistema IT-Wallet in termini di governance e processi operativi abilitati. 
+- **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`: Panoramica dell’architettura del Sistema IT-Wallet in termini di governance e processi operativi abilitati.
 
 - **Sezione** :ref:`trust-infrastructure:L'Infrastruttura di Trust`: Requisiti chiave del modello di fiducia federato e dei meccanismi di valutazione della fiducia tra le entità.
 
-- **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`: Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi. 
+- **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`: Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi.
 
 **Fase 2: Progettazione**
 
-Comprendere i requisiti e progettare tecnicamente i (Q)EAA, strutturandone i metadati in conformità ai requisiti tecnici e normativi. 
+Comprendere i requisiti e progettare tecnicamente i (Q)EAA, strutturandone i metadati in conformità ai requisiti tecnici e normativi.
 
 - **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: Requisiti chiave relativi alla struttura, all’emissione, allo stato e alla gestione nel tempo dei (Q)EAA.
 
-**Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`:  Requisiti tecnici e funzionali relativi al ciclo di vita dei (Q)EAA. 
+- **Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Requisiti tecnici e funzionali relativi al ciclo di vita dei (Q)EAA.
 
 **Fase 3: Implementazione**
 
-Sviluppare endpoint secondo su specifici protocolli e implementare le funzionalità di emissione, rinnovo, revoca e tutte le altre funzioni tecniche di gestione del ciclo di vita dei (Q)EAA. 
+Sviluppare endpoint secondo specifici protocolli e implementare le funzionalità di emissione, rinnovo, revoca e tutte le altre funzioni tecniche di gestione del ciclo di vita dei (Q)EAA.
 
-- **Sezione** :ref:`credential-issuer-solution:Soluzione del Fornitore di Attestati Elettronici`: Requisiti tecnici e funzionali relativi ai componenti e ai modelli di interazione necessari per l’emissione e la gestione del ciclo di vita dei (Q)EAA. 
+- **Sezione** :ref:`credential-issuer-solution:Soluzione del Fornitore di Attestati Elettronici`: Requisiti tecnici e funzionali relativi ai componenti e ai modelli di interazione necessari per l’emissione e la gestione del ciclo di vita dei (Q)EAA.
 
-- **Sezione** :ref:`digital-credential-flows:Flussi relativi agli attestati elettronici`: Requisiti tecnici e funzionali relativi ai flussi di emissione e presentazione dei (Q)EAA.
+- **Sezione** :ref:`digital-credential-flows:Flussi relativi agli Attestati Elettronici`: Requisiti tecnici e funzionali relativi ai flussi di emissione e presentazione dei (Q)EAA.
 
-- **Sezione** :ref:`credential-issuer-endopoint:Endpoint del Credential Issuer`: Requisiti chiave per l’implementazione dei metadati del Fornitore di Attestati Elettronici e degli endpoint di autorizzazione. 
+- **Sezione** :ref:`credential-issuer-endpoint:Endpoint del Credential Issuer`: Requisiti chiave per l’implementazione dei metadati del Fornitore di Attestati Elettronici e degli endpoint di autorizzazione.
 
-- **Sezione** :ref:`algorithms:Algoritmi Crittografici’: Selezione e implementazione degli standard crittografici necessari a garantire la sicurezza delle chiavi e delle transazioni. 
+- **Sezione** :ref:`algorithms:Algoritmi Crittografici`: Selezione e implementazione degli standard crittografici necessari a garantire la sicurezza delle chiavi e delle transazioni.
 
-- **Sezione** :ref:`e-service-pdnd:e-Service PDND’: Specifiche obbligatorie per l’integrazione con la PDND (Piattaforma Digitale Nazionale Dati) e relativi requisiti di interoperabilità per la pubblicazione di un e-service. 
+- **Sezione** :ref:`e-service-pdnd:e-Service PDND`: Specifiche obbligatorie per l’integrazione con la PDND (Piattaforma Digitale Nazionale Dati) e relativi requisiti di interoperabilità per la pubblicazione di un e-service.
 
-- **Sezione** :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`: Requisiti di sicurezza e conformità per le soluzioni implementate. 
+- **Sezione** :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`: Requisiti di sicurezza e conformità per le soluzioni implementate.
 
-- **Sezione** :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log`: Requisiti generali per la conservazione dei log e requisiti specifici per i Fornitori di Attestati Elettronici, in conformità alla norma ISO/IEC 27001. 
+- **Sezione** :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log`: Requisiti generali per la conservazione dei log e requisiti specifici per i Fornitori di Attestati Elettronici, in conformità alla norma ISO/IEC 27001.
 
-- **Sezione** :ref:`test-plans:Test Plans`: Guida alla configurazione dell’ambiente di test e alla validazione delle interazioni backend tramite l’utilizzo delle matrici di test fornite dall’ecosistema. 
+- **Sezione** :ref:`test-plans:Test Plans`: Guida alla configurazione dell’ambiente di test e alla validazione delle interazioni backend tramite l’utilizzo delle matrici di test fornite dall’ecosistema.
 
 **Fase 4: Registrazione**
 
-Registrarsi al sistema come Credential Issuer, completando le procedure amministrative e tecniche previste affinché i (Q)EAA emessi verso i Wallet siano riconosciuti come affidabili dal Sistema. 
+Registrarsi al sistema come Credential Issuer, completando le procedure amministrative e tecniche previste affinché i (Q)EAA emessi verso i Wallet siano riconosciuti come affidabili dal Sistema.
 
-- **Sezione** :ref:`onboarding-high-level:Sistema di Onboarding`: Panoramica dell’architettura del sistema di onboarding e del processo di registrazione della Fonte Autentica. 
+- **Sezione** :ref:`onboarding-high-level:Sistema di Onboarding`: Panoramica dell’architettura del sistema di onboarding e del processo di registrazione del Fornitore di Attestati Elettronici.
 
-- **Sezione** :ref:`Entity Onboarding:Onboarding delle Entità`: Approfondimento sulle procedure tecniche per la registrazione del Fornitore di Attestati Elettronici. 
+- **Sezione** :ref:`entity-onboarding:Onboarding delle Entità`: Approfondimento sulle procedure tecniche per la registrazione del Fornitore di Attestati Elettronici.
 
-- **Sezione** :ref:`x5c-evaluation:Operazioni di Gestione dei Certificati X.509`: Procedure operative per la gestione dei certificati X.509 nell’ambito della federazione IT-Wallet. 
+- **Sezione** :ref:`x5c-evaluation:Operazioni di Gestione dei Certificati X.509`: Procedure operative per la gestione dei certificati X.509 nell’ambito della federazione IT-Wallet.
 
 
 Fornitori di servizi (Relying Party)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Fase 1: Scoperta*
+I Fornitori di servizi (Relying Party) si occupano di richiedere, ricevere e verificare in modo sicuro l'autenticità e la validità del PID e dei (Q)EAA presentati dall'Utente per consentire l'accesso ai servizi online e offline.
 
-Comprendere il funzionamento generale dell’ecosistema, l’architettura tecnica e l’Infrastruttura di Trust. 
+**Fase 1: Scoperta**
+
+Comprendere il funzionamento generale dell’ecosistema, l’architettura tecnica e l’Infrastruttura di Trust.
 
 - **Sezione** :ref:`introduction:Introduzione`: Scopo e contesto normativo del Sistema IT-Wallet.
 
-- **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`: Panoramica dell’architettura del Sistema IT-Wallet in termini di governance e processi operativi abilitati. 
+- **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`: Panoramica dell’architettura del Sistema IT-Wallet in termini di governance e processi operativi abilitati.
 
 - **Sezione** :ref:`trust-infrastructure:L'Infrastruttura di Trust`: Requisiti chiave del modello di fiducia federato e dei meccanismi di valutazione della fiducia tra le entità.
 
-- **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`: Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi. 
+- **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`: Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi.
+
 **Fase 2: Progettazione**
 
-Comprendere i requisiti di Esperienza Utente e progettare le funzionalità di verifica necessarie all’erogazione del servizio all’Utente finale. 
+Comprendere i requisiti di Esperienza Utente e progettare le funzionalità di verifica necessarie all’erogazione del servizio all’Utente finale.
 
 - **Sezione** :ref:`brand-identity:Brand Identity`: Panoramica della Brand Identity del Sistema IT-Wallet e indicazioni sugli asset da adottare da parte della Relying Party.
 
-- **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: Requisiti chiave relativi ai modelli di interazione, ai layout delle interfacce e agli asset grafici, al fine di garantire un’esperienza utente efficace, fluida e assicurare coerenza tra i sistemi di presentazione e verifica. 
+- **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: Requisiti chiave relativi ai modelli di interazione, ai layout delle interfacce e agli asset grafici, al fine di garantire un’esperienza utente efficace, fluida e assicurare coerenza tra i sistemi di presentazione e verifica.
 
 
-**Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Gestione degli Attestati Elettronici: Requisiti tecnici e funzionali relativi al ciclo di vita dei (Q)EAA.
+- **Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Requisiti tecnici e funzionali relativi al ciclo di vita dei (Q)EAA.
 
 
 **Fase 3: Implementazione**
 
-Implementare le funzionalità di verifica secondo specifici protocolli, al fine di inviare richieste di verifica al Wallet e ricevere una risposta con l’autorizzazione dell’Utente. 
+Implementare le funzionalità di verifica secondo specifici protocolli, al fine di inviare richieste di verifica al Wallet e ricevere una risposta con l’autorizzazione dell’Utente.
 
 
-- **Sezione** :ref:`relying-party-solution:Soluzione di Relying Party`: Requisiti tecnici e funzionali relativi ai componenti e alle funzionalità per la verifica del PID e dei (Q)EAA. 
+- **Sezione** :ref:`relying-party-solution:Soluzione di Relying Party`: Requisiti tecnici e funzionali relativi ai componenti e alle funzionalità per la verifica del PID e dei (Q)EAA.
 
-- **Sezione** :ref:`digital-credential-flows:Flussi relativi agli Attestati Elettronici`: Requisiti tecnici e funzionali relativi ai flussi di emissione e presentazione dei (Q)EAA. 
+- **Sezione** :ref:`digital-credential-flows:Flussi relativi agli Attestati Elettronici`: Requisiti tecnici e funzionali relativi ai flussi di emissione e presentazione dei (Q)EAA.
 
-- **Sezione** :ref:`relying-party-endpoint:Endpoint della Relying Party`: Requisiti chiave per l’implementazione degli endpoint di verifica dei (Q)EAA.
+- **Sezione** :ref:`relying-party-endpoints:Endpoint della Relying Party`: Requisiti chiave per l’implementazione degli endpoint di verifica dei (Q)EAA.
 
-- **Sezione** :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`: Requisiti di sicurezza e conformità per le soluzioni implementate. 
+- **Sezione** :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`: Requisiti di sicurezza e conformità per le soluzioni implementate.
 
-- **Sezione** :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log`: Requisiti generali per la conservazione dei log e requisiti specifici per le Relying Party, in conformità alla norma ISO/IEC 27001. 
+- **Sezione** :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log`: Requisiti generali per la conservazione dei log e requisiti specifici per le Relying Party, in conformità alla norma ISO/IEC 27001.
 
-- **Sezione** :ref:`test-plans:Test Plans`: Guida alla configurazione dell’ambiente di test e alla validazione delle interazioni backend tramite l’utilizzo delle matrici di test fornite dall’ecosistema. 
+- **Sezione** :ref:`test-plans:Test Plans`: Guida alla configurazione dell’ambiente di test e alla validazione delle interazioni backend tramite l’utilizzo delle matrici di test fornite dall’ecosistema.
 
 **Fase 4: Registrazione**
 
-Registrarsi al sistema come Relying Party, completando le procedure amministrative e tecniche previste, e diventare soggetto affidabile per la richiesta dei dati degli Utenti. 
+Registrarsi al sistema come Relying Party, completando le procedure amministrative e tecniche previste, e diventare soggetto affidabile per la richiesta dei dati degli Utenti.
 
-- **Sezione** :ref:`onboarding-high-level:Sistema di Onboarding`: Approfondimento sulle procedure tecniche per la registrazione della Relying Party. 
+- **Sezione** :ref:`onboarding-high-level:Sistema di Onboarding`: Panoramica dell'architettura del sistema di onboarding e del processo di registrazione della Relying Party.
 
-- **Sezione** :ref:`entity Onboarding:Onboarding delle Entità`: Approfondimento sulle procedure tecniche per la registrazione della Relying Party. 
+- **Sezione** :ref:`entity-onboarding:Onboarding delle Entità`: Approfondimento sulle procedure tecniche per la registrazione della Relying Party.
 
-- **Sezione** :ref:`x5c-evaluation:Operazioni di Gestione dei Certificati X.509`: Procedure operative per la gestione dei certificati X.509 nell’ambito della federazione IT-Wallet. 
+- **Sezione** :ref:`x5c-evaluation:Operazioni di Gestione dei Certificati X.509`: Procedure operative per la gestione dei certificati X.509 nell’ambito della federazione IT-Wallet.
 
-
-
-.. note::
 

--- a/docs/it/how-to-read-spec.rst
+++ b/docs/it/how-to-read-spec.rst
@@ -1,6 +1,4 @@
 .. include:: ../common/common_definitions.rst
-.. Incluso tramite introduction.rst al livello di titolo '-' (livello 1).
-
 
 Come leggere le Specifiche
 --------------------------
@@ -12,158 +10,273 @@ Panoramica della Struttura delle Specifiche
 
 La specifica è organizzata nelle seguenti sezioni principali:
 
-**Sezione** :ref:`introduction:Introduzione`:
+**Sezione** :ref:`introduction:Introduzione`: 
   Stabilisce l'ambito e il linguaggio normativo per l'ecosistema IT-Wallet.
 
-**Sezione** :ref:`brand-identity:Brand Identity`:
-  Fornisce i requisiti relativi alla Brand Identity del Sistema IT-Wallet, le indicazioni relative al naming e all'applicazione degli elementi visivi che identificano l’ecosistema.
-
 **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`:
-  Fornisce una visione di alto livello dell’Architettura, in termini di governance e processi operativi abilitati.
+  Fornisce una visione di alto livello dell'Architettura, in termini di governance e processi operativi abilitati.
 
-**Sezione** :ref:`functionalities:Design dell'Esperienza Utente`:
-  Fornisce i principi di design e i requisiti funzionali di alto livello per garantire un’Esperienza Utente di qualità in tutte le fasi di interazione tra l’Utente e il servizio.
+**Sezione** :ref:`brand-identity:Brand Identity`:
+  Fornisce i requisiti relativi alla Brand Identity del Sistema IT-Wallet, le indicazioni relative al naming e all'applicazione degli elementi visivi che identificano l'ecosistema.
+
+**Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: 
+  Fornisce i principi di design e i requisiti funzionali di alto livello per garantire un’Esperienza Utente di qualità in tutte le fasi di interazione tra l’Utente e il servizio. 
 
 **Sezione** :ref:`trust-infrastructure:L'Infrastruttura di Trust`:
   Definisce il modello di trust basato sulla federazione, le relazioni tra entità e i meccanismi di valutazione della fiducia che proteggono l'intero ecosistema.
 
-**Sezione** :ref:`entities:Entità`:
+**Sezione** :ref:`entities:Entità`: 
   Requisiti di implementazione completi per ogni partecipante all'ecosistema: Soluzioni Wallet, Fornitori di Credenziali, Relying Party e Fonti Autentiche, inclusi i loro componenti, modelli di interazione e requisiti di configurazione.
 
-**Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`:
+**Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: 
   Copre i modelli di dati e i formati delle Credenziali Elettroniche, la gestione del ciclo di vita, la verifica della validità e la struttura del catalogo delle Credenziali.
 
 **Sezione** :ref:`digital-credential-flows:Flussi relativi agli Attestati Elettronici`:
   Guida dettagliata all'implementazione per i flussi di emissione e presentazione delle Credenziali Elettroniche, inclusi i flussi di interazione remota e di prossimità.
 
-**Sezione** :ref:`endpoints:Endpoints`:
+**Sezione** :ref:`endpoints:Endpoints`: 
   Specifiche tecniche per tutti gli endpoint API esposti da ciascun tipo di entità, inclusi gli endpoint di federazione e le integrazioni di servizi specializzati.
 
-**Sezione** :ref:`algorithms:Algoritmi Crittografici`, :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`, e :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log` (**Supporto all'Implementazione**):
+**Sezione** :ref:`algorithms:Algoritmi Crittografici`, :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`, e :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log` (**Supporto all'Implementazione**): 
   Requisiti crittografici, considerazioni sulla sicurezza e sulla privacy, e politiche di conservazione dei log essenziali per implementazioni conformi.
 
 **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`, :ref:`official-resources:Risorse Ufficiali`, :ref:`contribute:Come contribuire`, e :ref:`open-source:Rilasci Open Source` (**Terminologia e Riferimenti**):
   Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi.
 
-**Sezione** :ref:`appendix:Appendice`:
+**Sezione** :ref:`appendix:Appendice`: 
   Fornisce dettagli tecnici supplementari, modelli di implementazione e framework di test, inclusa la gestione delle istanze di applicazioni mobili, specifiche di integrazione della piattaforma nazionale e matrici di test complete per la validazione dell'ecosistema.
 
 
-Journey di Lettura per Ruolo
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Percorsi di lettura per ruolo
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Prima di immergersi nelle sezioni specifiche per ruolo, tutti i lettori dovrebbero familiarizzare con i concetti fondamentali delineati nelle Sezioni :ref:`introduction:Introduzione`, :ref:`brand-identity:Brand Identity`, :ref:`architecture-overview:Panoramica dell'Architettura` e :ref:`trust-infrastructure:L'Infrastruttura di Trust`, che stabiliscono il vocabolario comune e l'infrastruttura di fiducia che forniscono il quadro sottostante per l'intero ecosistema.
+""""""""""""""""""""""""""""
 
-Fornitore di Wallet
-"""""""""""""""""""
+""""""""""""""""""""""""""""
 
-I lettori che implementano o gestiscono una Soluzione di **Fornitore di Wallet** dovrebbero concentrarsi sulla comprensione di come gestire in modo sicuro le Credenziali Elettroniche e facilitare le interazioni dell'Utente con altri partecipanti all'ecosistema.
+Per facilitare la consultazione degli argomenti trattati in queste specifiche, di seguito sono riportati percorsi di lettura organizzati per ruolo. Ogni percorso è strutturato in base alle diverse fasi di adesione e partecipazione al Sistema IT-Wallet e contiene riferimenti diretti alle sezioni più rilevanti per ciascun ruolo. 
 
-**Sezioni essenziali:**
+I percorsi di lettura proposti hanno finalità orientativa e non sostituiscono la necessità di consultare le altre sezioni quando è richiesta una comprensione più ampia del sistema. 
 
-* **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: Requisiti funzionali di alto livello a supporto dell’Esperienza Utente in tutte le fasi di interazione tra l’Utente e il servizio.
-* **Sezione** :ref:`wallet-solution:Soluzione Wallet`: Requisiti completi di implementazione del Wallet, componenti e processi di interazione.
-* **Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Modelli di dati, formati e gestione del ciclo di vita delle Credenziali Elettroniche.
-* **Sezione** :ref:`digital-credential-flows:Flussi relativi agli Attestati Elettronici`: Flussi di emissione e presentazione per le Credenziali Elettroniche.
-* **Sezione** :ref:`wallet-provider-endpoint:Endpoint del Fornitore di Wallet`: Specifiche API per la federazione e specifiche per IT-Wallet.
-* **Sezione** :ref:`algorithms:Algoritmi Crittografici`: Requisiti di implementazione per sicurezza e crittografia.
-* **Sezione** :ref:`mobile-application-instance:Istanza dell'Applicazione Mobile`: Modelli di implementazione specifici per dispositivi mobili.
-* **Sezione** :ref:`e-service-pdnd:e-Service PDND`: Integrazione con la Piattaforma Nazionale di Interoperabilità dei Dati.
-
-**Sezioni secondarie:**
-
-* **Sezione** :ref:`credential-issuer-solution:Soluzione del Fornitore di Attestati Elettronici`: Comprensione delle interazioni e dei requisiti del Fornitore di Credenziali.
-* **Sezione** :ref:`relying-party-solution:Soluzione di Relying Party`: Comprensione delle interazioni con le Relying Party e dei protocolli di presentazione.
-
-
-Fornitore di Credenziali
-""""""""""""""""""""""""
-
-Per i lettori interessati all'implementazione di una Soluzione di **Fornitore di Credenziali**, dovrebbero concentrarsi sul ciclo di vita delle Credenziali Elettroniche e sui flussi di interazione per l'emissione.
-
-**Sezioni essenziali:**
-
-* **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: Requisiti funzionali di alto livello a supporto dell’Esperienza Utente in tutte le fasi di interazione tra l’Utente e il servizio.
-* **Sezione** :ref:`credential-issuer-solution:Soluzione del Fornitore di Attestati Elettronici`: Soluzione di Fornitore di Credenziali - Requisiti completi di implementazione e dettagli dei componenti.
-* **Sezione** :ref:`authentic-sources:Fonti Autentiche`: Comprensione dei modelli di integrazione con fonti di dati autorevoli.
-* **Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Formati delle Credenziali Elettroniche e gestione del ciclo di vita.
-* **Sezione** :ref:`credential-issuance:Emissione di Attestati Elettronici`: Implementazione dettagliata del flusso di emissione.
-* **Sezione** :ref:`credential-issuer-endpoint:Endpoint del Credential Issuer`: Specifiche API per la federazione e specifiche per l'emissione.
-* **Sezione** :ref:`algorithms:Algoritmi Crittografici`: Algoritmi di firma e requisiti di implementazione della sicurezza.
-
-**Sezioni secondarie:**
-
-* **Sezione** :ref:`wallet-solution:Soluzione Wallet`: Comprensione delle interazioni e dei requisiti dell'Istanza del Wallet.
-* **Sezione** :ref:`credential-presentation:Presentazione dell'Attestato Elettronico`: Comprensione di come le Credenziali Elettroniche vengono presentate sia in scenari remoti che di prossimità.
-* **Sezione** :ref:`e-service-pdnd:e-Service PDND`: Integrazione con la Piattaforma Nazionale di Interoperabilità dei Dati.
-
-.. note::
-
-    Se il Fornitore di Credenziali autentica l'Utente deve conformarsi alla Sezione :ref:`credential-presentation:Presentazione dell'Attestato Elettronico`. Se la Fonte Autentica che fornisce gli attributi dell'Utente appartiene al settore pubblico deve conformarsi alla Sezione :ref:`e-service-pdnd:e-Service PDND`.
-
+Per le entità interessate a operare in più ruoli, si raccomanda di approfondire tutti i percorsi di lettura relativi ai ruoli di interesse. 
 Fonte Autentica
-"""""""""""""""
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Se il lettore vuole gestire una **Fonte Autentica**, l'attenzione dovrebbe essere sulla fornitura sicura dei dati e sull'integrazione con i Fornitori di Credenziali.
+La Fonte Autentica si occupa di rendere disponibili i dati affidabili alla base dei (Q)EAA e di garantirne e gestirne in modo sicuro l’assoluta accuratezza e integrità. 
 
-**Sezioni essenziali:**
+- **Sezione** :ref:`introduction:Introduzione`: Scopo e contesto normativo del Sistema IT-Wallet.
 
-* **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: Requisiti funzionali di alto livello a supporto dell’Esperienza Utente in tutte le fasi di interazione tra l’Utente e il servizio.
-* **Sezione** :ref:`authentic-sources:Fonti Autentiche`: Requisiti e modelli di integrazione con i Fornitori di Credenziali.
-* **Sezione** :ref:`authentic-source-endpoint:Endpoint delle Fonti Autentiche`: Specifiche API e integrazione del catalogo.
-* **Sezione** :ref:`algorithms:Algoritmi Crittografici`: Requisiti di integrità dei dati, autenticazione e sicurezza.
-* **Sezione** :ref:`e-service-pdnd:e-Service PDND`: Integrazione PDND e requisiti di interoperabilità.
+- **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`: Panoramica dell’architettura del Sistema IT-Wallet in termini di governance e processi operativi abilitati. 
 
-**Sezioni secondarie:**
+- **Sezione** :ref:`trust-infrastructure:L'Infrastruttura di Trust`: Requisiti chiave del modello di fiducia federato e dei meccanismi di valutazione della fiducia tra le entità.
 
-* **Sezione** :ref:`credential-issuer-solution:Soluzione del Fornitore di Attestati Elettronici`: Comprensione dei componenti principali dei Fornitori di Credenziali e dei processi di integrazione.
-* **Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Comprensione di come i dati autorevoli e gli attributi diventano Credenziali Elettroniche e di come viene gestito il loro ciclo di vita.
+- **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`: Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi. 
+**Fase 2: Progettazione**
 
-Relying Party
-"""""""""""""
+Comprendere i requisiti e progettare gli aspetti, le funzionalità e le caratteristiche specifiche del (Q)EAA da emettere. 
 
-I lettori interessati all'implementazione o alla gestione di una Soluzione di **Relying Party** per accettare e verificare le Credenziali Elettroniche dovrebbero concentrarsi sui protocolli di presentazione e sui meccanismi di verifica.
 
-**Sezioni essenziali:**
+- **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: Requisiti chiave relativi alle modalità con cui consentire agli Utenti di ottenere i (Q)EAA, alla struttura dei (Q)EAA, al loro stato e alla loro gestione nel tempo.
 
-* **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: Requisiti funzionali di alto livello a supporto dell’Esperienza Utente in tutte le fasi di interazione tra l’Utente e il servizio.
-* **Sezione** :ref:`relying-party-solution:Soluzione di Relying Party`: Requisiti completi di implementazione del Verificatore di Credenziali.
-* **Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Comprensione dei formati delle Credenziali Elettroniche e verifica della validità.
-* **Sezione** :ref:`credential-presentation:Presentazione dell'Attestato Elettronico`: Implementazione del flusso di presentazione sia per scenari remoti che di prossimità.
-* **Sezione** :ref:`relying-party-endpoints:Endpoint della Relying Party`: Panoramica completa di tutti gli endpoint della Relying Party e i loro ambiti.
-* **Sezione** :ref:`algorithms:Algoritmi Crittografici`: Requisiti della suite crittografica.
 
-**Sezioni secondarie:**
+**Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Requisiti tecnici e funzionali relativi al ciclo di vita dei (Q)EAA. 
 
-* **Sezione** :ref:`wallet-solution:Soluzione Wallet`: Comprensione delle interazioni dell'Istanza del Wallet e dei protocolli di presentazione.
-* **Sezione** :ref:`mobile-application-instance:Istanza dell'Applicazione Mobile`: Modelli di implementazione specifici per dispositivi mobili.
+- **Sezione** :ref:`e-service-pdnd-template:PDND e-Service Template`: Modello di riferimento contenente tutti i metadati tecnici e descrittivi necessari per la definizione dell’e-service. 
 
-Argomenti Trasversali
-^^^^^^^^^^^^^^^^^^^^^
+**Fase 3: Implementazione**
 
-Indipendentemente dal ruolo principale, alcune sezioni contengono informazioni rilevanti per tutti i partecipanti all'ecosistema:
+Implementare le interfacce tecnologiche necessarie per comunicare con il Fornitore di Attestati Elettronici e gestire l’intero ciclo di vita dei dati associati ai (Q)EAA. 
 
-**Sicurezza e Conformità:**
-    Tutti gli implementatori devono implementare le loro soluzioni secondo la Sezione :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy` e la Sezione :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log`.
+- **Sezione** :ref:`authentic-sources:Fonti Autentiche`: Ruolo e responsabilità della Fonte Autentica. 
+**Sezione** :ref:`e-service-pdnd:e-Service PDND`: Specifiche obbligatorie per l’integrazione con la PDND (Piattaforma Digitale Nazionale Dati) e relativi requisiti di interoperabilità per la pubblicazione di un e-service.
 
-**Standard e Riferimenti:**
-    La Sezione :ref:`defined-terms-and-references:Termini Definiti e Riferimenti` fornisce riferimenti normativi, termini definiti e standard tecnici per consentire un'interoperabilità sicura e corretta tra tutti i partecipanti.
+**Sezione** :ref:`authentic-source-endpoint:Endpoint delle Fonti Autentiche`: Requisiti chiave per l’implementazione delle API che consentono al Credential Issuer di recuperare in modo sicuro e coerente i dati autorevoli e di gestirne il ciclo di vita tramite gli endpoint del Signal Hub. 
+- **Sezione** :ref:`registry infrastructure:Infrastruttura del Registro`: Approfondimento sui componenti del Registro di interesse per la Fonte Autentica. 
 
-**Test e Validazione:**
-    La Sezione :ref:`test-plans:Test Plans` fornisce una matrice di test completa per la validazione delle implementazioni tra diversi ruoli e flussi di interazione.
+- **Sezione** :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log`: Requisiti generali per la conservazione dei log e requisiti specifici per le Fonti Autentiche, in conformità alla norma ISO/IEC 27001. 
+- **Sezione** :ref:`test-plans:Test Plans`: Guida alla configurazione dell’ambiente di test e alla validazione delle interazioni backend tramite l’utilizzo delle matrici di test fornite dall’ecosistema. 
+**Fase 4: Registrazione**
 
-Approccio all'Implementazione
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Registrarsi al sistema come Fonte Autentica, completando le procedure amministrative e tecniche richieste. 
 
-Si suggerisce il seguente approccio di lettura in fasi:
+- **Sezione** :ref:`onboarding-high-level:Sistema di Onboarding`: Panoramica dell’architettura del sistema di onboarding e del processo di registrazione della Fonte Autentica. 
 
-    1. **Fase di Fondazione**: Leggere le Sezioni :ref:`introduction:Introduzione`, :ref:`brand-identity:Brand Identity`, :ref:`architecture-overview:Panoramica dell'Architettura` e :ref:`trust-infrastructure:L'Infrastruttura di Trust` per stabilire una comprensione concettuale del paradigma IT-Wallet, degli elementi di Brand Identity e dell'infrastruttura di fiducia.
-    2. **Fase Specifica per Ruolo**: Concentrarsi sulle sezioni essenziali del ruolo primario per comprendere i requisiti specifici di Esperienza Utente, funzionali e di implementazione, i componenti tecnici principali, l'architettura generale e i flussi di interazione (vedere la Sezione :ref:`functionalities:Design dell'Esperienza Utente`, :ref:`entities:Entità` e la Sezione :ref:`endpoints:Endpoints` per maggiori dettagli).
-    3. **Fase di Integrazione**: Rivedere le sezioni secondarie rilevanti per le interazioni con altri partecipanti all'ecosistema e i requisiti di integrazione della piattaforma.
-    4. **Fase di Validazione**: Studiare le considerazioni sulla sicurezza, le linee guida per i test e i requisiti di conformità secondo le Sezioni :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`, :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log` e :ref:`test-plans:Test Plans` per ulteriori informazioni.
+- **Sezione** :ref:`entity-onboarding:Onboarding delle Entità`: Approfondimento sulle procedure tecniche per la registrazione della Fonte Autentica. 
+
+- **Sezione** :ref:`x5c-evaluation:Operazioni di Gestione dei Certificati X.509`: Procedure operative per la gestione dei certificati X.509 nell’ambito della federazione IT-Wallet. 
+
+
+**Fornitore di Wallet**
+~~~~~~~~~~~~~~~~~~~
+
+Il Fornitore di Wallet si occupa della progettazione e dello sviluppo della Soluzione Wallet, che consente all’Utente di conservare, gestire e presentare il proprio PID e i propri (Q)EAA. 
+
+**Fase 1: Scoperta**
+
+Comprendere il funzionamento generale dell’ecosistema, l’architettura tecnica e l’Infrastruttura di Trust. 
+
+- **Sezione** :ref:`introduction:Introduzione`: Scopo e contesto normativo del Sistema IT-Wallet.
+
+- **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`: Panoramica dell’architettura del Sistema IT-Wallet in termini di governance e processi operativi abilitati. 
+
+- **Sezione** :ref:`trust-infrastructure:L'Infrastruttura di Trust`: Requisiti chiave del modello di fiducia federato e dei meccanismi di valutazione della fiducia tra le entità.
+
+- **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`: Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi. 
+
+**Fase 2: Progettazione**
+
+Comprendere i requisiti relativi all’Esperienza Utente e progettare la Soluzione Wallet secondo modelli comuni, al fine di garantirne l’usabilità e l’accessibilità. 
+
+- **Sezione** :ref:`brand-identity:Brand Identity`: Panoramica della Brand Identity del Sistema IT-Wallet e indicazioni sugli asset di riferimento per il Fornitore di Wallet.
+
+- **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: Requisiti chiave relativi ai modelli di interazione, ai layout delle interfacce e agli asset grafici, al fine di garantire un’esperienza utente efficace, fluida e assicurare coerenza tra le diverse Soluzioni Wallet.
+
+**Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Gestione degli Attestati Elettronici: Requisiti tecnici e funzionali relativi al ciclo di vita dei (Q)EAA. 
+
+**Fase 3: Implementazione**
+
+Implementare la Soluzione Wallet in conformità a specifici standard tecnologici, al fine di garantire la comunicazione tra la Soluzione Wallet e gli altri attori del Sistema. 
+
+- **Sezione** :ref:`wallet-solution:Soluzione Wallet`: Requisiti tecnici e funzionali relativi ai componenti, alle funzionalità e al ciclo di vita necessari per la configurazione della Soluzione Wallet. 
+
+- **Sezione** :ref:`digital-credential-flows: Flussi relativi agli Attestati Elettronici`: Requisiti tecnici e funzionali relativi ai flussi di emissione e presentazione dei (Q)EAA.
+
+- **Sezione** :ref:`wallet-provider-endpoint:Endpoint del Fornitore di Wallet`: Requisiti chiave per l’implementazione delle interfacce (API) del Fornitore di Wallet necessarie a garantire l’interoperabilità tra le entità. 
+
+- **Sezione** :ref:`registry-infrastructure:Infrastruttura del Registro`: Approfondimento sui componenti del Registro. 
+
+- **Sezione** :ref:`algorithms:Algoritmi Crittografici’: Selezione e implementazione degli standard crittografici necessari a garantire la sicurezza delle chiavi e delle transazioni. 
+
+- **Sezione** :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`: Requisiti di sicurezza e conformità per le Soluzioni Wallet. 
+
+- **Sezione** :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log`: Requisiti generali per la conservazione dei log e requisiti specifici per i Fornitori di Wallet, in conformità alla norma ISO/IEC 27001. 
+
+- **Sezione** :ref:`mobile-application-instance: Istanza dell'Applicazione Mobile`: Requisiti relativi all’istanza dell’applicazione mobile, con riferimento alla richiesta e alla risposta di inizializzazione. 
+
+- **Sezione** :ref:`test-plans:Test Plans`: Guida alla configurazione dell’ambiente di test e alla validazione delle interazioni backend tramite l’utilizzo delle matrici di test fornite dall’ecosistema. 
+
+**Fase 4: Registrazione**
+
+Registrarsi al sistema come Fornitore di Wallet, completando le procedure amministrative e tecniche richieste per il riconoscimento della Soluzione Wallet da parte del sistema. 
+
+- **Sezione** :ref:`onboarding-high-level:Sistema di Onboarding`: Panoramica dell’architettura del sistema di onboarding e del processo di registrazione del Fornitore di Wallet.
+
+- **Sezione** :ref:`entity-onboarding:Onboarding delle Entità`: Approfondimento sulle procedure tecniche per la registrazione del Fornitore di Wallet. 
+
+- **Sezione** :ref:`x5c-evaluation:Operazioni di Gestione dei Certificati X.509`: Procedure operative per la gestione dei certificati X.509 nell’ambito della federazione IT-Wallet. 
+
+
+
+Fornitore di Attestati Elettronici 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Il Fornitore di Attestati Elettronici si occupa di trasformare i dati autorevoli di origine provenienti dalle Fonti Autentiche in (Q)EAA e di gestirne l’intero ciclo di vita, dall’emissione alla revoca o alla scadenza. 
+
+**Fase 1: Scoperta**
+
+Comprendere il funzionamento generale dell’ecosistema, l’architettura tecnica e l’Infrastruttura di Trust. 
+
+- **Sezione** :ref:`introduction:Introduzione`: Scopo e contesto normativo del Sistema IT-Wallet.
+
+- **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`: Panoramica dell’architettura del Sistema IT-Wallet in termini di governance e processi operativi abilitati. 
+
+- **Sezione** :ref:`trust-infrastructure:L'Infrastruttura di Trust`: Requisiti chiave del modello di fiducia federato e dei meccanismi di valutazione della fiducia tra le entità.
+
+- **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`: Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi. 
+
+**Fase 2: Progettazione**
+
+Comprendere i requisiti e progettare tecnicamente i (Q)EAA, strutturandone i metadati in conformità ai requisiti tecnici e normativi. 
+
+- **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: Requisiti chiave relativi alla struttura, all’emissione, allo stato e alla gestione nel tempo dei (Q)EAA.
+
+**Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`:  Requisiti tecnici e funzionali relativi al ciclo di vita dei (Q)EAA. 
+
+**Fase 3: Implementazione**
+
+Sviluppare endpoint secondo su specifici protocolli e implementare le funzionalità di emissione, rinnovo, revoca e tutte le altre funzioni tecniche di gestione del ciclo di vita dei (Q)EAA. 
+
+- **Sezione** :ref:`credential-issuer-solution:Soluzione del Fornitore di Attestati Elettronici`: Requisiti tecnici e funzionali relativi ai componenti e ai modelli di interazione necessari per l’emissione e la gestione del ciclo di vita dei (Q)EAA. 
+
+- **Sezione** :ref:`digital-credential-flows:Flussi relativi agli attestati elettronici`: Requisiti tecnici e funzionali relativi ai flussi di emissione e presentazione dei (Q)EAA.
+
+- **Sezione** :ref:`credential-issuer-endopoint:Endpoint del Credential Issuer`: Requisiti chiave per l’implementazione dei metadati del Fornitore di Attestati Elettronici e degli endpoint di autorizzazione. 
+
+- **Sezione** :ref:`algorithms:Algoritmi Crittografici’: Selezione e implementazione degli standard crittografici necessari a garantire la sicurezza delle chiavi e delle transazioni. 
+
+- **Sezione** :ref:`e-service-pdnd:e-Service PDND’: Specifiche obbligatorie per l’integrazione con la PDND (Piattaforma Digitale Nazionale Dati) e relativi requisiti di interoperabilità per la pubblicazione di un e-service. 
+
+- **Sezione** :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`: Requisiti di sicurezza e conformità per le soluzioni implementate. 
+
+- **Sezione** :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log`: Requisiti generali per la conservazione dei log e requisiti specifici per i Fornitori di Attestati Elettronici, in conformità alla norma ISO/IEC 27001. 
+
+- **Sezione** :ref:`test-plans:Test Plans`: Guida alla configurazione dell’ambiente di test e alla validazione delle interazioni backend tramite l’utilizzo delle matrici di test fornite dall’ecosistema. 
+
+**Fase 4: Registrazione**
+
+Registrarsi al sistema come Credential Issuer, completando le procedure amministrative e tecniche previste affinché i (Q)EAA emessi verso i Wallet siano riconosciuti come affidabili dal Sistema. 
+
+- **Sezione** :ref:`onboarding-high-level:Sistema di Onboarding`: Panoramica dell’architettura del sistema di onboarding e del processo di registrazione della Fonte Autentica. 
+
+- **Sezione** :ref:`Entity Onboarding:Onboarding delle Entità`: Approfondimento sulle procedure tecniche per la registrazione del Fornitore di Attestati Elettronici. 
+
+- **Sezione** :ref:`x5c-evaluation:Operazioni di Gestione dei Certificati X.509`: Procedure operative per la gestione dei certificati X.509 nell’ambito della federazione IT-Wallet. 
+
+
+Fornitori di servizi (Relying Party)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Fase 1: Scoperta*
+
+Comprendere il funzionamento generale dell’ecosistema, l’architettura tecnica e l’Infrastruttura di Trust. 
+
+- **Sezione** :ref:`introduction:Introduzione`: Scopo e contesto normativo del Sistema IT-Wallet.
+
+- **Sezione** :ref:`architecture-overview:Panoramica dell'Architettura`: Panoramica dell’architettura del Sistema IT-Wallet in termini di governance e processi operativi abilitati. 
+
+- **Sezione** :ref:`trust-infrastructure:L'Infrastruttura di Trust`: Requisiti chiave del modello di fiducia federato e dei meccanismi di valutazione della fiducia tra le entità.
+
+- **Sezione** :ref:`defined-terms-and-references:Termini Definiti e Riferimenti`: Terminologia completa, riferimenti normativi, documentazione, risorse e strumenti aggiuntivi, linee guida per i contributi. 
+**Fase 2: Progettazione**
+
+Comprendere i requisiti di Esperienza Utente e progettare le funzionalità di verifica necessarie all’erogazione del servizio all’Utente finale. 
+
+- **Sezione** :ref:`brand-identity:Brand Identity`: Panoramica della Brand Identity del Sistema IT-Wallet e indicazioni sugli asset da adottare da parte della Relying Party.
+
+- **Sezione** :ref:`functionalities:Design dell'Esperienza Utente`: Requisiti chiave relativi ai modelli di interazione, ai layout delle interfacce e agli asset grafici, al fine di garantire un’esperienza utente efficace, fluida e assicurare coerenza tra i sistemi di presentazione e verifica. 
+
+
+**Sezione** :ref:`digital-credential-management:Gestione degli Attestati Elettronici`: Gestione degli Attestati Elettronici: Requisiti tecnici e funzionali relativi al ciclo di vita dei (Q)EAA.
+
+
+**Fase 3: Implementazione**
+
+Implementare le funzionalità di verifica secondo specifici protocolli, al fine di inviare richieste di verifica al Wallet e ricevere una risposta con l’autorizzazione dell’Utente. 
+
+
+- **Sezione** :ref:`relying-party-solution:Soluzione di Relying Party`: Requisiti tecnici e funzionali relativi ai componenti e alle funzionalità per la verifica del PID e dei (Q)EAA. 
+
+- **Sezione** :ref:`digital-credential-flows:Flussi relativi agli Attestati Elettronici`: Requisiti tecnici e funzionali relativi ai flussi di emissione e presentazione dei (Q)EAA. 
+
+- **Sezione** :ref:`relying-party-endpoint:Endpoint della Relying Party`: Requisiti chiave per l’implementazione degli endpoint di verifica dei (Q)EAA.
+
+- **Sezione** :ref:`security-privacy-considerations:Considerazioni di Sicurezza e Privacy`: Requisiti di sicurezza e conformità per le soluzioni implementate. 
+
+- **Sezione** :ref:`log-retention-policy:Politiche Generali di Conservazione dei Log`: Requisiti generali per la conservazione dei log e requisiti specifici per le Relying Party, in conformità alla norma ISO/IEC 27001. 
+
+- **Sezione** :ref:`test-plans:Test Plans`: Guida alla configurazione dell’ambiente di test e alla validazione delle interazioni backend tramite l’utilizzo delle matrici di test fornite dall’ecosistema. 
+
+**Fase 4: Registrazione**
+
+Registrarsi al sistema come Relying Party, completando le procedure amministrative e tecniche previste, e diventare soggetto affidabile per la richiesta dei dati degli Utenti. 
+
+- **Sezione** :ref:`onboarding-high-level:Sistema di Onboarding`: Approfondimento sulle procedure tecniche per la registrazione della Relying Party. 
+
+- **Sezione** :ref:`entity Onboarding:Onboarding delle Entità`: Approfondimento sulle procedure tecniche per la registrazione della Relying Party. 
+
+- **Sezione** :ref:`x5c-evaluation:Operazioni di Gestione dei Certificati X.509`: Procedure operative per la gestione dei certificati X.509 nell’ambito della federazione IT-Wallet. 
+
+
 
 .. note::
-
-    Per gli implementatori che lavorano su soluzioni che coprono più ruoli (ad esempio, una combinazione di Soluzioni di Fornitore di Credenziali e Relying Party), si raccomanda di rivedere le sezioni per tutti i ruoli pertinenti prima di procedere con gli sviluppi. È importante prestare particolare attenzione ai requisiti di Entity Configuration e ai flussi di federazione che si applicano a più ruoli.
-
 


### PR DESCRIPTION
This PR updates the How to Read the Specification section (EN/IT) for release 1.4.2, bringing editorial content from editorials-lts into the LTS line (versione-corrente) with build-safe RST and consistent structure.

**Changes**
1. Replaced the previous high-level reading guide with role-based paths (Authentic Source, Wallet Provider, Credential Issuer, Relying Party), organised by onboarding phases (Discovery → Design → Implementation → Registration).
2. Updated the specification overview (section order, terminology: IT-Wallet System, bullet-list layout).
3. Resolved syntax issues that broke CI (tox -e labels, tox -e build): list spacing, invalid transitions, broken :ref: targets, malformed role headings.
4. Fixed wrong/typo labels (e.g. registry, credential-issuer-endpoint, relying-party-endpoints, entity-onboarding).
5. Editorial polish — EN role titles as proper RST subsections; consistent spacing; typo/grammar fixes; corrected IT copy-paste errors (e.g. Credential Issuer registration text); added missing Relying Party intro (IT).
