### PR TITLE
"Display" Credential Issuer Metadata

### DIFF
--- a/docs/en/credential-issuer-metadata.rst
+++ b/docs/en/credential-issuer-metadata.rst
@@ -124,12 +124,12 @@ The *openid_credential_issuer* metadata contains the following claims.
 
                 - **background_color**: OPTIONAL. String value of a background color of the Digital Credential represented as numerical color values defined in `W3C.CSS-COLOR`_.
 
-          - **claims**: REQUIRED. Array of JSON object each describing how a certain claim related to the Credential MUST be displayed to the User. This Array lists the claims in the order they MUST be displayed by the Wallet. To provide detailed information about the claim, the innermost value MUST contain at least the following parameters. See `OpenID4VCI`_ Section A.3.2.
+          - **claims**: REQUIRED. Array of JSON object each describing how a certain claim related to the Credential MUST be displayed to the User. This Array lists the claims in the order they MUST be displayed by the Wallet. To provide detailed information about the claim, the innermost value contains the following parameters. See `OpenID4VCI`_ Section A.3.2.
 
-            - **path**: It contains the pointer that specifies the path to a specific claim within the Digital Credential as defined in Appendix C of `OpenID4VCI`_.
-            - **mandatory**: Boolean which, when set to `true`, indicates that the Credential Issuer will always include this claim in the issued Credential.
-            - **sd**: String indicating whether the claim is selectively disclosable. It MUST be set to `always` if the claim is selectively disclosure or `never` if not.
-            - **display**: Array of objects containing display language properties. Array containing display information about the claim indicated in the ``path``. The array contains an object for each language supported. It contains the following parameters:
+            - **path**: REQUIRED. It contains the pointer that specifies the path to a specific claim within the Digital Credential as defined in Appendix C of `OpenID4VCI`_.
+            - **mandatory**: REQUIRED. Boolean which, when set to `true`, indicates that the Credential Issuer will always include this claim in the issued Credential.
+            - **sd**: REQUIRED.String indicating whether the claim is selectively disclosable. It MUST be set to `always` if the claim is selectively disclosure or `never` if not.
+            - **display**: CONDITIONAL. REQUIRED only for the claims that are defined in the specific Attestation Rulebook. Array of objects containing display language properties. Array containing display information about the claim indicated in the ``path``. The array contains an object for each language supported. It contains the following parameters:
 
                 - **name**: REQUIRED. String value of a display name for the claim.
                 - **label**: OPTIONAL. String value of a display name for the claim.

--- a/docs/en/credential-issuer-metadata.rst
+++ b/docs/en/credential-issuer-metadata.rst
@@ -129,7 +129,7 @@ The *openid_credential_issuer* metadata contains the following claims.
             - **path**: REQUIRED. It contains the pointer that specifies the path to a specific claim within the Digital Credential as defined in Appendix C of `OpenID4VCI`_.
             - **mandatory**: REQUIRED. Boolean which, when set to `true`, indicates that the Credential Issuer will always include this claim in the issued Credential.
             - **sd**: REQUIRED.String indicating whether the claim is selectively disclosable. It MUST be set to `always` if the claim is selectively disclosure or `never` if not.
-            - **display**: CONDITIONAL. REQUIRED only for the claims that are defined in the specific Attestation Rulebook. Array of objects containing display language properties. Array containing display information about the claim indicated in the ``path``. The array contains an object for each language supported. It contains the following parameters:
+            - **display**: CONDITIONAL. REQUIRED only for the claims that are shown to the User. Array of objects containing display language properties. Array containing display information about the claim indicated in the ``path``. The array contains an object for each language supported. It contains the following parameters:
 
                 - **name**: REQUIRED. String value of a display name for the claim.
                 - **label**: OPTIONAL. String value of a display name for the claim.

--- a/docs/en/credential-issuer-metadata.rst
+++ b/docs/en/credential-issuer-metadata.rst
@@ -124,7 +124,7 @@ The *openid_credential_issuer* metadata contains the following claims.
 
                 - **background_color**: OPTIONAL. String value of a background color of the Digital Credential represented as numerical color values defined in `W3C.CSS-COLOR`_.
 
-          - **claims**: REQUIRED. Array of JSON object each describing how a certain claim related to the Credential MUST be displayed to the User. This Array lists the claims in the order they MUST be displayed by the Wallet. To provide detailed information about the claim, the innermost value contains the following parameters. See `OpenID4VCI`_ Section A.3.2.
+          - **claims**: REQUIRED. Array of JSON object each describing how a certain claim related to the Credential MUST be displayed to the User. This Array lists the claims in the order they MUST be displayed by the Wallet. To provide detailed information about the claim, the innermost value contains the following parameters. See `OpenID4VCI`_ Section B.2.
 
             - **path**: REQUIRED. It contains the pointer that specifies the path to a specific claim within the Digital Credential as defined in Appendix C of `OpenID4VCI`_.
             - **mandatory**: REQUIRED. Boolean which, when set to `true`, indicates that the Credential Issuer will always include this claim in the issued Credential.

--- a/docs/it/credential-issuer-metadata.rst
+++ b/docs/it/credential-issuer-metadata.rst
@@ -129,7 +129,7 @@ I Metadata *openid_credential_issuer* contiene i seguenti *claims*.
             - **path**: Contiene il puntatore che specifica il percorso all'attributo specifico all'interno dell'Attestato Elettronico come definito nell'Appendice C di `OpenID4VCI`_.
             - **mandatory**: Valore booleano che, se impostato su `true`, indica che il Credential Issuer includerà sempre questo attributo nelle Credenziali che emette.
             - **sd**: Stringa che indica se il claim è divulgabile selettivamente. DEVE essere impostato su `always` se il claim è divulgabile selettivamente o `never` se non lo è.
-            - **display**: Array di oggetti contenenti le proprietà di visualizzazione. Array contenente informazioni di visualizzazione relative al claim indicato nel ``path``. L'array contiene un oggetto per ogni lingua supportata. Contiene i seguenti parametri:
+            - **display**: CONDIZIONALE. OBBLIGATORIO solo per i *claims* definiti nello specifico Attestation Rulebook. Array di oggetti contenenti le proprietà di visualizzazione. Array contenente informazioni di visualizzazione relative al claim indicato nel ``path``. L'array contiene un oggetto per ogni lingua supportata. Contiene i seguenti parametri:
 
                 - **name**: OBBLIGATORIO. Nome dell'attributo in formato stringa.
                 - **label**: OPZIONALE. Nome dell'attributo in formato stringa.

--- a/docs/it/credential-issuer-metadata.rst
+++ b/docs/it/credential-issuer-metadata.rst
@@ -124,11 +124,11 @@ I Metadata *openid_credential_issuer* contiene i seguenti *claims*.
 
                 - **background_color**: OPZIONALE. Stringa che rappresenta il colore di sfondo dell’Attestato Elettronico, espresso come valore numerico secondo la definizione del documento `W3C.CSS-COLOR`_.
 
-          - **claims**: OBBLIGATORIO. Array di oggetti JSON ciascuno che descrive come un determinato attributo relativo all'Attestato Elettronico DEVE essere visualizzato all'Utente. Questo array elenca le attestazioni nell’ordine in cui DEVONO essere mostrate dal Wallet. Per fornire informazioni dettagliate sull’attestazione, il valore più interno DEVE contenere almeno i seguenti parametri. Vedi OpenID4VCI_ Sezione A.3.2.
+          - **claims**: OBBLIGATORIO. Array di oggetti JSON ciascuno che descrive come un determinato attributo relativo all'Attestato Elettronico DEVE essere visualizzato all'Utente. Questo array elenca le attestazioni nell’ordine in cui DEVONO essere mostrate dal Wallet. Per fornire informazioni dettagliate sull’attestazione, il valore più interno contiene i seguenti parametri. Vedi OpenID4VCI_ Sezione A.3.2.
 
-            - **path**: Contiene il puntatore che specifica il percorso all'attributo specifico all'interno dell'Attestato Elettronico come definito nell'Appendice C di `OpenID4VCI`_.
-            - **mandatory**: Valore booleano che, se impostato su `true`, indica che il Credential Issuer includerà sempre questo attributo nelle Credenziali che emette.
-            - **sd**: Stringa che indica se il claim è divulgabile selettivamente. DEVE essere impostato su `always` se il claim è divulgabile selettivamente o `never` se non lo è.
+            - **path**: OBBLIGATORIO. Contiene il puntatore che specifica il percorso all'attributo specifico all'interno dell'Attestato Elettronico come definito nell'Appendice C di `OpenID4VCI`_.
+            - **mandatory**: OBBLIGATORIO. Valore booleano che, se impostato su `true`, indica che il Credential Issuer includerà sempre questo attributo nelle Credenziali che emette.
+            - **sd**: OBBLIGATORIO. Stringa che indica se il claim è divulgabile selettivamente. DEVE essere impostato su `always` se il claim è divulgabile selettivamente o `never` se non lo è.
             - **display**: CONDIZIONALE. OBBLIGATORIO solo per i *claims* definiti nello specifico Attestation Rulebook. Array di oggetti contenenti le proprietà di visualizzazione. Array contenente informazioni di visualizzazione relative al claim indicato nel ``path``. L'array contiene un oggetto per ogni lingua supportata. Contiene i seguenti parametri:
 
                 - **name**: OBBLIGATORIO. Nome dell'attributo in formato stringa.

--- a/docs/it/credential-issuer-metadata.rst
+++ b/docs/it/credential-issuer-metadata.rst
@@ -129,7 +129,7 @@ I Metadata *openid_credential_issuer* contiene i seguenti *claims*.
             - **path**: OBBLIGATORIO. Contiene il puntatore che specifica il percorso all'attributo specifico all'interno dell'Attestato Elettronico come definito nell'Appendice C di `OpenID4VCI`_.
             - **mandatory**: OBBLIGATORIO. Valore booleano che, se impostato su `true`, indica che il Credential Issuer includerà sempre questo attributo nelle Credenziali che emette.
             - **sd**: OBBLIGATORIO. Stringa che indica se il claim è divulgabile selettivamente. DEVE essere impostato su `always` se il claim è divulgabile selettivamente o `never` se non lo è.
-            - **display**: CONDIZIONALE. OBBLIGATORIO solo per i *claims* definiti nello specifico Attestation Rulebook. Array di oggetti contenenti le proprietà di visualizzazione. Array contenente informazioni di visualizzazione relative al claim indicato nel ``path``. L'array contiene un oggetto per ogni lingua supportata. Contiene i seguenti parametri:
+            - **display**: CONDIZIONALE. OBBLIGATORIO solo per i *claims* che vengono mostrati all'Utente. Array di oggetti contenenti le proprietà di visualizzazione. Array contenente informazioni di visualizzazione relative al claim indicato nel ``path``. L'array contiene un oggetto per ogni lingua supportata. Contiene i seguenti parametri:
 
                 - **name**: OBBLIGATORIO. Nome dell'attributo in formato stringa.
                 - **label**: OPZIONALE. Nome dell'attributo in formato stringa.


### PR DESCRIPTION
Display properties for claims are mandatory only for those defined in the specific Attestation Rulebook.