### PR TITLE
pdf compression post build

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -93,6 +93,24 @@ jobs:
             tail -120 lualatex-en.log
             exit 1
           fi
+
+          # Post-build compression: downsample embedded bitmaps (typically 35MB → ~16MB).
+          echo "=== Compressing English PDF (Ghostscript /ebook) ==="
+          before_bytes=$(stat -c%s "$SETTINGS_FILE_NAME.pdf")
+          gs -sDEVICE=pdfwrite \
+            -dCompatibilityLevel=1.5 \
+            -dPDFSETTINGS=/ebook \
+            -dDetectDuplicateImages=true \
+            -dCompressFonts=true \
+            -dNOPAUSE -dQUIET -dBATCH \
+            -sOutputFile="$SETTINGS_FILE_NAME-opt.pdf" "$SETTINGS_FILE_NAME.pdf"
+          if [ -f "$SETTINGS_FILE_NAME-opt.pdf" ]; then
+            after_bytes=$(stat -c%s "$SETTINGS_FILE_NAME-opt.pdf")
+            mv "$SETTINGS_FILE_NAME-opt.pdf" "$SETTINGS_FILE_NAME.pdf"
+            echo "Compressed EN: $((before_bytes / 1024 / 1024))MB → $((after_bytes / 1024 / 1024))MB"
+          else
+            echo "Warning: Ghostscript compression failed for EN; keeping uncompressed PDF"
+          fi
           ls -la "$SETTINGS_FILE_NAME.pdf"
 
 
@@ -127,6 +145,24 @@ jobs:
             echo "=== Last 120 lines of LaTeX log ==="
             tail -120 lualatex-it.log
             exit 1
+          fi
+
+          # Post-build compression: downsample embedded bitmaps (typically 35MB → ~16MB).
+          echo "=== Compressing Italian PDF (Ghostscript /ebook) ==="
+          before_bytes=$(stat -c%s "$SETTINGS_FILE_NAME.pdf")
+          gs -sDEVICE=pdfwrite \
+            -dCompatibilityLevel=1.5 \
+            -dPDFSETTINGS=/ebook \
+            -dDetectDuplicateImages=true \
+            -dCompressFonts=true \
+            -dNOPAUSE -dQUIET -dBATCH \
+            -sOutputFile="$SETTINGS_FILE_NAME-opt.pdf" "$SETTINGS_FILE_NAME.pdf"
+          if [ -f "$SETTINGS_FILE_NAME-opt.pdf" ]; then
+            after_bytes=$(stat -c%s "$SETTINGS_FILE_NAME-opt.pdf")
+            mv "$SETTINGS_FILE_NAME-opt.pdf" "$SETTINGS_FILE_NAME.pdf"
+            echo "Compressed IT: $((before_bytes / 1024 / 1024))MB → $((after_bytes / 1024 / 1024))MB"
+          else
+            echo "Warning: Ghostscript compression failed for IT; keeping uncompressed PDF"
           fi
           ls -la "$SETTINGS_FILE_NAME.pdf"
 

--- a/README.md
+++ b/README.md
@@ -147,9 +147,10 @@ This command:
 - runs `./utils/build-pdf-local.sh`, which for each language in `docs/en` and `docs/it`:
   - builds LaTeX with Sphinx,
   - compiles the main `.tex` file with LuaLaTeX,
+  - compresses the PDF with Ghostscript (`/ebook`, typically ~35MB → ~16MB),
   - and copies the resulting PDFs into the `pdf_output/` directory in your working tree.
 
-
+Optional: set `PDF_COMPRESS_SETTINGS=/screen` for a smaller output (~13MB).
 ## How to contribute
 
 

--- a/utils/build-pdf-local.sh
+++ b/utils/build-pdf-local.sh
@@ -86,6 +86,31 @@ for LANG in en it; do
     cd "$PWD_BEFORE"
     exit 1
   fi
+
+  # Post-build compression: downsample embedded bitmaps (typically 35MB → ~16MB).
+  # Override with PDF_COMPRESS_SETTINGS=/screen for smaller files (~13MB).
+  if command -v gs &>/dev/null; then
+    PDF_COMPRESS_SETTINGS="${PDF_COMPRESS_SETTINGS:-/ebook}"
+    echo "=== Compressing ${ULANG} PDF (Ghostscript ${PDF_COMPRESS_SETTINGS}) ==="
+    before_bytes=$(stat -c%s "${BASENAME}.pdf")
+    gs -sDEVICE=pdfwrite \
+      -dCompatibilityLevel=1.5 \
+      -dPDFSETTINGS="${PDF_COMPRESS_SETTINGS}" \
+      -dDetectDuplicateImages=true \
+      -dCompressFonts=true \
+      -dNOPAUSE -dQUIET -dBATCH \
+      -sOutputFile="${BASENAME}-opt.pdf" "${BASENAME}.pdf"
+    if [[ -f "${BASENAME}-opt.pdf" ]]; then
+      after_bytes=$(stat -c%s "${BASENAME}-opt.pdf")
+      mv "${BASENAME}-opt.pdf" "${BASENAME}.pdf"
+      echo "Compressed ${ULANG}: $((before_bytes / 1024 / 1024))MB → $((after_bytes / 1024 / 1024))MB"
+    else
+      echo "Warning: Ghostscript compression failed for ${ULANG}; keeping uncompressed PDF"
+    fi
+  else
+    echo "Warning: gs not found; skipping post-build PDF compression for ${ULANG}"
+  fi
+
   cd "$PWD_BEFORE"
 
   cp "$ROOT_DIR/build/latex/${LANG}/${BASENAME}.pdf" "$ROOT_DIR/pdf_output/${BASENAME}-${LANG}-${TIMESTAMP}.pdf"


### PR DESCRIPTION
This pull request introduces automated post-build PDF compression using Ghostscript to significantly reduce the file size of generated PDFs (typically from ~35MB to ~16MB) for both English and Italian builds. The compression is now part of both the GitHub Actions workflow and the local build script, and the documentation has been updated to reflect this change and to describe how to further customize compression settings.

**PDF Compression Automation**

* Added Ghostscript-based compression after PDF generation in the GitHub Actions workflow for both English and Italian documents, reducing file size and improving artifact efficiency. [[1]](diffhunk://#diff-2a0da5bf1761ab6928664a10d5e27abecb31975620f11280dc92e1642f431b2bR96-R113) [[2]](diffhunk://#diff-2a0da5bf1761ab6928664a10d5e27abecb31975620f11280dc92e1642f431b2bR149-R166)
* Updated the local build script (`utils/build-pdf-local.sh`) to automatically compress PDFs if Ghostscript (`gs`) is available, with an option to override the compression level using the `PDF_COMPRESS_SETTINGS` environment variable.

**Documentation Updates**

* Updated the `README.md` to document the new compression step, including typical file size reductions and instructions for customizing compression settings.